### PR TITLE
feat(revisions): Peer Review tab — one place to run the review-assistant cycle [RANDZ-631]

### DIFF
--- a/frontend/components/assistant-ui/readonly-thread.tsx
+++ b/frontend/components/assistant-ui/readonly-thread.tsx
@@ -13,7 +13,15 @@ import type { FC } from 'react';
  * without any interactive features (no composer, no edit, no reload).
  * Useful for displaying conversation history from external sources.
  */
-export const ReadonlyThread: FC = () => {
+interface ReadonlyThreadProps {
+  /**
+   * Extra classes for the scroll viewport. Callers that already provide spacing
+   * above the thread pass `pt-0` here so the padding does not stack.
+   */
+  viewportClassName?: string;
+}
+
+export const ReadonlyThread: FC<ReadonlyThreadProps> = ({ viewportClassName }) => {
   return (
     <ThreadPrimitive.Root
       className="aui-root aui-thread-root @container flex h-full flex-col bg-background"
@@ -23,7 +31,10 @@ export const ReadonlyThread: FC = () => {
     >
       <ThreadPrimitive.Viewport
         turnAnchor="top"
-        className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth px-4 pt-4"
+        className={cn(
+          'aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth px-4 pt-4',
+          viewportClassName,
+        )}
       >
         <ThreadPrimitive.Messages
           components={{

--- a/frontend/components/results/components/html-report-frame.tsx
+++ b/frontend/components/results/components/html-report-frame.tsx
@@ -31,6 +31,15 @@ const REPORT_CSP = "default-src 'none'; style-src 'unsafe-inline'; img-src data:
 const REPORT_CONTAINMENT_CSS = `
 *, *::before, *::after { box-sizing: border-box; }
 html, body { width: auto !important; height: auto !important; min-height: 0 !important; }
+/* The frame is sized to its content, so the report never needs to scroll
+   itself. Undo a report that asks for its own scrollbar (\`overflow-y: scroll\`
+   forces the track to render even with nothing to scroll), then hide the root
+   scrollbar chrome outright. Hiding the chrome rather than setting
+   \`overflow: hidden\` keeps the content scrollable by wheel or keyboard, so a
+   measurement that ever came up short cannot make anything unreachable. */
+html, body { overflow: visible !important; }
+html { scrollbar-width: none; }
+html::-webkit-scrollbar { width: 0; height: 0; }
 body { overflow-wrap: break-word; }
 body * { max-width: 100%; }
 img, svg, video, canvas { height: auto; }

--- a/frontend/components/results/components/replace-main-document-dialog.tsx
+++ b/frontend/components/results/components/replace-main-document-dialog.tsx
@@ -42,6 +42,13 @@ export interface ReplaceMainDocumentDialogProps {
   /** Called after a new revision is successfully created, so the caller can
    *  switch the view to the newly created (now current) revision. */
   onRevisionCreated?: () => void;
+  /**
+   * Hides the "re-run previous assessments" choice. The Peer Review tab sets
+   * this: there, uploading a revised draft is one step of a sequence whose next
+   * steps the user starts deliberately, so an extra toggle about unrelated
+   * assessments is noise. Document processing still runs either way.
+   */
+  hideRerunOption?: boolean;
 }
 
 export function ReplaceMainDocumentDialog({
@@ -49,9 +56,13 @@ export function ReplaceMainDocumentDialog({
   projectId,
   onClose,
   onRevisionCreated,
+  hideRerunOption = false,
 }: ReplaceMainDocumentDialogProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [rerunAnalyses, setRerunAnalyses] = useState(true);
+  // Hiding the control also disables the behaviour: only document processing
+  // and the other initial workflows run.
+  const shouldRerunAnalyses = rerunAnalyses && !hideRerunOption;
   const [stage, setStage] = useState<Stage>('select');
   const [uploadProgress, setUploadProgress] = useState<UploadProgress | null>(null);
   const queryClient = useQueryClient();
@@ -90,7 +101,7 @@ export function ReplaceMainDocumentDialog({
       if (abortRef.current) return;
 
       // Step 3: Start workflows if requested
-      if (rerunAnalyses && previous_workflow_types.length > 0) {
+      if (shouldRerunAnalyses && previous_workflow_types.length > 0) {
         setStage('starting-workflows');
         const initialSet = new Set<string>(INITIAL_WORKFLOWS);
         const workflowTypes = [
@@ -115,7 +126,7 @@ export function ReplaceMainDocumentDialog({
       // Follow the newly created revision so the view doesn't stay pinned to
       // the previous one.
       onRevisionCreated?.();
-      toast.success(rerunAnalyses ? 'New revision created. Assessments started.' : 'New revision created.');
+      toast.success(shouldRerunAnalyses ? 'New revision created. Assessments started.' : 'New revision created.');
       onClose();
     },
     onError: (error) => {
@@ -191,22 +202,24 @@ export function ReplaceMainDocumentDialog({
               </div>
             )}
 
-            <div className="space-y-1">
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="rerun-analyses"
-                  checked={rerunAnalyses}
-                  onCheckedChange={(checked) => setRerunAnalyses(checked === true)}
-                />
-                <Label htmlFor="rerun-analyses" className="text-sm font-normal cursor-pointer">
-                  Re-run previous assessments on this revision
-                </Label>
+            {!hideRerunOption && (
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="rerun-analyses"
+                    checked={rerunAnalyses}
+                    onCheckedChange={(checked) => setRerunAnalyses(checked === true)}
+                  />
+                  <Label htmlFor="rerun-analyses" className="text-sm font-normal cursor-pointer">
+                    Re-run previous assessments on this revision
+                  </Label>
+                </div>
+                <p className="text-xs text-muted-foreground pl-6">
+                  Automatically run the same assessments on the new revision that were run on the previous one. If
+                  unchecked, you can still start assessments manually later.
+                </p>
               </div>
-              <p className="text-xs text-muted-foreground pl-6">
-                Automatically run the same assessments on the new revision that were run on the previous one. If
-                unchecked, you can still start assessments manually later.
-              </p>
-            </div>
+            )}
           </div>
         )}
 

--- a/frontend/components/results/constants.ts
+++ b/frontend/components/results/constants.ts
@@ -1,3 +1,3 @@
-export const TABS = ['document-explorer', 'summary', 'references', 'files', 'analyses'] as const;
+export const TABS = ['document-explorer', 'summary', 'references', 'files', 'analyses', 'peer-review'] as const;
 
 export type TabType = (typeof TABS)[number];

--- a/frontend/components/results/results-visualization.tsx
+++ b/frontend/components/results/results-visualization.tsx
@@ -16,8 +16,9 @@ import { BookOpen, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { AnalysisOptionsMenu } from './components/analysis-options-menu';
 import { TabType } from './constants';
-import { AnalysesTab, FilesTab, ReferenceReviewTab, SummaryTab } from './tabs';
+import { AnalysesTab, FilesTab, PeerReviewTab, ReferenceReviewTab, SummaryTab } from './tabs';
 import { DocumentExplorerTab } from './tabs/document-explorer-tab';
+import { derivePeerReviewFacts, peerReviewNeedsAttention } from './tabs/peer-review/peer-review-derive';
 import { UnmatchedReferencesApproveDialog } from './tabs/reference-review/unmatched-references-approve-dialog';
 import { useReferenceApprovalFlow } from './tabs/reference-review/use-reference-approval-flow';
 
@@ -72,6 +73,19 @@ export function ResultsVisualization({
     setActiveTab('document-explorer');
   };
 
+  const navigateToDocumentExplorer = (lineRange?: [number, number]) => {
+    if (lineRange) {
+      const [start, end] = lineRange;
+      const hash = start === end ? `#L${start}` : `#L${start}-${end}`;
+      window.history.pushState(null, '', hash);
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    }
+    setActiveTab('document-explorer');
+  };
+
+  const peerReviewFacts = derivePeerReviewFacts(projectDetail);
+  const peerReviewAttention = peerReviewNeedsAttention(peerReviewFacts, readOnly);
+
   const renderActiveTab = () => {
     switch (activeTab) {
       case 'summary':
@@ -101,16 +115,19 @@ export function ResultsVisualization({
           <AnalysesTab
             projectDetail={projectDetail}
             readOnly={readOnly}
-            onNavigateToDocumentExplorer={(lineRange?: [number, number]) => {
-              if (lineRange) {
-                const [start, end] = lineRange;
-                const hash = start === end ? `#L${start}` : `#L${start}-${end}`;
-                window.history.pushState(null, '', hash);
-                window.dispatchEvent(new HashChangeEvent('hashchange'));
-              }
-              setActiveTab('document-explorer');
-            }}
+            onNavigateToDocumentExplorer={navigateToDocumentExplorer}
             onNavigateToReferences={() => setActiveTab('references')}
+            onNavigateToPeerReview={() => setActiveTab('peer-review')}
+          />
+        );
+      case 'peer-review':
+        return (
+          <PeerReviewTab
+            projectDetail={projectDetail}
+            readOnly={readOnly}
+            onRevisionChange={onRevisionChange}
+            onRevisionCreated={onRevisionCreated}
+            onNavigateToDocumentExplorer={navigateToDocumentExplorer}
           />
         );
     }
@@ -202,6 +219,17 @@ export function ResultsVisualization({
                 <Badge className="rounded-full h-4.5 min-w-4.5" variant="secondary">
                   {results.filter((r) => isWorkflowTypeVisible(r.run.type)).length}
                 </Badge>
+              </TabsTrigger>
+              <TabsTrigger value="peer-review" className="relative">
+                Peer Review
+                {peerReviewFacts.memos.length > 0 && (
+                  <Badge className="rounded-full h-4.5 min-w-4.5" variant="secondary">
+                    {peerReviewFacts.memos.length}
+                  </Badge>
+                )}
+                {peerReviewAttention && (
+                  <span className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-amber-500 ring-2 ring-background" />
+                )}
               </TabsTrigger>
             </TabsList>
           </Tabs>

--- a/frontend/components/results/tabs/analyses-tab.tsx
+++ b/frontend/components/results/tabs/analyses-tab.tsx
@@ -21,9 +21,10 @@ import { getErrorMessage } from '@/lib/api-error';
 import { WorkflowDuration } from './workflow-duration';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { getDisplayStatus } from '@/lib/workflow-state';
+import { isPeerReviewWorkflowType } from '@/lib/peer-review';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
-import { InfoIcon, PlusIcon } from 'lucide-react';
+import { ArrowRight, InfoIcon, PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { useWorkflowSelection } from './use-workflow-selection';
@@ -35,6 +36,8 @@ interface AnalysesTabProps {
   readOnly?: boolean;
   onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
   onNavigateToReferences: () => void;
+  /** Sends the user to the tab that owns the peer-review assessments. */
+  onNavigateToPeerReview?: () => void;
 }
 
 export function AnalysesTab({
@@ -42,6 +45,7 @@ export function AnalysesTab({
   readOnly,
   onNavigateToDocumentExplorer,
   onNavigateToReferences,
+  onNavigateToPeerReview,
 }: AnalysesTabProps) {
   const projectId = projectDetail.project.id;
   const workflowDetails = projectDetail.workflow_runs ?? [];
@@ -121,21 +125,32 @@ export function AnalysesTab({
                     onSelectRun={handleSelectRun}
                     historyData={historyData}
                   />
-                  {!readOnly && (
-                    <StartWorkflowButton
-                      type={selectedWorkflowRun.run.type}
-                      projectId={projectId}
-                      workflow={selectedWorkflowRun.run}
-                      onConfirm={async () => {
-                        return await startMultipleWorkflowsApiWorkflowsStartMultiplePost({
-                          body: {
-                            project_id: projectId,
-                            workflow_types: [selectedWorkflowRun.run.type],
-                          },
-                        });
-                      }}
-                    />
-                  )}
+                  {!readOnly &&
+                    // Peer-review assessments are started from the Peer Review
+                    // tab, which sequences their prerequisites; re-running one
+                    // from here could produce a guard report instead of a result.
+                    (isPeerReviewWorkflowType(selectedWorkflowRun.run.type) ? (
+                      onNavigateToPeerReview && (
+                        <Button variant="outline" size="sm" onClick={onNavigateToPeerReview}>
+                          Manage in Peer Review
+                          <ArrowRight className="size-4" />
+                        </Button>
+                      )
+                    ) : (
+                      <StartWorkflowButton
+                        type={selectedWorkflowRun.run.type}
+                        projectId={projectId}
+                        workflow={selectedWorkflowRun.run}
+                        onConfirm={async () => {
+                          return await startMultipleWorkflowsApiWorkflowsStartMultiplePost({
+                            body: {
+                              project_id: projectId,
+                              workflow_types: [selectedWorkflowRun.run.type],
+                            },
+                          });
+                        }}
+                      />
+                    ))}
                 </div>
               </div>
               <div className="flex items-center gap-4 text-sm text-muted-foreground">

--- a/frontend/components/results/tabs/files-tab.tsx
+++ b/frontend/components/results/tabs/files-tab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { formatFileSize } from '@/components/analysis-form/utils';
+import { FileTypeIcon } from '@/components/shared/file-type-icon';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -26,7 +27,7 @@ import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-fil
 import { buildReferenceByFileIdMap, composeReferences, ComposedReference } from '@/lib/composed-references';
 import { FileListItem, FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
-import { Download, FileText, Loader2, MoreVerticalIcon, RefreshCw, Search, Trash2, Upload } from 'lucide-react';
+import { Download, Loader2, MoreVerticalIcon, RefreshCw, Search, Trash2, Upload } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useRemoveFileMutation } from './reference-review/mutations';
 import { ReplaceMainDocumentDialog } from '../components/replace-main-document-dialog';
@@ -36,25 +37,6 @@ interface FilesTabProps {
   projectDetail: ProjectDetailed;
   readOnly?: boolean;
   onRevisionCreated?: () => void;
-}
-
-function FileTypeIcon({ fileType }: { fileType?: string | null }) {
-  const normalizedType = fileType?.toLowerCase() || '';
-
-  if (normalizedType.includes('pdf') || normalizedType === 'application/pdf') {
-    return <FileText className="flex-shrink-0 size-4 text-red-700" />;
-  }
-
-  if (
-    normalizedType.includes('docx') ||
-    normalizedType.includes('doc') ||
-    normalizedType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
-    normalizedType === 'application/msword'
-  ) {
-    return <FileText className="flex-shrink-0 size-4 text-blue-700" />;
-  }
-
-  return <FileText className="flex-shrink-0 size-4 text-muted-foreground" />;
 }
 
 function FileNameLink({ file }: { file: FileListItem }) {
@@ -335,6 +317,8 @@ export function FilesTab({ projectDetail, readOnly = false, onRevisionCreated }:
         description="Add supporting documents or reviewer memos to this project."
         multiple
         allowRoleSelection
+        allowRevisionSelection
+        currentRevision={currentRevision}
         onCancel={() => setIsUploadOpen(false)}
         onComplete={() => setIsUploadOpen(false)}
       />

--- a/frontend/components/results/tabs/index.ts
+++ b/frontend/components/results/tabs/index.ts
@@ -3,3 +3,4 @@ export { ReferenceReviewTab } from './reference-review/reference-review-tab';
 export { FilesTab } from './files-tab';
 export { DocumentExplorerTab } from './document-explorer-tab';
 export { AnalysesTab } from './analyses-tab';
+export { PeerReviewTab } from './peer-review/peer-review-tab';

--- a/frontend/components/results/tabs/peer-review/peer-review-derive.ts
+++ b/frontend/components/results/tabs/peer-review/peer-review-derive.ts
@@ -1,0 +1,159 @@
+/**
+ * Derives everything the Peer Review tab needs from `projectDetail`.
+ *
+ * Deliberately pure and React-free: these predicates mirror server-side
+ * prechecks, and the point of keeping them in one file is that they can be read
+ * side by side with the Python. A blocked run still *succeeds* on the backend,
+ * returning a one-paragraph HTML guard message that is indistinguishable from a
+ * real report inside the iframe, so the client has to refuse to start rather
+ * than start and render something that looks like a result.
+ *
+ * Mirrored from:
+ * - `get_latest_reviewer_memo_revision()` — lib/services/file_artifacts_service/file_artifacts_service.py
+ * - `precheck()` in lib/workflows/{revision_planning_summary,reviewer_response_memos,reviewer_coverage_report}/manifest.py
+ */
+
+import {
+  FileListItem,
+  FileRole,
+  ProjectDetailed,
+  SimpleDeepAgentState,
+  WorkflowRunStatus,
+  WorkflowRunType,
+} from '@/lib/generated-api';
+import { getDisplayStatus, getWorkflowRunByType, WorkflowRunDetailTyped } from '@/lib/workflow-state';
+
+export interface PeerReviewRuns {
+  plan?: WorkflowRunDetailTyped<SimpleDeepAgentState>;
+  memos?: WorkflowRunDetailTyped<SimpleDeepAgentState>;
+  coverage?: WorkflowRunDetailTyped<SimpleDeepAgentState>;
+}
+
+export interface PeerReviewFacts {
+  currentRevision: number;
+  viewedRevision: number;
+  isViewingOldRevision: boolean;
+
+  /** Every reviewer memo in the project, across all revisions. */
+  memos: FileListItem[];
+  /** The revision the assessments will read memos from, or null when there are none. */
+  reviewedRevision: number | null;
+  /** Memos on `reviewedRevision` — the ones that will actually be read. */
+  activeMemos: FileListItem[];
+  /** Revisions holding memos the agent will ignore, newest first. */
+  staleMemoRevisions: number[];
+
+  reviewedMain?: FileListItem;
+  currentMain?: FileListItem;
+  hasRevisedDraft: boolean;
+
+  documentProcessingReady: boolean;
+
+  planBlockedReason: string | null;
+  reviseBlockedReason: string | null;
+  /**
+   * Blocks both draft-comparing steps — the response memos and the coverage
+   * report. They are separate steps in the UI but their backend prechecks are
+   * identical, so one reason serves both rather than two copies drifting apart.
+   */
+  comparisonBlockedReason: string | null;
+
+  runs: PeerReviewRuns;
+}
+
+export function derivePeerReviewFacts(projectDetail: ProjectDetailed): PeerReviewFacts {
+  const files = projectDetail.files ?? [];
+  const workflowRuns = projectDetail.workflow_runs ?? [];
+
+  const currentRevision = projectDetail.project.current_revision ?? 1;
+  // `projectDetail.revision` is the revision the API actually returned, which is
+  // more reliable than the selectedRevision prop (the share page never sends one).
+  const viewedRevision = projectDetail.revision ?? currentRevision;
+  const isViewingOldRevision = viewedRevision < currentRevision;
+
+  // Mirrors get_latest_reviewer_memo_revision(): every memo, drop null revisions,
+  // take the max. `projectDetail.files` spans all revisions.
+  const memos = files.filter((f) => f.role === FileRole.ReviewerMemo);
+  const memoRevisions = memos.map((f) => f.revision).filter((r): r is number => r != null);
+  const reviewedRevision = memoRevisions.length > 0 ? Math.max(...memoRevisions) : null;
+  const activeMemos = memos.filter((f) => f.revision === reviewedRevision);
+  const staleMemoRevisions = [...new Set(memoRevisions)].filter((r) => r !== reviewedRevision).sort((a, b) => b - a);
+
+  const mainByRevision = new Map<number, FileListItem>();
+  for (const file of files) {
+    if (file.role === FileRole.Main && file.revision != null) mainByRevision.set(file.revision, file);
+  }
+  const currentMain = mainByRevision.get(currentRevision);
+  const reviewedMain = reviewedRevision != null ? mainByRevision.get(reviewedRevision) : undefined;
+  // The precheck compares main file IDs, not revision numbers. Mirror that.
+  // Note this is against currentRevision, never viewedRevision: a run always
+  // executes at the current revision regardless of what is on screen.
+  const hasRevisedDraft = !!currentMain && !!reviewedMain && currentMain.id !== reviewedMain.id;
+
+  // All three declare required_dependencies = [DOCUMENT_PROCESSING], and starting
+  // a run whose dependency has not completed errors out. There is a real window
+  // right after a new revision where the main file exists but processing is not done.
+  const documentProcessing = getWorkflowRunByType(workflowRuns, WorkflowRunType.DocumentProcessing);
+  const documentProcessingReady =
+    !!documentProcessing && getDisplayStatus(documentProcessing) === WorkflowRunStatus.Completed;
+
+  const noMemos = reviewedRevision === null;
+
+  const planBlockedReason = noMemos
+    ? 'Upload at least one reviewer memo to generate a revision-planning summary.'
+    : !documentProcessingReady
+      ? 'Waiting for the document to finish processing.'
+      : null;
+
+  const reviseBlockedReason = noMemos ? 'Waiting on reviewer memos.' : null;
+
+  const comparisonBlockedReason = noMemos
+    ? 'Upload at least one reviewer memo first.'
+    : // Not a precheck mirror but a crash guard: get_main_file(revision=R) raises
+      // ValueError when the revision has no main, failing the run outright.
+      !reviewedMain
+      ? `Revision ${reviewedRevision} has no main document on record, so there is nothing to compare against.`
+      : !hasRevisedDraft
+        ? `Your memos are attached to revision ${reviewedRevision}, which is still the current draft. Upload your revised draft as a new revision in step 2 — or, if the memos reviewed an earlier draft, re-upload them targeting that revision.`
+        : !documentProcessingReady
+          ? 'Waiting for the revised draft to finish processing.'
+          : null;
+
+  return {
+    currentRevision,
+    viewedRevision,
+    isViewingOldRevision,
+    memos,
+    reviewedRevision,
+    activeMemos,
+    staleMemoRevisions,
+    reviewedMain,
+    currentMain,
+    hasRevisedDraft,
+    documentProcessingReady,
+    planBlockedReason,
+    reviseBlockedReason,
+    comparisonBlockedReason,
+    runs: {
+      plan: getWorkflowRunByType(workflowRuns, WorkflowRunType.RevisionPlanningSummary),
+      memos: getWorkflowRunByType(workflowRuns, WorkflowRunType.ReviewerResponseMemos),
+      coverage: getWorkflowRunByType(workflowRuns, WorkflowRunType.ReviewerCoverageReport),
+    },
+  };
+}
+
+/** True when a stage is actionable and nobody has acted on it, or a run failed. */
+export function peerReviewNeedsAttention(facts: PeerReviewFacts, readOnly: boolean): boolean {
+  if (readOnly || facts.reviewedRevision === null) return false;
+  const { plan, memos, coverage } = facts.runs;
+  const failed = [plan, memos, coverage].some((run) => run && getDisplayStatus(run) === WorkflowRunStatus.Failed);
+  // When the memos belong to an earlier revision the planning summary usually
+  // lives there too, and the tab falls back to showing it. This runs outside
+  // that fetch, so treat "no plan on this revision" as actionable only when
+  // there is no earlier revision it could have come from — otherwise the tab
+  // would show an attention dot next to a summary that is right there.
+  const planCouldExistElsewhere = facts.reviewedRevision !== facts.viewedRevision;
+  const planActionable = facts.planBlockedReason === null && !plan && !planCouldExistElsewhere;
+  const respondActionable = facts.comparisonBlockedReason === null && (!memos || !coverage);
+  return failed || planActionable || respondActionable;
+}

--- a/frontend/components/results/tabs/peer-review/peer-review-derive.ts
+++ b/frontend/components/results/tabs/peer-review/peer-review-derive.ts
@@ -99,25 +99,40 @@ export function derivePeerReviewFacts(projectDetail: ProjectDetailed): PeerRevie
 
   const noMemos = reviewedRevision === null;
 
-  const planBlockedReason = noMemos
-    ? 'Upload at least one reviewer memo to generate a revision-planning summary.'
-    : !documentProcessingReady
-      ? 'Waiting for the document to finish processing.'
-      : null;
+  // Runs always execute at the current revision, but `workflow_runs` above is
+  // scoped to the revision on screen — so while an older one is being viewed we
+  // cannot know whether the current revision is ready, and every readiness
+  // signal here would be about the wrong revision. Block outright and say so
+  // rather than report a status that is not about the draft a run would use.
+  // (Viewing an older revision also forces readOnly, so no action is offered
+  // either way; this keeps the derived state from lying about it.)
+  const staleRevisionReason = isViewingOldRevision
+    ? `You are viewing revision ${viewedRevision}. These assessments always run against revision ${currentRevision} — switch to it to run them.`
+    : null;
 
-  const reviseBlockedReason = noMemos ? 'Waiting on reviewer memos.' : null;
+  const planBlockedReason =
+    staleRevisionReason ??
+    (noMemos
+      ? 'Upload at least one reviewer memo to generate a revision-planning summary.'
+      : !documentProcessingReady
+        ? 'Waiting for the document to finish processing.'
+        : null);
 
-  const comparisonBlockedReason = noMemos
-    ? 'Upload at least one reviewer memo first.'
-    : // Not a precheck mirror but a crash guard: get_main_file(revision=R) raises
-      // ValueError when the revision has no main, failing the run outright.
-      !reviewedMain
-      ? `Revision ${reviewedRevision} has no main document on record, so there is nothing to compare against.`
-      : !hasRevisedDraft
-        ? `Your memos are attached to revision ${reviewedRevision}, which is still the current draft. Upload your revised draft as a new revision in step 2 — or, if the memos reviewed an earlier draft, re-upload them targeting that revision.`
-        : !documentProcessingReady
-          ? 'Waiting for the revised draft to finish processing.'
-          : null;
+  const reviseBlockedReason = staleRevisionReason ?? (noMemos ? 'Waiting on reviewer memos.' : null);
+
+  const comparisonBlockedReason =
+    staleRevisionReason ??
+    (noMemos
+      ? 'Upload at least one reviewer memo first.'
+      : // Not a precheck mirror but a crash guard: get_main_file(revision=R) raises
+        // ValueError when the revision has no main, failing the run outright.
+        !reviewedMain
+        ? `Revision ${reviewedRevision} has no main document on record, so there is nothing to compare against.`
+        : !hasRevisedDraft
+          ? `Your memos are attached to revision ${reviewedRevision}, which is still the current draft. Upload your revised draft as a new revision in step 2 — or, if the memos reviewed an earlier draft, re-upload them targeting that revision.`
+          : !documentProcessingReady
+            ? 'Waiting for the revised draft to finish processing.'
+            : null);
 
   return {
     currentRevision,

--- a/frontend/components/results/tabs/peer-review/peer-review-empty-state.tsx
+++ b/frontend/components/results/tabs/peer-review/peer-review-empty-state.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { EmptyState } from '@/components/shared/empty-state';
+import { Button } from '@/components/ui/button';
+import { MessagesSquare, Upload } from 'lucide-react';
+
+interface PeerReviewEmptyStateProps {
+  readOnly: boolean;
+  onUploadMemos: () => void;
+}
+
+/**
+ * Zero state. The tab is always visible, so on a project that never goes
+ * through peer review this has to teach rather than nag.
+ */
+export function PeerReviewEmptyState({ readOnly, onUploadMemos }: PeerReviewEmptyStateProps) {
+  return (
+    <EmptyState
+      icon={MessagesSquare}
+      title="No reviewer memos yet"
+      description="Once your draft comes back from peer review, upload the reviewers' memos here. Draft Detective will turn their points into a revision plan, then — after you upload your revised draft — draft a response memo per reviewer and a coverage report for a QA manager."
+    >
+      {!readOnly && (
+        <Button onClick={onUploadMemos}>
+          <Upload className="size-4" />
+          Upload reviewer memos
+        </Button>
+      )}
+    </EmptyState>
+  );
+}

--- a/frontend/components/results/tabs/peer-review/peer-review-memos-card.tsx
+++ b/frontend/components/results/tabs/peer-review/peer-review-memos-card.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { formatFileSize } from '@/components/analysis-form/utils';
+import { FileTypeIcon } from '@/components/shared/file-type-icon';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Callout } from '@/components/ui/callout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FileDownloadLink } from '@/components/ui/file-download-link';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { FileListItem } from '@/lib/generated-api';
+import { AlertTriangle, Loader2, Trash2, Upload } from 'lucide-react';
+import { useRemoveFileMutation } from '../reference-review/mutations';
+import { PeerReviewFacts } from './peer-review-derive';
+
+interface PeerReviewMemosCardProps {
+  facts: PeerReviewFacts;
+  projectId: string;
+  readOnly: boolean;
+  onUploadMemos: () => void;
+}
+
+function MemoRow({
+  memo,
+  projectId,
+  readOnly,
+  showRevision = false,
+}: {
+  memo: FileListItem;
+  projectId: string;
+  readOnly: boolean;
+  /** Ignored memos can span several revisions, so each says which it belongs to. */
+  showRevision?: boolean;
+}) {
+  const removeFileMutation = useRemoveFileMutation(projectId, memo.id);
+  const isRemoving = removeFileMutation.isPending;
+
+  return (
+    <li className="flex items-center gap-3 rounded-md border px-3 py-2">
+      <FileTypeIcon fileType={memo.file_type} />
+      <FileDownloadLink fileId={memo.id} className="min-w-0 flex-1 truncate text-sm hover:underline">
+        {memo.file_name || 'Unknown'}
+      </FileDownloadLink>
+      {showRevision && memo.revision != null && (
+        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          Revision {memo.revision}
+        </span>
+      )}
+      <span className="shrink-0 text-xs text-muted-foreground">{formatFileSize(memo.file_size)}</span>
+      {!readOnly && (
+        <AlertDialog>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <AlertDialogTrigger asChild>
+                <Button variant="ghost" size="icon" className="size-8 shrink-0" disabled={isRemoving}>
+                  {isRemoving ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="size-4 text-muted-foreground" />
+                  )}
+                  <span className="sr-only">Remove memo</span>
+                </Button>
+              </AlertDialogTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Remove memo</TooltipContent>
+          </Tooltip>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Remove reviewer memo?</AlertDialogTitle>
+              <AlertDialogDescription className="break-all">
+                &quot;{memo.file_name}&quot; will be removed from this project. This cannot be undone, and assessments
+                you run afterwards will no longer read it. Reports already generated are unaffected.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={() => removeFileMutation.mutate()}>Remove</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </li>
+  );
+}
+
+export function PeerReviewMemosCard({ facts, projectId, readOnly, onUploadMemos }: PeerReviewMemosCardProps) {
+  const { activeMemos, reviewedRevision, staleMemoRevisions, memos } = facts;
+  const ignoredMemos = memos.filter((memo) => memo.revision !== reviewedRevision);
+
+  return (
+    <Card className="gap-3">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-sm">
+          {activeMemos.length} reviewer {activeMemos.length === 1 ? 'memo' : 'memos'} on revision {reviewedRevision}
+        </CardTitle>
+        {!readOnly && (
+          <Button variant="outline" size="sm" onClick={onUploadMemos}>
+            <Upload className="size-4" />
+            Add memos
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <ul className="space-y-2">
+          {activeMemos.map((memo) => (
+            <MemoRow key={memo.id} memo={memo} projectId={projectId} readOnly={readOnly} />
+          ))}
+        </ul>
+
+        {ignoredMemos.length > 0 && (
+          // `max()` is not "most recently uploaded": memos targeting an older
+          // revision than an existing batch are silently ignored by the agent.
+          // Without saying so, that behaviour is inexplicable — and they are
+          // listed below so the advice can be acted on without leaving the tab.
+          <div className="space-y-2">
+            <Callout variant="warning" icon={AlertTriangle} title="Some memos are not being used">
+              <p className="text-sm">
+                {ignoredMemos.length} memo{ignoredMemos.length === 1 ? '' : 's'} on revision{' '}
+                {staleMemoRevisions.join(', ')} {ignoredMemos.length === 1 ? 'is' : 'are'} ignored. The assessments read
+                only the memos on revision {reviewedRevision}, the most recent draft that has any. Remove them, or
+                re-upload them targeting revision {reviewedRevision}, to include them.
+              </p>
+            </Callout>
+            <ul className="space-y-2 opacity-70">
+              {ignoredMemos.map((memo) => (
+                <MemoRow key={memo.id} memo={memo} projectId={projectId} readOnly={readOnly} showRevision />
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/results/tabs/peer-review/peer-review-stage-card.tsx
+++ b/frontend/components/results/tabs/peer-review/peer-review-stage-card.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Callout } from '@/components/ui/callout';
+import { StatusIndicator } from '@/components/ui/status-indicator';
+import { TabsTrigger } from '@/components/ui/tabs';
+import { WorkflowRunDetail, WorkflowRunStatus } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import { getDisplayStatus, isWorkflowProcessing } from '@/lib/workflow-state';
+import { Check, Info, Loader2, X, type LucideIcon } from 'lucide-react';
+import { ReactNode } from 'react';
+
+interface StepTriggerProps {
+  value: string;
+  index: number;
+  title: string;
+  /** One line describing what this step does. */
+  subtitle: string;
+  complete: boolean;
+  blocked: boolean;
+  /** The run backing this step's status chip. Absent for steps the author does by hand. */
+  run?: WorkflowRunDetail;
+  /** Status text when the step is actionable but not yet done. */
+  readyLabel?: string;
+}
+
+/**
+ * One step, rendered as a clickable card that behaves as a tab.
+ *
+ * These reports run to many screens, so the steps select a single panel rather
+ * than stacking: only the active step's report is mounted, and switching
+ * between them does not mean scrolling past the others.
+ */
+export function PeerReviewStepTrigger({
+  value,
+  index,
+  title,
+  subtitle,
+  complete,
+  blocked,
+  run,
+  readyLabel = 'Ready to run',
+}: StepTriggerProps) {
+  return (
+    <TabsTrigger
+      value={value}
+      className={cn(
+        // Override the pill-style defaults: these are full cards in a grid.
+        // `border-border` is required — the default sets `border-transparent`,
+        // which is a colour class and so survives adding `border`.
+        'h-auto w-full flex-none items-start justify-start whitespace-normal rounded-lg border border-border bg-card p-3 text-left shadow-none',
+        'data-[state=active]:border-primary data-[state=active]:bg-accent/50 data-[state=active]:shadow-sm',
+        // The default carries a dark-mode active border that would otherwise
+        // win over the one above, since it is a different variant.
+        'dark:data-[state=active]:border-primary dark:data-[state=active]:bg-accent/30',
+        'hover:bg-accent/30',
+      )}
+    >
+      <div className="flex w-full items-start gap-3">
+        <span
+          className={cn(
+            'flex size-6 shrink-0 items-center justify-center rounded-full border text-xs font-medium',
+            complete
+              ? 'border-green-600 bg-green-600 text-white'
+              : blocked
+                ? 'border-muted-foreground/30 text-muted-foreground'
+                : 'border-primary text-primary',
+          )}
+        >
+          {complete ? <Check className="size-3.5" /> : index}
+        </span>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="text-sm font-medium leading-tight">{title}</div>
+          <div className="text-xs font-normal text-muted-foreground leading-snug">{subtitle}</div>
+          <div className="pt-0.5">
+            {/* A run's own status wins. Steps the author does by hand have no
+                run, so completion has to be reported from `complete` — without
+                this they show a tick and "Ready to run" at the same time. */}
+            {run ? (
+              <StatusIndicator status={getDisplayStatus(run)} />
+            ) : complete ? (
+              <StatusIndicator status={WorkflowRunStatus.Completed} />
+            ) : (
+              <span className="text-xs text-muted-foreground">{blocked ? 'Not ready' : readyLabel}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </TabsTrigger>
+  );
+}
+
+interface StagePanelProps {
+  /** Non-null when the step cannot be acted on; rendered above the body. */
+  blockedReason: string | null;
+  actions?: ReactNode;
+  children?: ReactNode;
+}
+
+/** Body of the selected step: why it is blocked, its content, then its actions. */
+export function PeerReviewStagePanel({ blockedReason, actions, children }: StagePanelProps) {
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      {blockedReason && (
+        <Callout variant="info" icon={Info} title="Not ready yet">
+          <p className="text-sm">{blockedReason}</p>
+        </Callout>
+      )}
+      {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The call to action for a step with nothing to show yet: what it produces,
+ * then the button. Centred like `EmptyState`, but without its Card — the stage
+ * panel already provides the border.
+ */
+export function PeerReviewStageCta({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-10 text-center">
+      <Icon className="size-8 text-muted-foreground" />
+      <div className="space-y-1.5">
+        <p className="text-sm font-medium">{title}</p>
+        <p className="mx-auto max-w-prose text-sm text-muted-foreground">{description}</p>
+      </div>
+      {action}
+    </div>
+  );
+}
+
+interface StageActionProps {
+  label: string;
+  /** Overrides the "Re-run" text when a result already exists. */
+  reRunLabel?: string;
+  run?: WorkflowRunDetail;
+  disabled: boolean;
+  isStarting: boolean;
+  variant?: 'default' | 'outline';
+  /** CTA buttons render at the default size; toolbar ones stay small. */
+  size?: 'sm' | 'default';
+  onStart: () => void;
+  onCancel: (runId: string) => void;
+}
+
+/**
+ * Start / cancel / re-run for one deliverable.
+ *
+ * Not `StartWorkflowButton`: that opens `WorkflowConfigDialog`, the dialog this
+ * tab exists to remove, and none of these workflows needs web-search consent or
+ * a publication date, so there is nothing to configure.
+ */
+export function PeerReviewStageAction({
+  label,
+  reRunLabel,
+  run,
+  disabled,
+  isStarting,
+  variant = 'default',
+  size = 'sm',
+  onStart,
+  onCancel,
+}: StageActionProps) {
+  if (run && isWorkflowProcessing(run)) {
+    return (
+      <Button variant="outline" size={size} onClick={() => onCancel(run.run.id)}>
+        <Loader2 className="size-4 animate-spin" />
+        Running
+        <X className="size-4" />
+      </Button>
+    );
+  }
+
+  const hasResult = !!run;
+  return (
+    <Button variant={hasResult ? 'outline' : variant} size={size} disabled={disabled || isStarting} onClick={onStart}>
+      {isStarting && <Loader2 className="size-4 animate-spin" />}
+      {hasResult ? (reRunLabel ?? 'Re-run') : label}
+    </Button>
+  );
+}

--- a/frontend/components/results/tabs/peer-review/peer-review-tab.tsx
+++ b/frontend/components/results/tabs/peer-review/peer-review-tab.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Callout } from '@/components/ui/callout';
+import { Tabs, TabsContent, TabsList } from '@/components/ui/tabs';
+import { SimpleDeepAgentResults } from '@/components/workflows/results/simple-deep-agent-results';
+import { FileRole, ProjectDetailed, WorkflowRunDetail, WorkflowRunStatus, WorkflowRunType } from '@/lib/generated-api';
+import { getDisplayStatus } from '@/lib/workflow-state';
+import { ClipboardCheck, History, ListChecks, MessagesSquare, Upload } from 'lucide-react';
+import { useState } from 'react';
+import { ReplaceMainDocumentDialog } from '../../components/replace-main-document-dialog';
+import { FileUploadDialog } from '../reference-review/file-upload-dialog';
+import { PeerReviewEmptyState } from './peer-review-empty-state';
+import { PeerReviewMemosCard } from './peer-review-memos-card';
+import {
+  PeerReviewStageAction,
+  PeerReviewStageCta,
+  PeerReviewStagePanel,
+  PeerReviewStepTrigger,
+} from './peer-review-stage-card';
+import { usePeerReviewState } from './use-peer-review-state';
+
+type StageId = 'plan' | 'revise' | 'respond' | 'coverage';
+
+interface PeerReviewTabProps {
+  projectDetail: ProjectDetailed;
+  readOnly?: boolean;
+  onRevisionChange?: (revision: number) => void;
+  onRevisionCreated?: () => void;
+  onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
+}
+
+const isComplete = (run?: WorkflowRunDetail) => !!run && getDisplayStatus(run) === WorkflowRunStatus.Completed;
+
+export function PeerReviewTab({
+  projectDetail,
+  readOnly = false,
+  onRevisionChange,
+  onRevisionCreated,
+  onNavigateToDocumentExplorer,
+}: PeerReviewTabProps) {
+  const { facts, planFallback, startStage, cancelRun, isStarting } = usePeerReviewState({ projectDetail });
+  const [isMemoUploadOpen, setIsMemoUploadOpen] = useState(false);
+  const [isRevisionDialogOpen, setIsRevisionDialogOpen] = useState(false);
+
+  const { runs, currentRevision, reviewedRevision, hasRevisedDraft, isViewingOldRevision } = facts;
+
+  // The plan for the reviewed draft stays relevant after a new revision exists,
+  // so fall back to the run on that revision rather than showing step 1 empty.
+  const planRun = runs.plan ?? planFallback?.run;
+  const planRunRevision = runs.plan ? facts.viewedRevision : planFallback?.revision;
+  const planRunProject = runs.plan ? projectDetail : (planFallback?.projectDetail ?? projectDetail);
+  const planComplete = isComplete(planRun);
+  const memosComplete = isComplete(runs.memos);
+  const coverageComplete = isComplete(runs.coverage);
+
+  // Land on the furthest step that has something to show. Held in state rather
+  // than recomputed, so the 3s project poll cannot move the selection out from
+  // under someone who is reading.
+  const [activeStage, setActiveStage] = useState<StageId>(() => {
+    if (runs.coverage) return 'coverage';
+    if (runs.memos || hasRevisedDraft) return 'respond';
+    if (planComplete) return 'revise';
+    return 'plan';
+  });
+
+  const memoDialog = (
+    <FileUploadDialog
+      isOpen={isMemoUploadOpen}
+      projectId={projectDetail.project.id}
+      title="Upload reviewer memos"
+      description="Add the memos your peer reviewers returned. They are read against the draft the reviewers saw."
+      multiple
+      fileRole={FileRole.ReviewerMemo}
+      allowRevisionSelection
+      currentRevision={currentRevision}
+      onCancel={() => setIsMemoUploadOpen(false)}
+      onComplete={() => setIsMemoUploadOpen(false)}
+    />
+  );
+
+  if (reviewedRevision === null) {
+    return (
+      <div className="space-y-4">
+        <PeerReviewHeader />
+        <PeerReviewEmptyState readOnly={readOnly} onUploadMemos={() => setIsMemoUploadOpen(true)} />
+        {memoDialog}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <PeerReviewHeader />
+
+      {isViewingOldRevision && (
+        <Callout variant="info" icon={History} title={`Viewing revision ${facts.viewedRevision}`}>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm min-w-0">
+              These assessments always run against the current draft, revision {currentRevision}.
+            </p>
+            {onRevisionChange && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="shrink-0"
+                onClick={() => onRevisionChange(currentRevision)}
+              >
+                View current
+              </Button>
+            )}
+          </div>
+        </Callout>
+      )}
+
+      <PeerReviewMemosCard
+        facts={facts}
+        projectId={projectDetail.project.id}
+        readOnly={readOnly}
+        onUploadMemos={() => setIsMemoUploadOpen(true)}
+      />
+
+      <Tabs value={activeStage} onValueChange={(value) => setActiveStage(value as StageId)} className="gap-4">
+        <TabsList className="grid h-auto w-full grid-cols-1 gap-3 bg-transparent p-0 sm:grid-cols-2 xl:grid-cols-4">
+          <PeerReviewStepTrigger
+            value="plan"
+            index={1}
+            title="Plan the revision"
+            subtitle="Every reviewer point, located and actionable."
+            complete={planComplete}
+            blocked={facts.planBlockedReason !== null}
+            run={planRun}
+          />
+          <PeerReviewStepTrigger
+            value="revise"
+            index={2}
+            title="Upload your revised draft"
+            subtitle="Creates the revision the response compares against."
+            complete={hasRevisedDraft}
+            blocked={facts.reviseBlockedReason !== null}
+            readyLabel="Ready to upload"
+          />
+          <PeerReviewStepTrigger
+            value="respond"
+            index={3}
+            title="Respond to the reviewers"
+            subtitle="One response memo per reviewer, point by point."
+            complete={memosComplete}
+            blocked={facts.comparisonBlockedReason !== null}
+            run={runs.memos}
+          />
+          <PeerReviewStepTrigger
+            value="coverage"
+            index={4}
+            title="QA coverage report"
+            subtitle="A verdict per point, consolidated for a QA manager."
+            complete={coverageComplete}
+            blocked={facts.comparisonBlockedReason !== null}
+            run={runs.coverage}
+          />
+        </TabsList>
+
+        <TabsContent value="plan">
+          <PeerReviewStagePanel
+            blockedReason={facts.planBlockedReason}
+            actions={
+              planRun &&
+              !readOnly && (
+                <PeerReviewStageAction
+                  label="Generate planning summary"
+                  reRunLabel={planFallback ? `Generate again for revision ${currentRevision}` : undefined}
+                  run={planRun}
+                  disabled={facts.planBlockedReason !== null}
+                  isStarting={isStarting}
+                  onStart={() => startStage([WorkflowRunType.RevisionPlanningSummary])}
+                  onCancel={cancelRun}
+                />
+              )
+            }
+          >
+            {planRun ? (
+              <div className="space-y-3">
+                <p className="text-xs text-muted-foreground">
+                  Based on revision {planRunRevision} — the draft your reviewers read, and the{' '}
+                  {facts.activeMemos.length} memo{facts.activeMemos.length === 1 ? '' : 's'} attached to it.
+                  {planFallback && ' It still applies: those memos have not changed.'}
+                </p>
+                <SimpleDeepAgentResults
+                  project={planRunProject}
+                  workflowDetail={planRun}
+                  workflowName="Revision-Planning Summary"
+                  onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+                />
+              </div>
+            ) : (
+              <PeerReviewStageCta
+                icon={ListChecks}
+                title="Turn the reviewers' memos into a revision plan"
+                description={`Reads the ${facts.activeMemos.length} memo${facts.activeMemos.length === 1 ? '' : 's'} on revision ${reviewedRevision} against that revision's draft, reproduces each memo verbatim, and adds a planning note under every point.`}
+                action={
+                  !readOnly && (
+                    <PeerReviewStageAction
+                      label="Generate planning summary"
+                      run={undefined}
+                      disabled={facts.planBlockedReason !== null}
+                      isStarting={isStarting}
+                      size="default"
+                      onStart={() => startStage([WorkflowRunType.RevisionPlanningSummary])}
+                      onCancel={cancelRun}
+                    />
+                  )
+                }
+              />
+            )}
+          </PeerReviewStagePanel>
+        </TabsContent>
+
+        <TabsContent value="revise">
+          <PeerReviewStagePanel
+            blockedReason={facts.reviseBlockedReason}
+            actions={
+              hasRevisedDraft &&
+              !readOnly && (
+                <Button variant="outline" size="sm" onClick={() => setIsRevisionDialogOpen(true)}>
+                  <Upload className="size-4" />
+                  Create another revision
+                </Button>
+              )
+            }
+          >
+            {hasRevisedDraft ? (
+              <p className="text-sm text-muted-foreground">
+                Revision {currentRevision} is your revised draft. Revision {reviewedRevision} is kept as the draft the
+                reviewers read, and steps 3 and 4 compare the two.
+              </p>
+            ) : (
+              <PeerReviewStageCta
+                icon={Upload}
+                title="Upload the draft you revised"
+                description={`Revision ${reviewedRevision} is the draft your reviewers read. Uploading your revised version creates a new revision — revision ${reviewedRevision} and all its results are kept, and steps 3 and 4 compare the two.`}
+                action={
+                  !readOnly && (
+                    <Button disabled={facts.reviseBlockedReason !== null} onClick={() => setIsRevisionDialogOpen(true)}>
+                      <Upload className="size-4" />
+                      Upload revised draft
+                    </Button>
+                  )
+                }
+              />
+            )}
+          </PeerReviewStagePanel>
+        </TabsContent>
+
+        <TabsContent value="respond">
+          <PeerReviewStagePanel
+            blockedReason={facts.comparisonBlockedReason}
+            actions={
+              runs.memos &&
+              !readOnly && (
+                <PeerReviewStageAction
+                  label="Generate response memos"
+                  run={runs.memos}
+                  disabled={facts.comparisonBlockedReason !== null}
+                  isStarting={isStarting}
+                  onStart={() => startStage([WorkflowRunType.ReviewerResponseMemos])}
+                  onCancel={cancelRun}
+                />
+              )
+            }
+          >
+            {runs.memos ? (
+              <SimpleDeepAgentResults
+                project={projectDetail}
+                workflowDetail={runs.memos}
+                workflowName="Reviewer Response Memos"
+                onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+              />
+            ) : (
+              <PeerReviewStageCta
+                icon={MessagesSquare}
+                title="Draft a reply to every reviewer point"
+                description={`One response memo per reviewer. Compares revision ${currentRevision} against revision ${reviewedRevision} to state, for every point, what changed and where, or why it was not changed.`}
+                action={
+                  !readOnly && (
+                    <PeerReviewStageAction
+                      label="Generate response memos"
+                      run={undefined}
+                      disabled={facts.comparisonBlockedReason !== null}
+                      isStarting={isStarting}
+                      size="default"
+                      onStart={() => startStage([WorkflowRunType.ReviewerResponseMemos])}
+                      onCancel={cancelRun}
+                    />
+                  )
+                }
+              />
+            )}
+          </PeerReviewStagePanel>
+        </TabsContent>
+
+        <TabsContent value="coverage">
+          <PeerReviewStagePanel
+            blockedReason={facts.comparisonBlockedReason}
+            actions={
+              runs.coverage &&
+              !readOnly && (
+                <PeerReviewStageAction
+                  label="Generate coverage report"
+                  run={runs.coverage}
+                  disabled={facts.comparisonBlockedReason !== null}
+                  isStarting={isStarting}
+                  onStart={() => startStage([WorkflowRunType.ReviewerCoverageReport])}
+                  onCancel={cancelRun}
+                />
+              )
+            }
+          >
+            {runs.coverage ? (
+              <SimpleDeepAgentResults
+                project={projectDetail}
+                workflowDetail={runs.coverage}
+                workflowName="Reviewer Coverage Report"
+                onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+              />
+            ) : (
+              <PeerReviewStageCta
+                icon={ClipboardCheck}
+                title="Sign off on how responsive the revision was"
+                description="A single view for a QA manager: every reviewer point with a verdict (addressed, partially addressed, declined with rationale, or not addressed), a summary count table, and an overall responsiveness read."
+                action={
+                  !readOnly && (
+                    <PeerReviewStageAction
+                      label="Generate coverage report"
+                      run={undefined}
+                      disabled={facts.comparisonBlockedReason !== null}
+                      isStarting={isStarting}
+                      size="default"
+                      onStart={() => startStage([WorkflowRunType.ReviewerCoverageReport])}
+                      onCancel={cancelRun}
+                    />
+                  )
+                }
+              />
+            )}
+          </PeerReviewStagePanel>
+        </TabsContent>
+      </Tabs>
+
+      {memoDialog}
+      <ReplaceMainDocumentDialog
+        isOpen={isRevisionDialogOpen}
+        projectId={projectDetail.project.id}
+        onClose={() => setIsRevisionDialogOpen(false)}
+        onRevisionCreated={onRevisionCreated}
+        hideRerunOption
+      />
+    </div>
+  );
+}
+
+function PeerReviewHeader() {
+  return (
+    <div className="space-y-1">
+      <h2 className="text-lg font-semibold">Peer review</h2>
+      <p className="text-sm text-muted-foreground">
+        Plan your revision from the reviewers&apos; memos, upload the revised draft, then generate the response memos
+        and the coverage report.
+      </p>
+    </div>
+  );
+}

--- a/frontend/components/results/tabs/peer-review/use-peer-review-state.ts
+++ b/frontend/components/results/tabs/peer-review/use-peer-review-state.ts
@@ -1,0 +1,107 @@
+'use client';
+
+import { getErrorMessage } from '@/lib/api-error';
+import {
+  cancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPost,
+  ProjectDetailed,
+  startMultipleWorkflowsApiWorkflowsStartMultiplePost,
+  WorkflowRunType,
+} from '@/lib/generated-api';
+import { useProjectDetails } from '@/lib/hooks/use-project-details';
+import { getWorkflowRunByType, WorkflowRunDetailTyped } from '@/lib/workflow-state';
+import { SimpleDeepAgentState } from '@/lib/generated-api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { toast } from 'sonner';
+import { derivePeerReviewFacts, PeerReviewFacts } from './peer-review-derive';
+
+interface UsePeerReviewStateArgs {
+  projectDetail: ProjectDetailed;
+}
+
+/** A planning summary that lives on an earlier revision than the one on screen. */
+export interface PlanFallback {
+  run: WorkflowRunDetailTyped<SimpleDeepAgentState>;
+  revision: number;
+  /** That revision's payload, so the run's own issues resolve correctly. */
+  projectDetail: ProjectDetailed;
+}
+
+export interface PeerReviewState {
+  facts: PeerReviewFacts;
+  planFallback?: PlanFallback;
+  startStage: (types: WorkflowRunType[]) => void;
+  cancelRun: (runId: string) => void;
+  isStarting: boolean;
+}
+
+/**
+ * Derived peer-review state plus the two mutations the tab needs.
+ *
+ * These workflows are startable only from this tab, so start/cancel live here
+ * rather than going through StartWorkflowButton — that opens WorkflowConfigDialog,
+ * which is the dialog this tab exists to remove, and none of the three has
+ * anything to configure.
+ */
+export function usePeerReviewState({ projectDetail }: UsePeerReviewStateArgs): PeerReviewState {
+  const projectId = projectDetail.project.id;
+  const queryClient = useQueryClient();
+
+  const facts = useMemo(() => derivePeerReviewFacts(projectDetail), [projectDetail]);
+
+  // Workflow runs are scoped to a revision, so the planning summary disappears
+  // from view the moment a revised draft creates a new one — even though it is
+  // still the summary for the memos being worked through. Fetch the reviewed
+  // revision's payload to keep showing it. Same query key as the revision
+  // switcher, so this usually resolves from cache, and the project-wide
+  // invalidation below clears it too.
+  const needsPlanFallback =
+    facts.reviewedRevision !== null && facts.reviewedRevision !== facts.viewedRevision && !facts.runs.plan;
+  const { project: reviewedRevisionDetail } = useProjectDetails(
+    needsPlanFallback ? projectId : null,
+    facts.reviewedRevision,
+  );
+
+  const planFallback = useMemo<PlanFallback | undefined>(() => {
+    if (!needsPlanFallback || !reviewedRevisionDetail || facts.reviewedRevision === null) return undefined;
+    const run = getWorkflowRunByType(
+      reviewedRevisionDetail.workflow_runs ?? [],
+      WorkflowRunType.RevisionPlanningSummary,
+    );
+    return run ? { run, revision: facts.reviewedRevision, projectDetail: reviewedRevisionDetail } : undefined;
+  }, [needsPlanFallback, reviewedRevisionDetail, facts.reviewedRevision]);
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['project', projectId] });
+
+  const startMutation = useMutation({
+    mutationFn: async (workflowTypes: WorkflowRunType[]) =>
+      startMultipleWorkflowsApiWorkflowsStartMultiplePost({
+        body: { project_id: projectId, workflow_types: workflowTypes },
+      }),
+    onSuccess: (_data, workflowTypes) => {
+      toast.success(workflowTypes.length > 1 ? 'Assessments started' : 'Assessment started');
+      invalidate();
+    },
+    onError: (error) => toast.error(getErrorMessage(error, 'Failed to start assessment')),
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: async (runId: string) =>
+      cancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPost({
+        path: { workflow_run_id: runId },
+      }),
+    onSuccess: () => {
+      toast.success('Assessment cancelled');
+      invalidate();
+    },
+    onError: (error) => toast.error(getErrorMessage(error, 'Failed to cancel assessment')),
+  });
+
+  return {
+    facts,
+    planFallback,
+    startStage: startMutation.mutate,
+    cancelRun: cancelMutation.mutate,
+    isStarting: startMutation.isPending,
+  };
+}

--- a/frontend/components/results/tabs/reference-review/file-upload-dialog.tsx
+++ b/frontend/components/results/tabs/reference-review/file-upload-dialog.tsx
@@ -44,8 +44,11 @@ export interface FileUploadDialogProps {
    */
   targetRevision?: number;
   /**
-   * Let the user pick which draft the memos reviewed. Requires `currentRevision`
-   * and only renders once the project has more than one revision.
+   * Show which draft the memos are attached to, and let the user change it.
+   * Requires `currentRevision`. The control renders for every reviewer-memo
+   * upload — memos are always bound to a draft, and seeing that up front is
+   * what stops a later batch going to the wrong one — but it is disabled while
+   * the project has only one revision, since there is nothing to choose.
    */
   allowRevisionSelection?: boolean;
   /** The project's current revision, used to build the revision options. */

--- a/frontend/components/results/tabs/reference-review/file-upload-dialog.tsx
+++ b/frontend/components/results/tabs/reference-review/file-upload-dialog.tsx
@@ -14,6 +14,7 @@ import {
 import { Label } from '@/components/ui/label';
 import { FileUpload } from '@/components/ui/file-upload';
 import { RadioGroup, RadioGroupItemWithDescription } from '@/components/ui/radio-group-with-description';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { FileListItem } from '@/components/analysis-form/file-list-item';
 import { UploadProgressList } from '@/components/ui/upload-progress-list';
 import { useUpload } from '@/lib/hooks/upload';
@@ -37,6 +38,18 @@ export interface FileUploadDialogProps {
    * Not compatible with `referenceId`.
    */
   allowRoleSelection?: boolean;
+  /**
+   * Revision reviewer memos are attached to. Defaults to the current revision.
+   * Only meaningful for the reviewer-memo role.
+   */
+  targetRevision?: number;
+  /**
+   * Let the user pick which draft the memos reviewed. Requires `currentRevision`
+   * and only renders once the project has more than one revision.
+   */
+  allowRevisionSelection?: boolean;
+  /** The project's current revision, used to build the revision options. */
+  currentRevision?: number;
   /** When set, force-matches the uploaded file to this reference instead of triggering the matching workflow. */
   referenceId?: string;
   onCancel: () => void;
@@ -52,12 +65,16 @@ export function FileUploadDialog({
   projectId,
   fileRole = FileRole.Support,
   allowRoleSelection = false,
+  targetRevision,
+  allowRevisionSelection = false,
+  currentRevision,
   referenceId,
   onCancel,
   onComplete,
 }: FileUploadDialogProps) {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [selectedRole, setSelectedRole] = useState<FileRole>(fileRole);
+  const [selectedRevision, setSelectedRevision] = useState<number | undefined>(targetRevision);
   const [isStartingWorkflow, setIsStartingWorkflow] = useState(false);
   const queryClient = useQueryClient();
   const resetRef = useRef<(() => void) | null>(null);
@@ -70,6 +87,14 @@ export function FileUploadDialog({
   // already tied to a specific reference); other roles skip it.
   const activeSkipMatching = activeRole !== FileRole.Support;
   const activeSuccessMessage = isMemoUpload ? 'Reviewer memos uploaded.' : 'Files uploaded. Matching workflow started.';
+  // Only memos carry a revision; sending one for any other role is a 400.
+  const activeRevision = isMemoUpload ? selectedRevision : undefined;
+  // Shown even when there is only one revision: memos are always bound to a
+  // specific draft, and seeing that up front is what stops people from
+  // attaching a later batch to the wrong one.
+  const showRevisionPicker = isMemoUpload && allowRevisionSelection;
+  const revisionCount = currentRevision ?? 1;
+  const revisionOptions = Array.from({ length: revisionCount }, (_, i) => revisionCount - i);
 
   const handleAllComplete = useCallback(async () => {
     if (referenceId) {
@@ -108,6 +133,7 @@ export function FileUploadDialog({
     projectId,
     fileRole: activeRole,
     referenceId,
+    targetRevision: activeRevision,
     onAllComplete: handleAllComplete,
   });
 
@@ -119,10 +145,11 @@ export function FileUploadDialog({
     if (isOpen) {
       setSelectedFiles([]);
       setSelectedRole(fileRole);
+      setSelectedRevision(targetRevision);
       setIsStartingWorkflow(false);
       resetRef.current?.();
     }
-  }, [isOpen, fileRole]);
+  }, [isOpen, fileRole, targetRevision]);
 
   const handleFilesChange = (newFiles: File[]) => {
     setSelectedFiles(multiple ? newFiles : newFiles.slice(-1));
@@ -233,10 +260,38 @@ export function FileUploadDialog({
                       id={FileRole.ReviewerMemo}
                       value={selectedRole}
                       label="Reviewer memo"
-                      description="Peer-review feedback attached to the current revision. Used by the Peer Review Assistant assessments."
+                      description="Peer-review feedback on a specific draft. Used by the Peer Review assessments."
                       disabled={isUploading}
                     />
                   </RadioGroup>
+                </div>
+              )}
+
+              {showRevisionPicker && (
+                <div className="space-y-2">
+                  <Label htmlFor="memo-revision">Which draft did these reviewers read?</Label>
+                  <Select
+                    value={String(selectedRevision ?? revisionCount)}
+                    onValueChange={(v) => setSelectedRevision(Number(v))}
+                    disabled={isUploading || revisionCount === 1}
+                  >
+                    <SelectTrigger id="memo-revision" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {revisionOptions.map((rev) => (
+                        <SelectItem key={rev} value={String(rev)}>
+                          Revision {rev}
+                          {rev === revisionCount ? ' (current)' : ''}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    {revisionCount === 1
+                      ? 'Memos are attached to the draft they reviewed. This project has one revision, so they attach to revision 1 — once you upload a revised draft, the assessments compare the two.'
+                      : 'The assessments compare that draft against the current one. Pick the draft the reviewers actually saw, which is not always the latest.'}
+                  </p>
                 </div>
               )}
               <div className="space-y-2">

--- a/frontend/components/shared/file-type-icon.tsx
+++ b/frontend/components/shared/file-type-icon.tsx
@@ -1,0 +1,21 @@
+import { FileText } from 'lucide-react';
+
+/** Document icon tinted by file type, so a file list scans at a glance. */
+export function FileTypeIcon({ fileType, className }: { fileType?: string | null; className?: string }) {
+  const normalizedType = fileType?.toLowerCase() || '';
+
+  if (normalizedType.includes('pdf') || normalizedType === 'application/pdf') {
+    return <FileText className={className ?? 'flex-shrink-0 size-4 text-red-700'} />;
+  }
+
+  if (
+    normalizedType.includes('docx') ||
+    normalizedType.includes('doc') ||
+    normalizedType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+    normalizedType === 'application/msword'
+  ) {
+    return <FileText className={className ?? 'flex-shrink-0 size-4 text-blue-700'} />;
+  }
+
+  return <FileText className={className ?? 'flex-shrink-0 size-4 text-muted-foreground'} />;
+}

--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -19,7 +19,7 @@ import {
 import { AssistantRuntimeProvider, ThreadMessageLike, useExternalStoreRuntime } from '@assistant-ui/react';
 import { convertLangChainMessages, LangChainMessage } from '@assistant-ui/react-langgraph';
 import { Ban, CheckCircle2, ClipboardList, Download, Loader2, MessageSquare, XCircle } from 'lucide-react';
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 interface SimpleDeepAgentResultsProps {
   project: ProjectDetailed;
@@ -103,23 +103,6 @@ function ReportCard({ reportMarkdown }: { reportMarkdown: string }) {
   );
 }
 
-// No Card wrapper here: the report document already renders inside its own
-// bordered frame, so an outer card would just nest a box in a box.
-function HtmlReportCard({ reportHtml }: { reportHtml: string }) {
-  const frameRef = useRef<HtmlReportFrameHandle>(null);
-  return (
-    <div className="space-y-2">
-      <div className="flex justify-end">
-        <Button variant="outline" size="sm" onClick={() => frameRef.current?.print()}>
-          <Download className="size-4" />
-          Download PDF
-        </Button>
-      </div>
-      <HtmlReportFrame ref={frameRef} html={reportHtml} title="Report" />
-    </div>
-  );
-}
-
 export function SimpleDeepAgentResults({
   project,
   workflowDetail,
@@ -141,6 +124,12 @@ export function SimpleDeepAgentResults({
     isRunning: false,
     onNew: async () => {},
   });
+
+  // Declared above the early returns below, so the hook order stays stable.
+  // The tab is controlled because the Download PDF button sits in the tab row
+  // and only applies to the Results tab.
+  const [activeTab, setActiveTab] = useState('results');
+  const frameRef = useRef<HtmlReportFrameHandle>(null);
 
   if (isWorkflowProcessing(workflowDetail)) {
     return (
@@ -184,22 +173,33 @@ export function SimpleDeepAgentResults({
   const { result } = state;
 
   return (
-    <Tabs defaultValue="results">
-      <TabsList>
-        <TabsTrigger value="results" className="gap-1.5">
-          <ClipboardList className="h-3.5 w-3.5" />
-          Results
-        </TabsTrigger>
-        <TabsTrigger value="messages" className="gap-1.5">
-          <MessageSquare className="h-3.5 w-3.5" />
-          Messages
-        </TabsTrigger>
-      </TabsList>
+    <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <div className="flex items-center justify-between gap-2">
+        <TabsList>
+          <TabsTrigger value="results" className="gap-1.5">
+            <ClipboardList className="h-3.5 w-3.5" />
+            Results
+          </TabsTrigger>
+          <TabsTrigger value="messages" className="gap-1.5">
+            <MessageSquare className="h-3.5 w-3.5" />
+            Messages
+          </TabsTrigger>
+        </TabsList>
+        {/* Only on the Results tab: the other tab unmounts the frame, which
+            would leave this printing nothing. */}
+        {result.report_html && activeTab === 'results' && (
+          <Button variant="outline" size="sm" onClick={() => frameRef.current?.print()}>
+            <Download className="size-4" />
+            Download PDF
+          </Button>
+        )}
+      </div>
 
       <TabsContent value="results" className="space-y-4">
         {result.report_html ? (
           // HTML-report workflows produce a document deliverable, not a checklist.
-          <HtmlReportCard reportHtml={result.report_html} />
+          // No Card wrapper: the report renders in its own bordered frame already.
+          <HtmlReportFrame ref={frameRef} html={result.report_html} title="Report" />
         ) : (
           <>
             {result.report_markdown && <ReportCard reportMarkdown={result.report_markdown} />}
@@ -208,9 +208,11 @@ export function SimpleDeepAgentResults({
         )}
       </TabsContent>
 
-      <TabsContent value="messages" className="mt-4">
+      {/* No top margin: the Tabs root already spaces panels from the tab list,
+          and the thread's own viewport padding is dropped for the same reason. */}
+      <TabsContent value="messages">
         <AssistantRuntimeProvider runtime={runtime}>
-          <ReadonlyThread />
+          <ReadonlyThread viewportClassName="pt-0" />
         </AssistantRuntimeProvider>
       </TabsContent>
     </Tabs>

--- a/frontend/components/workflows/workflow-type-selector.tsx
+++ b/frontend/components/workflows/workflow-type-selector.tsx
@@ -44,8 +44,27 @@ export function WorkflowTypeSelector({
   }, [allTypes, restrictToType]);
 
   const experimentalVisible = showExperimentalFeatures;
+  const typeMap = useMemo(() => new Map(workflowTypes.map((wt) => [wt.type, wt])), [workflowTypes]);
 
-  const visibleCount = workflowTypes.filter((wt) => !wt.is_experimental || experimentalVisible).length;
+  // Category membership is what decides whether a workflow is on offer here:
+  // anything absent from every category (the peer-review workflows, which are
+  // started from their own tab) is not shown and not counted.
+  const visibleGroups = useMemo(() => {
+    if (restrictToType) return [];
+    return categories
+      .map((category) => ({
+        category,
+        workflows: category.workflows
+          .map((type) => typeMap.get(type as WorkflowRunType))
+          .filter((wt): wt is WorkflowTypeDescription => wt !== undefined)
+          .filter((wt) => experimentalVisible || !wt.is_experimental),
+      }))
+      .filter((group) => group.workflows.length > 0);
+  }, [categories, typeMap, experimentalVisible, restrictToType]);
+
+  const visibleCount = restrictToType
+    ? workflowTypes.filter((wt) => !wt.is_experimental || experimentalVisible).length
+    : visibleGroups.reduce((total, group) => total + group.workflows.length, 0);
 
   const handleCheckedChange = (type: WorkflowRunType, checked: boolean) => {
     if (checked) {
@@ -66,7 +85,6 @@ export function WorkflowTypeSelector({
     />
   );
 
-  const typeMap = new Map(workflowTypes.map((wt) => [wt.type, wt]));
   const controlsDisabled = disabled || isLoadingWorkflowTypes;
 
   return (
@@ -97,21 +115,12 @@ export function WorkflowTypeSelector({
             <p className="text-sm text-muted-foreground">This workflow type is not available for your account.</p>
           )
         ) : (
-          categories.map((category) => {
-            const categoryWorkflows = category.workflows
-              .map((type) => typeMap.get(type as WorkflowRunType))
-              .filter((wt): wt is WorkflowTypeDescription => wt !== undefined)
-              .filter((wt) => experimentalVisible || !wt.is_experimental);
-
-            if (categoryWorkflows.length === 0) return null;
-
-            return (
-              <div key={category.slug} className="space-y-2">
-                <h3 className="text-sm font-semibold text-foreground pt-2">{category.label}</h3>
-                {categoryWorkflows.map(renderCheckbox)}
-              </div>
-            );
-          })
+          visibleGroups.map(({ category, workflows }) => (
+            <div key={category.slug} className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground pt-2">{category.label}</h3>
+              {workflows.map(renderCheckbox)}
+            </div>
+          ))
         )}
 
         {error && <p className="text-sm text-destructive">{error}</p>}

--- a/frontend/lib/hooks/upload/types.ts
+++ b/frontend/lib/hooks/upload/types.ts
@@ -27,6 +27,12 @@ export interface UseUploadOptions {
   fileRole?: FileRole;
   /** When set, the backend will force-match the uploaded file to this reference. */
   referenceId?: string;
+  /**
+   * Revision the uploaded file belongs to. Only meaningful for reviewer memos,
+   * which review a specific draft that is not always the current one. Omit to
+   * attach to the project's current revision.
+   */
+  targetRevision?: number;
   /** Callback when a file is completed. */
   onFileComplete?: (file: File, uppyFile: UppyFile<Meta, AnyBody>) => void;
   /** Callback when all files are completed. */

--- a/frontend/lib/hooks/upload/use-upload.ts
+++ b/frontend/lib/hooks/upload/use-upload.ts
@@ -14,7 +14,15 @@ import type { UseUploadOptions, UseUploadReturn, UploadFileState, UploadStatus }
 import { createProgress, isActiveStatus } from './types';
 
 export function useUpload(options: UseUploadOptions): UseUploadReturn {
-  const { projectId, fileRole = FileRole.Support, referenceId, onFileComplete, onAllComplete, onError } = options;
+  const {
+    projectId,
+    fileRole = FileRole.Support,
+    referenceId,
+    targetRevision,
+    onFileComplete,
+    onAllComplete,
+    onError,
+  } = options;
 
   const queryClient = useQueryClient();
   const [files, setFiles] = useState<UploadFileState[]>([]);
@@ -24,6 +32,13 @@ export function useUpload(options: UseUploadOptions): UseUploadReturn {
   // Refs for callbacks to get latest values in event handlers
   const callbackRefs = useRef({ onFileComplete, onAllComplete, onError });
   callbackRefs.current = { onFileComplete, onAllComplete, onError };
+
+  // The Uppy instance is created once and cached, so its `file-added` handler
+  // would otherwise capture the revision selected at first render. Read it
+  // through a ref, and re-stamp it at upload time, so changing the target
+  // revision after files are picked still takes effect.
+  const targetRevisionRef = useRef(targetRevision);
+  targetRevisionRef.current = targetRevision;
 
   const findUppyId = useCallback((fileId: string): string | undefined => {
     for (const [uppyId, entry] of fileMapRef.current.entries()) {
@@ -60,6 +75,10 @@ export function useUpload(options: UseUploadOptions): UseUploadReturn {
       };
       if (referenceId) {
         meta.reference_id = referenceId;
+      }
+      // TUS metadata values are strings; the server parses and validates this.
+      if (targetRevisionRef.current !== undefined) {
+        meta.revision = String(targetRevisionRef.current);
       }
       uppy.setFileMeta(file.id, meta);
     });
@@ -142,6 +161,9 @@ export function useUpload(options: UseUploadOptions): UseUploadReturn {
           if (referenceId) {
             meta.reference_id = referenceId;
           }
+          if (targetRevisionRef.current !== undefined) {
+            meta.revision = String(targetRevisionRef.current);
+          }
           const uppyFileId = uppy.addFile({
             name: file.name,
             type: file.type,
@@ -182,6 +204,12 @@ export function useUpload(options: UseUploadOptions): UseUploadReturn {
       const uppy = getUppy();
       if (filesToUpload && filesToUpload.length > 0) {
         addFiles(filesToUpload);
+      }
+      // Re-stamp in case the target revision changed after the files were added.
+      if (targetRevisionRef.current !== undefined) {
+        for (const uppyFile of uppy.getFiles()) {
+          uppy.setFileMeta(uppyFile.id, { revision: String(targetRevisionRef.current) });
+        }
       }
       setFiles((prev) => prev.map((f) => (f.status === 'pending' ? { ...f, status: 'uploading' as UploadStatus } : f)));
       uppy.upload();

--- a/frontend/lib/peer-review.ts
+++ b/frontend/lib/peer-review.ts
@@ -1,0 +1,17 @@
+import { WorkflowRunType } from '@/lib/generated-api';
+
+/**
+ * The workflows owned by the Peer Review tab, in the order of the cycle.
+ *
+ * They are started only from that tab, so the Analyses picker filters them out.
+ * Keeping the list here means the tab and the exclusion cannot drift apart.
+ */
+export const PEER_REVIEW_WORKFLOW_TYPES: readonly WorkflowRunType[] = [
+  WorkflowRunType.RevisionPlanningSummary,
+  WorkflowRunType.ReviewerResponseMemos,
+  WorkflowRunType.ReviewerCoverageReport,
+] as const;
+
+export function isPeerReviewWorkflowType(type: WorkflowRunType): boolean {
+  return PEER_REVIEW_WORKFLOW_TYPES.includes(type);
+}

--- a/frontend/lib/workflow-state.ts
+++ b/frontend/lib/workflow-state.ts
@@ -56,6 +56,12 @@ type WorkflowTypeToDetail = {
   [WorkflowRunType.DocumentStructure]: SimpleDeepAgentState;
   [WorkflowRunType.FiguresTablesCheck]: SimpleDeepAgentState;
   [WorkflowRunType.AdvocacyToneV2]: SimpleDeepAgentState;
+  [WorkflowRunType.RecommendationCheck]: SimpleDeepAgentState;
+  [WorkflowRunType.LiteratureReviewV2]: SimpleDeepAgentState;
+  [WorkflowRunType.LiveReportsV2]: SimpleDeepAgentState;
+  [WorkflowRunType.RevisionPlanningSummary]: SimpleDeepAgentState;
+  [WorkflowRunType.ReviewerResponseMemos]: SimpleDeepAgentState;
+  [WorkflowRunType.ReviewerCoverageReport]: SimpleDeepAgentState;
 };
 
 export interface WorkflowRunDetailTyped<T> {

--- a/lib/api/routers/tus_upload.py
+++ b/lib/api/routers/tus_upload.py
@@ -45,7 +45,10 @@ def _resolve_file_revision(metadata: dict, role: FileRole, project: Project) -> 
     raw = metadata.get("revision")
     has_explicit_revision = raw is not None and str(raw).strip() != ""
 
-    if role == FileRole.SUPPORT:
+    # Only MAIN and REVIEWER_MEMO are revision-scoped. Everything else is shared
+    # across revisions — including SUPPORTING_CANDIDATE, the temporary role the
+    # reference downloader uses before promoting a file to SUPPORT.
+    if role not in (FileRole.MAIN, FileRole.REVIEWER_MEMO):
         return None
 
     if role == FileRole.MAIN:

--- a/lib/api/routers/tus_upload.py
+++ b/lib/api/routers/tus_upload.py
@@ -10,7 +10,7 @@ from fastapi import Depends, HTTPException
 from lib.api.auth import get_current_user
 from lib.config.env import config
 from lib.models.file import FileRole
-from lib.models.project import AccessLevel
+from lib.models.project import AccessLevel, Project
 from lib.models.user import User
 from lib.services.file_finalization import finalize_file_from_path
 from lib.services.files import get_files_by_project_id
@@ -24,19 +24,73 @@ logger = logging.getLogger(__name__)
 DEFAULT_FILENAME = "unknown"
 
 
+def _parse_role(metadata: dict) -> FileRole:
+    """Read the file role from upload metadata, defaulting to SUPPORT."""
+    try:
+        return FileRole(metadata.get("role", FileRole.SUPPORT.value))
+    except ValueError:
+        return FileRole.SUPPORT
+
+
+def _resolve_file_revision(metadata: dict, role: FileRole, project: Project) -> int | None:
+    """Resolve the revision an uploaded file belongs to.
+
+    Supporting documents are shared across revisions (``None``). A main document
+    always defines the current revision. Reviewer memos review a *specific*
+    draft, which is not always the current one — an author may replace the main
+    document before uploading the memos that reviewed the previous draft — so
+    clients may target that draft with a ``revision`` metadata field. Omitting it
+    keeps the historical behaviour of attaching to the current revision.
+    """
+    raw = metadata.get("revision")
+    has_explicit_revision = raw is not None and str(raw).strip() != ""
+
+    if role == FileRole.SUPPORT:
+        return None
+
+    if role == FileRole.MAIN:
+        # A main document defines its revision; back-dating one would collide
+        # with the one-main-per-revision guard below and corrupt the timeline.
+        if has_explicit_revision and str(raw).strip() != str(project.current_revision):
+            raise HTTPException(
+                status_code=400,
+                detail="revision cannot be set for main documents",
+            )
+        return project.current_revision
+
+    if not has_explicit_revision:
+        return project.current_revision
+
+    try:
+        revision = int(str(raw).strip())
+    except ValueError:
+        raise HTTPException(status_code=400, detail="revision must be an integer")
+
+    if not 1 <= revision <= project.current_revision:
+        raise HTTPException(
+            status_code=400,
+            detail=f"revision must be between 1 and {project.current_revision}",
+        )
+    return revision
+
+
 def _get_pre_create_hook(
     current_user: User = Depends(get_current_user),
 ) -> Callable[[dict, dict], Awaitable[None]]:
-    """Validates user access before upload starts."""
+    """Validates user access and metadata before upload starts."""
 
     async def handler(metadata: dict, upload_info: dict) -> None:
         project_id = metadata.get("project_id")
         if not project_id:
             raise HTTPException(status_code=400, detail="project_id is required")
 
-        await get_project_access(
+        project, _ = await get_project_access(
             project_id, user=current_user, required_level=AccessLevel.WRITE
         )
+
+        # Validate the target revision here as well as on completion, so a bad
+        # value fails before the client uploads the whole file.
+        _resolve_file_revision(metadata, _parse_role(metadata), project)
 
     return handler
 
@@ -52,22 +106,13 @@ def _get_completion_hook(
         if not project_id:
             raise HTTPException(status_code=400, detail="project_id is required")
 
-        role_str = metadata.get("role", FileRole.SUPPORT.value)
-        try:
-            role = FileRole(role_str)
-        except ValueError:
-            role = FileRole.SUPPORT
+        role = _parse_role(metadata)
 
         project, _ = await get_project_access(
             project_id, user=current_user, required_level=AccessLevel.WRITE
         )
 
-        # Determine revision for the file. MAIN and REVIEWER_MEMO files are
-        # scoped to the current revision (a memo reviews a specific draft);
-        # other roles (e.g. supporting docs) are shared across revisions (None).
-        revision: int | None = None
-        if role in (FileRole.MAIN, FileRole.REVIEWER_MEMO):
-            revision = project.current_revision
+        revision = _resolve_file_revision(metadata, role, project)
 
         if role == FileRole.MAIN:
             # Validate: only one MAIN file per revision

--- a/lib/services/projects.py
+++ b/lib/services/projects.py
@@ -38,6 +38,7 @@ from lib.services.workflow_runs import (
 )
 from lib.workflows.document_processing.state import DocumentProcessingState
 from lib.workflows.models import WorkflowRunType
+from lib.workflows.registry import get_all_manifests
 
 logger = logging.getLogger(__name__)
 
@@ -498,9 +499,22 @@ async def create_new_revision(
             .distinct()
         )
         result = await session.execute(types_stmt)
-        previous_workflow_types = [
+        ran_before = [
             WorkflowRunType(row[0]) if isinstance(row[0], str) else row[0]
             for row in result.all()
+        ]
+        # Workflows can opt out of being re-run automatically. The peer-review
+        # ones do: they read the *reviewed* revision against the current draft,
+        # so firing them the moment a revision is created either wastes an
+        # expensive run or returns a guard message. The user starts them from
+        # the Peer Review tab once the new draft is in place.
+        manifests = get_all_manifests()
+        previous_workflow_types = [
+            workflow_type
+            for workflow_type in ran_before
+            if getattr(
+                manifests.get(workflow_type), "auto_rerun_on_new_revision", True
+            )
         ]
 
         # Increment project revision

--- a/lib/workflows/categories.py
+++ b/lib/workflows/categories.py
@@ -59,15 +59,13 @@ WORKFLOW_DISPLAY_CONFIG: list[CategoryConfig] = [
             WorkflowRunType.ADVOCACY_TONE_V2,
         ],
     ),
-    CategoryConfig(
-        slug="peer_review_assistant",
-        label="Peer Review Assistant",
-        workflows=[
-            WorkflowRunType.REVISION_PLANNING_SUMMARY,
-            WorkflowRunType.REVIEWER_RESPONSE_MEMOS,
-            WorkflowRunType.REVIEWER_COVERAGE_REPORT,
-        ],
-    ),
+    # The peer-review workflows (REVISION_PLANNING_SUMMARY,
+    # REVIEWER_RESPONSE_MEMOS, REVIEWER_COVERAGE_REPORT) are deliberately absent.
+    # They are started only from the Peer Review tab, which sequences their
+    # prerequisites — memos first, then the revised draft — and starting them out
+    # of order returns a guard message instead of a report. Leaving them out of
+    # every category is what keeps them out of the assessment picker; they stay
+    # registered, so existing runs still list and render normally.
     CategoryConfig(
         slug="research_writing_assistant",
         label="Research & Writing Assistant",

--- a/lib/workflows/manifest.py
+++ b/lib/workflows/manifest.py
@@ -46,6 +46,12 @@ class WorkflowManifest[WorkflowStateType, WorkflowConfigType](ABC):
     # If True, workflow stays PENDING until explicitly triggered via API
     requires_human_trigger: bool = False
 
+    # Whether creating a new revision may re-run this workflow automatically,
+    # as part of "re-run previous assessments". Set False for workflows whose
+    # inputs are not simply "the current draft" — re-running them the moment a
+    # revision appears would either waste a run or produce a guard message.
+    auto_rerun_on_new_revision: bool = True
+
     # If True, workflow always runs even if already completed (when included as dependency)
     # The workflows needs to be idempotent, meaning it can be run multiple times without changing the result and typical execute only "new" content that was not processed in a previous run, reusing cached results from previous runs, like summarization, document conversion, etc (should process only new files in subsequent runs).
     always_run: bool = False

--- a/lib/workflows/reviewer_coverage_report/manifest.py
+++ b/lib/workflows/reviewer_coverage_report/manifest.py
@@ -86,6 +86,9 @@ class ReviewerCoverageReportManifest(HtmlReportDeepAgentManifest):
     )
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
     is_experimental = True
+    # Started only from the Peer Review tab, which sequences the prerequisites.
+    # Creating a revision must not fire these off on its own.
+    auto_rerun_on_new_revision = False
 
     skill = "review-assistant"
     system_prompt = _SYSTEM_PROMPT

--- a/lib/workflows/reviewer_response_memos/manifest.py
+++ b/lib/workflows/reviewer_response_memos/manifest.py
@@ -79,6 +79,9 @@ class ReviewerResponseMemosManifest(HtmlReportDeepAgentManifest):
     )
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
     is_experimental = True
+    # Started only from the Peer Review tab, which sequences the prerequisites.
+    # Creating a revision must not fire these off on its own.
+    auto_rerun_on_new_revision = False
 
     skill = "review-assistant"
     system_prompt = _SYSTEM_PROMPT

--- a/lib/workflows/revision_planning_summary/manifest.py
+++ b/lib/workflows/revision_planning_summary/manifest.py
@@ -74,6 +74,9 @@ class RevisionPlanningSummaryManifest(HtmlReportDeepAgentManifest):
     )
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
     is_experimental = True
+    # Started only from the Peer Review tab, which sequences the prerequisites.
+    # Creating a revision must not fire these off on its own.
+    auto_rerun_on_new_revision = False
 
     skill = "review-assistant"
     system_prompt = _SYSTEM_PROMPT

--- a/tests/unit/services/test_create_new_revision.py
+++ b/tests/unit/services/test_create_new_revision.py
@@ -193,6 +193,44 @@ async def test_create_new_revision_returns_previous_workflow_types():
 
 
 @pytest.mark.asyncio
+async def test_create_new_revision_excludes_workflows_opted_out_of_auto_rerun():
+    """Workflows with auto_rerun_on_new_revision=False are not offered for re-run.
+
+    The peer-review workflows read the *reviewed* revision against the current
+    draft, so re-running them the moment a revision is created would waste an
+    expensive run or return a guard message.
+    """
+    project = _make_project(current_revision=1)
+
+    previous_types = [
+        (WorkflowRunType.CLAIM_EXTRACTION,),
+        (WorkflowRunType.REVISION_PLANNING_SUMMARY,),
+        (WorkflowRunType.REVIEWER_RESPONSE_MEMOS,),
+        (WorkflowRunType.REVIEWER_COVERAGE_REPORT,),
+    ]
+
+    sessions = [
+        _FakeSession(scalars_result=[]),
+        _FakeSession(all_result=previous_types),
+    ]
+    session_iter = iter(sessions)
+
+    with (
+        patch(
+            "lib.services.projects.get_project_access",
+            new=AsyncMock(return_value=(project, AccessLevel.WRITE)),
+        ),
+        patch(
+            "lib.services.projects.get_async_db_session",
+            side_effect=lambda: next(session_iter),
+        ),
+    ):
+        _, returned_types = await create_new_revision(str(project.id), MagicMock())
+
+    assert returned_types == [WorkflowRunType.CLAIM_EXTRACTION]
+
+
+@pytest.mark.asyncio
 async def test_create_new_revision_requires_write_access():
     """Should raise when user lacks WRITE access."""
     from fastapi import HTTPException

--- a/tests/unit/test_tus_upload_revision.py
+++ b/tests/unit/test_tus_upload_revision.py
@@ -1,0 +1,92 @@
+"""Unit tests for revision resolution on TUS uploads.
+
+Reviewer memos review a specific draft, so clients may target a revision other
+than the current one. These cover the resolution rules in isolation — no DB, no
+HTTP.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from lib.api.routers.tus_upload import _parse_role, _resolve_file_revision
+from lib.models.file import FileRole
+from lib.models.project import Project
+
+
+def _project(current_revision: int = 3) -> Project:
+    return Project(name="Test project", current_revision=current_revision)
+
+
+class TestParseRole:
+    def test_defaults_to_support_when_absent(self):
+        assert _parse_role({}) == FileRole.SUPPORT
+
+    def test_defaults_to_support_when_invalid(self):
+        assert _parse_role({"role": "nonsense"}) == FileRole.SUPPORT
+
+    def test_reads_a_valid_role(self):
+        assert _parse_role({"role": "reviewer_memo"}) == FileRole.REVIEWER_MEMO
+
+
+class TestReviewerMemoRevision:
+    def test_absent_revision_uses_current(self):
+        revision = _resolve_file_revision({}, FileRole.REVIEWER_MEMO, _project(3))
+        assert revision == 3
+
+    def test_empty_revision_uses_current(self):
+        revision = _resolve_file_revision(
+            {"revision": ""}, FileRole.REVIEWER_MEMO, _project(3)
+        )
+        assert revision == 3
+
+    def test_explicit_earlier_revision_is_honoured(self):
+        revision = _resolve_file_revision(
+            {"revision": "2"}, FileRole.REVIEWER_MEMO, _project(3)
+        )
+        assert revision == 2
+
+    def test_whitespace_is_tolerated(self):
+        revision = _resolve_file_revision(
+            {"revision": " 1 "}, FileRole.REVIEWER_MEMO, _project(3)
+        )
+        assert revision == 1
+
+    @pytest.mark.parametrize("value", ["abc", "1.0", "-"])
+    def test_non_integer_is_rejected(self, value: str):
+        with pytest.raises(HTTPException) as exc:
+            _resolve_file_revision(
+                {"revision": value}, FileRole.REVIEWER_MEMO, _project(3)
+            )
+        assert exc.value.status_code == 400
+        assert "integer" in exc.value.detail
+
+    @pytest.mark.parametrize("value", ["0", "-1", "4", "99"])
+    def test_out_of_range_is_rejected(self, value: str):
+        with pytest.raises(HTTPException) as exc:
+            _resolve_file_revision(
+                {"revision": value}, FileRole.REVIEWER_MEMO, _project(3)
+            )
+        assert exc.value.status_code == 400
+        assert "between 1 and 3" in exc.value.detail
+
+
+class TestOtherRoles:
+    def test_supporting_documents_are_shared_across_revisions(self):
+        assert (
+            _resolve_file_revision({"revision": "2"}, FileRole.SUPPORT, _project(3))
+            is None
+        )
+
+    def test_main_uses_current_revision(self):
+        assert _resolve_file_revision({}, FileRole.MAIN, _project(3)) == 3
+
+    def test_main_tolerates_a_revision_matching_the_current_one(self):
+        assert (
+            _resolve_file_revision({"revision": "3"}, FileRole.MAIN, _project(3)) == 3
+        )
+
+    def test_main_rejects_a_back_dated_revision(self):
+        with pytest.raises(HTTPException) as exc:
+            _resolve_file_revision({"revision": "1"}, FileRole.MAIN, _project(3))
+        assert exc.value.status_code == 400
+        assert "main documents" in exc.value.detail

--- a/tests/unit/test_tus_upload_revision.py
+++ b/tests/unit/test_tus_upload_revision.py
@@ -77,6 +77,20 @@ class TestOtherRoles:
             is None
         )
 
+    def test_supporting_candidates_are_shared_across_revisions(self):
+        # The reference downloader's temporary role. Only MAIN and REVIEWER_MEMO
+        # are revision-scoped; anything else must stay NULL.
+        assert (
+            _resolve_file_revision({}, FileRole.SUPPORTING_CANDIDATE, _project(3))
+            is None
+        )
+        assert (
+            _resolve_file_revision(
+                {"revision": "2"}, FileRole.SUPPORTING_CANDIDATE, _project(3)
+            )
+            is None
+        )
+
     def test_main_uses_current_revision(self):
         assert _resolve_file_revision({}, FileRole.MAIN, _project(3)) == 3
 

--- a/tests/unit/test_tus_upload_revision.py
+++ b/tests/unit/test_tus_upload_revision.py
@@ -5,6 +5,8 @@ than the current one. These cover the resolution rules in isolation — no DB, n
 HTTP.
 """
 
+import uuid
+
 import pytest
 from fastapi import HTTPException
 
@@ -14,7 +16,12 @@ from lib.models.project import Project
 
 
 def _project(current_revision: int = 3) -> Project:
-    return Project(name="Test project", current_revision=current_revision)
+    return Project(
+        id=uuid.uuid4(),
+        title="Test Project",
+        user_id=uuid.uuid4(),
+        current_revision=current_revision,
+    )
 
 
 class TestParseRole:


### PR DESCRIPTION
Closes [RANDZ-631](https://linear.app/ae-studio/issue/RANDZ-631/polish-review-assistant-in-the-web-ui-enough-to-demoshowcase-it)

Follow-up to #647, which shipped the three peer-review workflows. This makes them usable.

## Summary

Adds a **Peer Review** tab that owns the whole cycle in four steps — plan the revision, upload the revised draft, respond to the reviewers, generate the QA coverage report. Each step says what it produces, whether it is ready, and why not if it isn't. Reviewer memos can now be attached to the draft they actually reviewed, which removes the trap that silently broke both comparison workflows.

## Motivation

Running these three took **three tabs, three dialogs and a profile setting**, in an order stated nowhere:

1. Profile dropdown → enable experimental features (all three are `is_experimental`).
2. Files tab → Upload files → switch the role radio to "Reviewer memo".
3. Analyses tab → "+" → find the Peer Review Assistant category → run the planning summary.
4. Revise externally, then Options menu → Create new revision.
5. Analyses tab → "+" again → run the other two.

Two things actively broke. **Order was load-bearing and invisible:** memos were pinned to `project.current_revision` at upload, so uploading them *after* replacing the main document made the reviewed revision equal the current one, and both comparison workflows refused. **A blocked run still succeeds**, returning a one-paragraph HTML guard message that is indistinguishable from a real report inside the iframe — so doing it wrong looked like a result.

## What's Changed

### Backend

**`lib/api/routers/tus_upload.py`** — `_resolve_file_revision()` accepts an optional `revision` in the TUS metadata for reviewer memos. Absent/empty keeps the old behaviour (no migration, existing rows unaffected); non-integer or out-of-range is a 400, as is a revision sent with a main document, which defines its own. Validated in the pre-create hook too, so a bad value fails before the upload runs.

**`lib/workflows/manifest.py`** — new `auto_rerun_on_new_revision` flag (default `True`). The three peer-review manifests set it `False`, and **`lib/services/projects.py`** filters `previous_workflow_types` through it, so "re-run previous assessments" no longer fires them. They read the *reviewed* revision against the current draft, so an automatic run at revision-creation time would either waste an expensive high-effort run or return a guard message.

**`lib/workflows/categories.py`** — the `peer_review_assistant` category is removed. Category membership is what the assessment picker walks, so this is what keeps them out of it; they stay registered, so historical runs still list and render.

**Tests** — `tests/unit/test_tus_upload_revision.py` (18 cases over revision resolution) and a case in `test_create_new_revision.py` covering the auto-rerun exclusion.

### Frontend

**`components/results/tabs/peer-review/`** (new) — `peer-review-derive.ts` is pure and React-free by design: its predicates mirror the server-side prechecks and are meant to be read beside the Python. The tab renders four clickable step cards that select a single panel; only the active step's report is mounted, since these reports run to many screens. `use-peer-review-state.ts` holds the start/cancel mutations and the cross-revision fetch.

**`components/results/results-visualization.tsx`** — mounts the tab, with a count badge and an attention dot.

**`components/workflows/workflow-type-selector.tsx`** — the peer-review filter that was here is gone; the backend category removal handles it. Fixed a latent bug while there: `visibleCount` came from the flat list, so any non-internal workflow absent from every category inflated the "0/N selected" count.

**`components/workflows/results/simple-deep-agent-results.tsx`**, **`html-report-frame.tsx`**, **`readonly-thread.tsx`** — Download PDF moved onto the tab row; ~50px of stacked padding removed above the Messages panel; and the report's phantom vertical scrollbar fixed.

**`lib/hooks/upload/*`, `file-upload-dialog.tsx`, `files-tab.tsx`** — the revision picker and its plumbing. `FileTypeIcon` moved to `components/shared` so the memo list reuses it.

## Risks and Mitigations

- **Guard reports masquerading as results.** The client now refuses to start a blocked step and says why, so the guard path should not be reachable through the tab.
- **Silently ignored memos.** The reviewed revision is `max()`, not most-recently-uploaded, so memos on an older revision are skipped by the agent. The memos card names them and offers to remove them.
- **Dependency window.** Right after a revision is created the main file exists but document processing has not finished; starting then errors. Steps stay blocked until it completes.
- **Hidden re-run option.** The Peer Review tab hides the "re-run previous assessments" checkbox *and* disables the behaviour, so a hidden control cannot act on its default.
- **Scrollbar chrome is hidden, not disabled.** Content stays scrollable by wheel/keyboard, so a bad measurement cannot make anything unreachable.

## Verification

`uv run mypy .` clean (393 files) · `uv run pytest` 849 passed · `tsc`, `pnpm lint` (0 errors), `pnpm build` clean.

Because the frontend has no test runner, `derivePeerReviewFacts` was exercised against fixtures for all nine scenarios (no memos, the ordering trap, the happy path, memos split across revisions, a reviewed revision missing its main, processing still running, null revisions) — 24 assertions. The report containment CSS was verified in a real browser across nine report styles, including two that force their own scrollbar.

**Not yet verified end to end against a running stack** — worth exercising the reversed trap (create revision 2 first, then upload memos targeting revision 1; step 3 should be ready immediately) and the share/read-only view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mw1VFjYyZ65xSsoQyoiruy
