### PR TITLE
feat(teams): remember a conversation, and re-read its document each turn

### DIFF
--- a/lib/agents/checkpointer.py
+++ b/lib/agents/checkpointer.py
@@ -51,7 +51,12 @@ checkpointer_pool: AsyncConnectionPool[AsyncConnection[dict[str, Any]]] = (
     )
 )
 
+# Two flags rather than one, because they can disagree: a setup failure leaves the pool
+# open but not usable. Conflating them loses track of a pool that shutdown must still
+# close, and psycopg_pool refuses to reopen a closed one -- so closing it to recover is
+# not an option, and the open flag has to stay honest instead.
 _opened = False
+_ready = False
 _open_lock = asyncio.Lock()
 
 
@@ -77,18 +82,27 @@ async def _run_setup() -> None:
 
 
 async def _ensure_pool_ready() -> None:
-    """Open the pool and run the checkpoint migrations, once per process."""
+    """Open the pool and run the checkpoint migrations, once per process.
 
-    global _opened
-    if _opened:
+    A failure here leaves the pool open and retries the setup on the next call, which is
+    the right answer for the transient kind. It deliberately does not close the pool to
+    tidy up: a closed pool cannot be reopened, so that would turn one slow advisory lock
+    into every later turn failing.
+    """
+
+    global _opened, _ready
+    if _ready:
         return
     async with _open_lock:
         # Checked again under the lock: several first calls can arrive together.
-        if _opened:
+        if _ready:
             return
-        await checkpointer_pool.open(wait=True)
+        if not _opened:
+            await checkpointer_pool.open(wait=True)
+            # Set before setup runs, so a failure there still leaves something to close.
+            _opened = True
         await _run_setup()
-        _opened = True
+        _ready = True
         logger.info("checkpointer pool opened and checkpoint tables verified")
 
 
@@ -105,9 +119,16 @@ async def get_checkpointer() -> AsyncIterator[AsyncPostgresSaver]:
 
 
 async def close_checkpointer_pool() -> None:
-    """Close the pool. Called from the FastAPI lifespan shutdown."""
+    """Close the pool, for good. Called from the FastAPI lifespan shutdown.
 
-    global _opened
+    One way only: psycopg_pool raises on reopening a closed pool, so this is the end of
+    checkpointing in this process rather than something to call between runs.
+    """
+
+    global _ready
     if _opened:
         await checkpointer_pool.close()
-        _opened = False
+        # ``_opened`` stays true because the pool remains closed-and-used forever; only
+        # readiness is withdrawn, so a later call fails on the pool rather than
+        # cheerfully trying to open it again.
+        _ready = False

--- a/lib/agents/checkpointer.py
+++ b/lib/agents/checkpointer.py
@@ -1,0 +1,113 @@
+"""Durable graph state, for any agent whose thread outlives a single run.
+
+A caller opts in by passing the saver to ``create_deep_agent`` and a ``thread_id`` in the
+run config; nothing here knows what a thread belongs to.
+
+Three non-obvious constraints, two of which fail silently:
+
+- **A psycopg pool, not the SQLAlchemy engine.** ``AsyncPostgresSaver`` accepts neither,
+  so this is a second pool on the same database.
+- **A fresh saver per call over a shared pool.** Each saver holds its own
+  ``asyncio.Lock``, so sharing one serialises every concurrent run.
+- **Not ``from_conn_string``**, which holds a connection for a whole run.
+
+Connections: the SQLAlchemy engine is capped at 8 + 3 per process and this adds 4, so a
+4-worker deployment sits at 60 against a default limit of 100.
+"""
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool
+
+from lib.config.env import config
+
+logger = logging.getLogger(__name__)
+
+# An arbitrary but fixed key, so every worker contends for the same lock. Advisory
+# locks live in one tenant-wide namespace, hence something distinctive rather than 1.
+SETUP_LOCK_KEY = 0x44445F4341
+
+# ``min_size=0`` so an unused process holds nothing; ``prepare_threshold=0`` because a
+# transaction-pooling proxy would break on prepared statements; ``autocommit`` and
+# ``dict_row`` are required by AsyncPostgresSaver.
+checkpointer_pool: AsyncConnectionPool[AsyncConnection[dict[str, Any]]] = (
+    AsyncConnectionPool(
+        conninfo=config.DATABASE_URL,
+        min_size=0,
+        max_size=4,
+        kwargs={
+            "autocommit": True,
+            "prepare_threshold": 0,
+            "row_factory": dict_row,
+        },
+        open=False,
+    )
+)
+
+_opened = False
+_open_lock = asyncio.Lock()
+
+
+async def _run_setup() -> None:
+    """Create the checkpoint tables, once across every worker.
+
+    ``setup()`` is a versioned migration runner and ``checkpoint_migrations.v`` is a
+    primary key, so on a fresh database two of the four workers can read the same version
+    and race to insert it, one dying on a duplicate key.
+
+    Session-level rather than ``_xact_``, since the pool runs in autocommit and there is
+    no transaction to end with -- which makes releasing it our job, or a connection goes
+    back to the pool still holding it.
+    """
+
+    async with checkpointer_pool.connection() as conn:
+        await conn.execute("SELECT pg_advisory_lock(%s)", (SETUP_LOCK_KEY,))
+        try:
+            # Idempotent: it reads the applied version first and only applies the rest.
+            await AsyncPostgresSaver(conn=conn).setup()
+        finally:
+            await conn.execute("SELECT pg_advisory_unlock(%s)", (SETUP_LOCK_KEY,))
+
+
+async def _ensure_pool_ready() -> None:
+    """Open the pool and run the checkpoint migrations, once per process."""
+
+    global _opened
+    if _opened:
+        return
+    async with _open_lock:
+        # Checked again under the lock: several first calls can arrive together.
+        if _opened:
+            return
+        await checkpointer_pool.open(wait=True)
+        await _run_setup()
+        _opened = True
+        logger.info("checkpointer pool opened and checkpoint tables verified")
+
+
+@asynccontextmanager
+async def get_checkpointer() -> AsyncIterator[AsyncPostgresSaver]:
+    """A saver over the shared pool, opening the pool on first use.
+
+    Yields a new saver each time on purpose -- see the module docstring. The pool is
+    what is shared; the saver is a handle with a lock attached.
+    """
+
+    await _ensure_pool_ready()
+    yield AsyncPostgresSaver(conn=checkpointer_pool)
+
+
+async def close_checkpointer_pool() -> None:
+    """Close the pool. Called from the FastAPI lifespan shutdown."""
+
+    global _opened
+    if _opened:
+        await checkpointer_pool.close()
+        _opened = False

--- a/lib/agents/teams_agent.py
+++ b/lib/agents/teams_agent.py
@@ -7,8 +7,8 @@ rather than three sentences. So the reply guidance differs enough to warrant its
 prompt.
 
 What does not differ is the construction, which is shared through
-``lib/agents/deep_agent_setup.py``: once a document is open it is at ``/main.md``
-with numbered paragraphs, the skills are available, and there is no internet.
+``lib/agents/deep_agent_setup.py``: once a document is open it is markdown at
+``/main.md``, the skills are available, and there is no internet.
 
 The document is not chosen for the agent. A question from Teams may paste a link or
 not, so opening one is the agent's job via ``open_document_for`` in
@@ -102,9 +102,14 @@ those directly rather than asking for a link you do not need.
 
 ## Reading it
 
-Every paragraph in `/main.md` is prefixed with its number, like `[12]`. Those \
-numbers are not part of the text, and they are for your own navigation rather than \
-for the reader: nobody can jump to paragraph 93 in Word.
+`/main.md` is markdown, so the document's structure is visible: `##` headings, tables, \
+and bold or highlighted text. Use it to navigate — searching for `"## "` gives you the \
+outline before you read anything in full.
+
+Your search tool matches **literal text, not regular expressions**, so `^#` finds \
+nothing and `## ` finds every heading. Your read tool numbers the lines it shows you; \
+those numbers are for your own navigation, not for the reader, who cannot jump to a \
+line number in Word.
 
 ## What you can and cannot reach
 
@@ -140,10 +145,10 @@ list is often clearer than a paragraph. Still write like a colleague who has rea
 document:
 
 - Answer the question that was actually asked. Nothing else.
-- Point at places by quoting them, not by numbering them. A short distinctive \
-phrase in quotation marks is something the reader can search for in Word; "[93]" is \
-not. Quote the words at issue, and add the paragraph number in brackets afterwards \
-only as a rough position.
+- Point at places by quoting them, never by numbering them. A short distinctive \
+phrase in quotation marks is something the reader can search for in Word; a line number \
+is meaningless to them. Naming the section it is under helps; the line it sits on does \
+not.
 - Be concrete about figures and claims: give the number or the wording you mean, \
 not a description of it.
 - Length should match the question. A yes-or-no question gets a sentence. "Check \

--- a/lib/agents/teams_agent.py
+++ b/lib/agents/teams_agent.py
@@ -7,25 +7,25 @@ rather than three sentences. So the reply guidance differs enough to warrant its
 prompt.
 
 What does not differ is the construction, which is shared through
-``lib/agents/deep_agent_setup.py``: once a document is open it is markdown at
-``/main.md``, the skills are available, and there is no internet.
+``lib/agents/deep_agent_setup.py``: the skills are available, and there is no internet.
 
-The document is not chosen for the agent. A question from Teams may paste a link or
-not, so opening one is the agent's job via ``open_document_for`` in
-``lib/agents/tools/sharepoint.py``. A link is the only way in -- there is no lookup
-by name -- so a question that names a document without linking to it gets a request
-for the link. Skills are still mounted up front, because the skills middleware reads
-them once before the run and a tool cannot add them later.
+**No document is chosen for the agent, and nor is where to put it.** The links found in
+the message are handed over as candidates and the agent opens what it needs, via the
+tools in ``lib/agents/tools/sharepoint.py``. Which link is meant is a question about the
+conversation -- "compare these two", "the second one" -- so it belongs to the agent
+rather than to a regex. A link is still the only way in: there is no lookup by name, so a
+question naming a document without linking to it gets a request for the link.
 
-``graph_token`` is whose reading this run does. The tool is built from it per run, so
+``graph_token`` is whose reading this run does. Both tools are built from it per run, so
 the agent inherits the asker's own access rather than the service's: a document they
 cannot open is refused by Graph and the agent says so.
 
 One Teams thread is one LangGraph thread, so a follow-up arrives with the earlier turns
-in view. Its document does not: only the link persists, and every turn re-reads it as
-whoever is asking then. Two reasons, either sufficient -- the document may have been
-edited since, and a shared thread's next question may come from someone who cannot open
-it. Re-reading is itself the permission check, since Graph applies that person's access.
+*and the documents opened in them* still in view. Two things follow, and the agent is
+told about both: a mounted document may have been edited since it was read, and in a
+shared thread it may have been loaded for somebody else. ``check_document`` answers both
+in one cheap call -- it reports the edit time, and it fails when the person asking now
+cannot reach the document.
 
 Nothing here writes to the document. That is the point of this path -- a question
 answered in chat needs no document access at all, which sidesteps both the 423 a
@@ -51,17 +51,10 @@ from lib.agents.deep_agent_setup import (
     build_skill_files,
     tool_names,
 )
-from lib.agents.tools.sharepoint import (
-    document_files,
-    evict_document,
-    mounted_document,
-    open_document_for,
-)
+from lib.agents.tools.sharepoint import check_document_for, open_document_for
 from lib.config.langfuse import langfuse_handler
 from lib.config.llm_error_logger import ErrorLoggingCallback
 from lib.config.llm_models import LLMModel
-from lib.services.microsoft.graph import documents
-from lib.services.microsoft.graph.client import redacted
 
 logger = logging.getLogger(__name__)
 
@@ -71,28 +64,44 @@ question about a Word document from a chat, and you are answering them there.
 
 ## The conversation so far
 
-You may be part-way through a conversation. Earlier questions and your own earlier \
-answers are above, and any document this conversation is about is open and freshly \
-re-read — so check what you already have before asking for something again. Because it \
-is re-read every time, it may have changed since you last looked.
+You may be part-way through a conversation. Earlier questions, your own earlier answers, \
+and any documents you opened in them are all still here — so look at what you already \
+have with `ls` before asking for anything again.
 
-More than one person may be in this thread. Each question says who asked it; answer \
-the person asking now, and do not assume they are the person who asked before.
+More than one person may be in this thread. Each question says who asked it; answer the \
+person asking now, and do not assume they are the person who asked before.
 
-## Getting the document
+**A document you opened in an earlier turn is a copy, and two things may have changed \
+since.** It may have been edited in Word. And it may have been opened for somebody else \
+in this thread, who has access the person asking now does not. `check_document(url)` \
+settles both cheaply, without downloading anything: it tells you when the document was \
+last modified, so you can compare that with the time reported when you opened it, and it \
+fails outright if the person asking cannot reach the document.
 
-`open_document(url)` opens a document from a SharePoint link: it becomes available at \
-`/main.md`, and any comments already on it at `/comments.md`. Read or search those \
-files with your usual tools; the tool does not hand you the text.
+So before answering from a copy you did not open this turn: check it. If it has been \
+edited, open it again to replace it. If the check is refused, say you cannot read that \
+document as them — do not answer from the copy you still have, and do not describe its \
+contents.
 
-Check whether a document is already open before asking for a link — on a follow-up \
-there usually is one, and asking again for what you have is worse than useless.
+## Getting a document
+
+`open_document(url, path)` opens a document from a SharePoint link and saves it as \
+markdown at the path you choose, with any comments beside it. Read or search those files \
+with your usual tools; the tool does not hand you the text.
+
+Choose the path, under `/documents/`, and name it after the document — for example, \
+`/documents/v3-cern-for-ai.md`. Two documents, or two revisions of one, means two \
+different paths, so you can hold both open and tell them apart. Re-opening at the same \
+path replaces what is there, which is how you refresh a stale copy.
 
 **A link is the only way to reach a document.** You cannot look one up by name or \
 title, and you must not guess at a URL. If someone asks about a document without \
 linking to it, say you need the link and ask them to paste it — even when the name \
 they used sounds unambiguous. This is deliberate: a link is something they already \
 had access to, and searching on their behalf could reach documents they cannot open.
+
+When a message carries links, they are listed for you. Which one is meant is yours to \
+work out from what was asked; when it is genuinely unclear, ask rather than guess.
 
 Open a document before answering anything about one. Never answer from a name or a \
 file title alone, and never describe content you have not read.
@@ -102,9 +111,9 @@ those directly rather than asking for a link you do not need.
 
 ## Reading it
 
-`/main.md` is markdown, so the document's structure is visible: `##` headings, tables, \
-and bold or highlighted text. Use it to navigate — searching for `"## "` gives you the \
-outline before you read anything in full.
+A document is markdown, so its structure is visible: `##` headings, tables, and bold or \
+highlighted text. Use it to navigate — searching for `"## "` gives you the outline \
+before you read anything in full.
 
 Your search tool matches **literal text, not regular expressions**, so `^#` finds \
 nothing and `## ` finds every heading. Your read tool numbers the lines it shows you; \
@@ -162,21 +171,29 @@ REQUEST_PROMPT = """\
 {who} asked:
 
 {question}
-{hint}"""
+{links}"""
 
-HINT_PREAMBLE = """
-They linked to this document, so open it:
+# Every link found, not one chosen for the agent: which is meant is a question about the
+# conversation, and only the agent has that.
+ONE_LINK = """
+They linked to this document:
 
-{hint}"""
+{links}"""
 
-# In the request rather than the system prompt: it is about this turn. Worded without
-# asserting why -- a refusal and a timeout arrive the same way here, so claiming they lack
-# access would sometimes be a confident falsehood about someone's permissions.
-LOST_DOCUMENT_NOTICE = """
-The document this conversation was about could not be opened for the person asking now, \
-so it is no longer available to you. Do not answer from what was said about it earlier, \
-and do not describe its contents. Say plainly that you could not open it as them -- they \
-may not have access, or it may have moved -- and ask for a link they can open."""
+MANY_LINKS = """
+They linked to these documents:
+
+{links}"""
+
+
+def links_in(question_urls: Sequence[str]) -> str:
+    """The links from the message, as a block for the request prompt."""
+
+    if not question_urls:
+        return ""
+    listed = "\n".join(f"- {url}" for url in question_urls)
+    template = ONE_LINK if len(question_urls) == 1 else MANY_LINKS
+    return template.format(links=listed)
 
 
 def answer_text(messages: Sequence[BaseMessage]) -> str:
@@ -211,51 +228,11 @@ class QuestionAnswer(BaseModel):
     error: Optional[str] = None
 
 
-async def _document_for_this_turn(
-    agent: Any,
-    run_config: RunnableConfig,
-    *,
-    graph_token: str,
-    document_hint: Optional[str],
-) -> tuple[dict[str, Any], bool]:
-    """Re-read the document this thread is about, as the person asking now.
-
-    Returns the turn's ``files`` update and whether the document had to be given up;
-    empty on a thread with nothing open. A re-read rather than a check on the cached copy
-    because the document may have been edited, and because re-reading *is* the permission
-    check -- Graph applies this person's own access.
-
-    Any failure gives the document up. Fail-closed on purpose: a 403 and a timeout are
-    indistinguishable from here, and the wrong guess costs someone else's confidentiality
-    in one direction and a re-paste in the other.
-    """
-
-    snapshot = await agent.aget_state(run_config)
-    url = mounted_document(snapshot.values.get("files"))
-    if not url:
-        return {}, False
-
-    if document_hint and document_hint != url:
-        # They linked to something else, so the agent will open that instead. The old
-        # document goes now rather than lingering as a copy nobody re-read.
-        logger.info("this turn links elsewhere, so %s is closed", redacted(url))
-        return evict_document(), False
-
-    try:
-        document = await documents.load(url, token=graph_token)
-    except Exception as error:  # noqa: BLE001 - every failure ends the same way
-        logger.info("could not re-open %s for the asker: %s", redacted(url), error)
-        return evict_document(), True
-
-    logger.info("re-opened %s as the asker for this turn", redacted(url))
-    return document_files(document, url), False
-
-
 async def answer_question(
     question: str,
     graph_token: str,
     thread_id: str,
-    document_hint: Optional[str] = None,
+    document_urls: Optional[Sequence[str]] = None,
     asked_by: str = "Someone",
     model: LLMModel = DEFAULT_MODEL,
     api_key: Optional[str] = None,
@@ -263,17 +240,17 @@ async def answer_question(
 ) -> QuestionAnswer:
     """Answer a question about a document the agent opens for itself.
 
-    ``graph_token`` is the identity the document is read with -- the asker's own,
-    under Teams SSO. Required rather than optional: the alternative would be reading
-    as the service, which is exactly the privilege this path is meant not to have.
+    ``graph_token`` is the identity documents are read with -- the asker's own, under
+    Teams SSO. Required rather than optional: the alternative would be reading as the
+    service, which is exactly the privilege this path is meant not to have.
 
     ``thread_id`` keys both the checkpoint and the Langfuse session, deliberately under
     one name so a conversation is findable in the trace view under what it is stored as.
-    Required: a caller with nothing to continue passes a fresh id rather than opting out,
-    which would be a second path where the document is never re-read.
+    Required: a caller with nothing to continue passes a fresh id rather than opting out.
 
-    ``document_hint`` is a link found in the message, when there was one. Without it the
-    agent falls back on whatever the conversation already has open.
+    ``document_urls`` are the links found in the message, all of them. Candidates rather
+    than a decision: which one is meant, and whether to open it at all, depends on what
+    was asked and on what the conversation already has open.
 
     Never raises: a failure comes back as ``failed`` so the caller can decide whether to
     say anything.
@@ -281,9 +258,10 @@ async def answer_question(
 
     # Langfuse discards propagated metadata that is not a string, so these are
     # stringified rather than silently going missing from the trace.
+    urls = list(document_urls or [])
     metadata: dict[str, Any] = {
         "langfuse_tags": ["teams-agent", "document-question"],
-        "had_link": str(bool(document_hint)),
+        "links_found": str(len(urls)),
         # The same id the checkpoint is keyed by, so a conversation can be found in the
         # trace view under what it is stored as.
         "langfuse_session_id": thread_id,
@@ -305,33 +283,26 @@ async def answer_question(
         async with get_checkpointer() as saver:
             agent = create_deep_agent(
                 model=build_llm(model, api_key),
-                tools=[open_document_for(graph_token)],
+                tools=[
+                    open_document_for(graph_token),
+                    check_document_for(graph_token),
+                ],
                 skills=["/skills/"],
                 system_prompt=SYSTEM_PROMPT,
                 checkpointer=saver,
             )
 
-            document, lost = await _document_for_this_turn(
-                agent,
-                run_config,
-                graph_token=graph_token,
-                document_hint=document_hint,
-            )
-
-            hint = HINT_PREAMBLE.format(hint=document_hint) if document_hint else ""
             prompt = REQUEST_PROMPT.format(
-                who=asked_by, question=question.strip(), hint=hint
+                who=asked_by, question=question.strip(), links=links_in(urls)
             )
-            if lost:
-                prompt += LOST_DOCUMENT_NOTICE
 
             with propagate_attributes(user_id=user_id):
                 result = await agent.ainvoke(
                     {
-                        # Skills, and the thread's document as of now. Skills must be
-                        # mounted up front because a tool cannot add them later; the
-                        # re-mount each turn is the same paths and content.
-                        "files": {**build_skill_files(), **document},
+                        # Skills only. Documents arrive through the tool and stay in the
+                        # thread's own files; skills have to be mounted up front because
+                        # a tool cannot add them later.
+                        "files": build_skill_files(),
                         "messages": [HumanMessage(content=prompt)],
                     },
                     config=run_config,

--- a/lib/agents/teams_agent.py
+++ b/lib/agents/teams_agent.py
@@ -21,6 +21,12 @@ them once before the run and a tool cannot add them later.
 the agent inherits the asker's own access rather than the service's: a document they
 cannot open is refused by Graph and the agent says so.
 
+One Teams thread is one LangGraph thread, so a follow-up arrives with the earlier turns
+in view. Its document does not: only the link persists, and every turn re-reads it as
+whoever is asking then. Two reasons, either sufficient -- the document may have been
+edited since, and a shared thread's next question may come from someone who cannot open
+it. Re-reading is itself the permission check, since Graph applies that person's access.
+
 Nothing here writes to the document. That is the point of this path -- a question
 answered in chat needs no document access at all, which sidesteps both the 423 a
 server-side write hits while someone is editing and the licensing questions around
@@ -28,15 +34,16 @@ automating a Word client.
 """
 
 import logging
+from collections.abc import Sequence
 from typing import Any, Optional
 
 from deepagents import create_deep_agent
-from langchain.agents.structured_output import AutoStrategy
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import BaseMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langfuse import propagate_attributes
 from pydantic import BaseModel, Field
 
+from lib.agents.checkpointer import get_checkpointer
 from lib.agents.deep_agent_setup import (
     DEFAULT_MODEL,
     RECURSION_LIMIT,
@@ -44,10 +51,17 @@ from lib.agents.deep_agent_setup import (
     build_skill_files,
     tool_names,
 )
-from lib.agents.tools.sharepoint import open_document_for
+from lib.agents.tools.sharepoint import (
+    document_files,
+    evict_document,
+    mounted_document,
+    open_document_for,
+)
 from lib.config.langfuse import langfuse_handler
 from lib.config.llm_error_logger import ErrorLoggingCallback
 from lib.config.llm_models import LLMModel
+from lib.services.microsoft.graph import documents
+from lib.services.microsoft.graph.client import redacted
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +69,24 @@ SYSTEM_PROMPT = """\
 You are Draft Detective, a document review assistant. Someone has asked you a \
 question about a Word document from a chat, and you are answering them there.
 
+## The conversation so far
+
+You may be part-way through a conversation. Earlier questions and your own earlier \
+answers are above, and any document this conversation is about is open and freshly \
+re-read — so check what you already have before asking for something again. Because it \
+is re-read every time, it may have changed since you last looked.
+
+More than one person may be in this thread. Each question says who asked it; answer \
+the person asking now, and do not assume they are the person who asked before.
+
 ## Getting the document
 
-No document is open when you start. `open_document(url)` opens one from a SharePoint \
-link: it becomes available at `/main.md`, and any comments already on it at \
-`/comments.md`. Read or search those files with your usual tools; the tool does not \
-hand you the text.
+`open_document(url)` opens a document from a SharePoint link: it becomes available at \
+`/main.md`, and any comments already on it at `/comments.md`. Read or search those \
+files with your usual tools; the tool does not hand you the text.
+
+Check whether a document is already open before asking for a link — on a follow-up \
+there usually is one, and asking again for what you have is worse than useless.
 
 **A link is the only way to reach a document.** You cannot look one up by name or \
 title, and you must not guess at a URL. If someone asks about a document without \
@@ -108,8 +134,10 @@ every skill; find the ones that apply.
 
 ## How to answer
 
-You are writing in a chat, so markdown renders and a list is often clearer than a \
-paragraph. Still write like a colleague who has read the document:
+Your last message is posted into the chat as it is, so write the answer itself as \
+markdown — no JSON, no wrapper object, no preamble about what you are about to say. A \
+list is often clearer than a paragraph. Still write like a colleague who has read the \
+document:
 
 - Answer the question that was actually asked. Nothing else.
 - Point at places by quoting them, not by numbering them. A short distinctive \
@@ -136,11 +164,35 @@ They linked to this document, so open it:
 
 {hint}"""
 
+# In the request rather than the system prompt: it is about this turn. Worded without
+# asserting why -- a refusal and a timeout arrive the same way here, so claiming they lack
+# access would sometimes be a confident falsehood about someone's permissions.
+LOST_DOCUMENT_NOTICE = """
+The document this conversation was about could not be opened for the person asking now, \
+so it is no longer available to you. Do not answer from what was said about it earlier, \
+and do not describe its contents. Say plainly that you could not open it as them -- they \
+may not have access, or it may have moved -- and ask for a link they can open."""
 
-class QuestionReply(BaseModel):
-    """The structured answer, so an empty reply is detectable rather than posted."""
 
-    answer: str = Field(description="The answer, as markdown, for a chat client")
+def answer_text(messages: Sequence[BaseMessage]) -> str:
+    """What the agent said this turn, as markdown. Empty if it said nothing.
+
+    Read from the messages rather than through a structured ``response_format``. The
+    answer is one markdown string, and asking for it as JSON made the model escape a
+    whole review into a string literal -- tokens spent on backslashes, and a parse to
+    fail.
+
+    Stops at the most recent question, which a persisted thread makes load-bearing:
+    without it, a turn that produced no text would reach back and re-post the previous
+    turn's answer as though it were new.
+    """
+
+    for message in reversed(messages):
+        if message.type == "human":
+            break
+        if message.type == "ai" and (text := str(message.text).strip()):
+            return text
+    return ""
 
 
 class QuestionAnswer(BaseModel):
@@ -154,14 +206,54 @@ class QuestionAnswer(BaseModel):
     error: Optional[str] = None
 
 
+async def _document_for_this_turn(
+    agent: Any,
+    run_config: RunnableConfig,
+    *,
+    graph_token: str,
+    document_hint: Optional[str],
+) -> tuple[dict[str, Any], bool]:
+    """Re-read the document this thread is about, as the person asking now.
+
+    Returns the turn's ``files`` update and whether the document had to be given up;
+    empty on a thread with nothing open. A re-read rather than a check on the cached copy
+    because the document may have been edited, and because re-reading *is* the permission
+    check -- Graph applies this person's own access.
+
+    Any failure gives the document up. Fail-closed on purpose: a 403 and a timeout are
+    indistinguishable from here, and the wrong guess costs someone else's confidentiality
+    in one direction and a re-paste in the other.
+    """
+
+    snapshot = await agent.aget_state(run_config)
+    url = mounted_document(snapshot.values.get("files"))
+    if not url:
+        return {}, False
+
+    if document_hint and document_hint != url:
+        # They linked to something else, so the agent will open that instead. The old
+        # document goes now rather than lingering as a copy nobody re-read.
+        logger.info("this turn links elsewhere, so %s is closed", redacted(url))
+        return evict_document(), False
+
+    try:
+        document = await documents.load(url, token=graph_token)
+    except Exception as error:  # noqa: BLE001 - every failure ends the same way
+        logger.info("could not re-open %s for the asker: %s", redacted(url), error)
+        return evict_document(), True
+
+    logger.info("re-opened %s as the asker for this turn", redacted(url))
+    return document_files(document, url), False
+
+
 async def answer_question(
     question: str,
     graph_token: str,
+    thread_id: str,
     document_hint: Optional[str] = None,
     asked_by: str = "Someone",
     model: LLMModel = DEFAULT_MODEL,
     api_key: Optional[str] = None,
-    thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
 ) -> QuestionAnswer:
     """Answer a question about a document the agent opens for itself.
@@ -170,28 +262,27 @@ async def answer_question(
     under Teams SSO. Required rather than optional: the alternative would be reading
     as the service, which is exactly the privilege this path is meant not to have.
 
-    ``document_hint`` is a link found in the message, when there was one. Without it
-    the agent has no way to reach a document and will ask for the link, so this is
-    what makes a question about a document answerable at all.
+    ``thread_id`` keys both the checkpoint and the Langfuse session, deliberately under
+    one name so a conversation is findable in the trace view under what it is stored as.
+    Required: a caller with nothing to continue passes a fresh id rather than opting out,
+    which would be a second path where the document is never re-read.
 
-    ``thread_id`` groups a conversation's traces in Langfuse, so a follow-up in the
-    same Teams thread reads as one session. Never raises: a failure comes back as
-    ``failed`` so the caller can decide whether to say anything.
+    ``document_hint`` is a link found in the message, when there was one. Without it the
+    agent falls back on whatever the conversation already has open.
+
+    Never raises: a failure comes back as ``failed`` so the caller can decide whether to
+    say anything.
     """
-
-    hint = HINT_PREAMBLE.format(hint=document_hint) if document_hint else ""
-    prompt = REQUEST_PROMPT.format(
-        who=asked_by, question=question.strip(), hint=hint
-    )
 
     # Langfuse discards propagated metadata that is not a string, so these are
     # stringified rather than silently going missing from the trace.
     metadata: dict[str, Any] = {
         "langfuse_tags": ["teams-agent", "document-question"],
         "had_link": str(bool(document_hint)),
+        # The same id the checkpoint is keyed by, so a conversation can be found in the
+        # trace view under what it is stored as.
+        "langfuse_session_id": thread_id,
     }
-    if thread_id:
-        metadata["langfuse_session_id"] = thread_id
     if user_id:
         metadata["langfuse_user_id"] = user_id
 
@@ -200,28 +291,46 @@ async def answer_question(
         "recursion_limit": RECURSION_LIMIT,
         "callbacks": [langfuse_handler, ErrorLoggingCallback()],
         "metadata": metadata,
+        # The checkpointer and this are a pair: LangGraph refuses a checkpointer with no
+        # ``configurable`` to key it by.
+        "configurable": {"thread_id": thread_id},
     }
 
     try:
-        agent = create_deep_agent(
-            model=build_llm(model, api_key),
-            tools=[open_document_for(graph_token)],
-            response_format=AutoStrategy(QuestionReply),
-            skills=["/skills/"],
-        )
-        with propagate_attributes(user_id=user_id):
-            result = await agent.ainvoke(
-                {
-                    # Skills only: the document arrives via open_document, and skills
-                    # cannot be added mid-run.
-                    "files": build_skill_files(),
-                    "messages": [
-                        SystemMessage(content=SYSTEM_PROMPT),
-                        HumanMessage(content=prompt),
-                    ],
-                },
-                config=run_config,
+        async with get_checkpointer() as saver:
+            agent = create_deep_agent(
+                model=build_llm(model, api_key),
+                tools=[open_document_for(graph_token)],
+                skills=["/skills/"],
+                system_prompt=SYSTEM_PROMPT,
+                checkpointer=saver,
             )
+
+            document, lost = await _document_for_this_turn(
+                agent,
+                run_config,
+                graph_token=graph_token,
+                document_hint=document_hint,
+            )
+
+            hint = HINT_PREAMBLE.format(hint=document_hint) if document_hint else ""
+            prompt = REQUEST_PROMPT.format(
+                who=asked_by, question=question.strip(), hint=hint
+            )
+            if lost:
+                prompt += LOST_DOCUMENT_NOTICE
+
+            with propagate_attributes(user_id=user_id):
+                result = await agent.ainvoke(
+                    {
+                        # Skills, and the thread's document as of now. Skills must be
+                        # mounted up front because a tool cannot add them later; the
+                        # re-mount each turn is the same paths and content.
+                        "files": {**build_skill_files(), **document},
+                        "messages": [HumanMessage(content=prompt)],
+                    },
+                    config=run_config,
+                )
     except Exception as error:  # noqa: BLE001 - the caller decides what to do
         logger.exception("Draft Detective could not answer a question")
         return QuestionAnswer(
@@ -229,8 +338,7 @@ async def answer_question(
         )
 
     messages = result.get("messages", [])
-    structured = result.get("structured_response")
-    text = (structured.answer if structured else "").strip()
+    text = answer_text(messages)
     if not text:
         logger.warning("the question agent returned an empty answer")
         return QuestionAnswer(

--- a/lib/agents/tools/sharepoint.py
+++ b/lib/agents/tools/sharepoint.py
@@ -15,8 +15,10 @@ service instead. The model never sees the token -- it is closed over, not a para
 ``open_document`` mounts the document at ``/main.md`` rather than returning its text.
 Two reasons, and the second is the one that decides it:
 
-- ``/main.md`` is the path every other agent and skill in this codebase reads. The
-  line numbers in ``skills/issues/SKILL.md`` are *defined* relative to it.
+- ``/main.md`` is the path every other agent and skill in this codebase reads, holding
+  the same markdown that the workflow path mounts there. The line numbers in
+  ``skills/issues/SKILL.md`` are *defined* relative to it, and the read and search tools
+  report positions in lines, so nothing needs numbering into the text itself.
 - A tool result over roughly 80,000 characters is evicted by the filesystem
   middleware to ``/large_tool_results/{tool_call_id}``. Real documents here run to
   that size, so returning the body would scatter it to a machine-generated path
@@ -36,7 +38,6 @@ from langchain.tools import BaseTool, ToolRuntime, tool
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 
-from lib.agents.deep_agent_setup import number_paragraphs
 from lib.services.microsoft.graph import documents
 from lib.services.microsoft.graph.client import (
     DocumentNotAllowed,
@@ -70,10 +71,10 @@ def open_document_for(token: str) -> BaseTool:
         """
         Open a Word document so you can read it. Do this before answering about one.
 
-        The document becomes available at /main.md, with every paragraph prefixed by
-        its number like [12]. Any comments already on it become available at
-        /comments.md. Use your read and search tools on those files; this tool does
-        not return the text.
+        The document becomes available at /main.md as markdown: headings, tables and
+        emphasis are preserved, so its structure is readable. Any comments already on
+        it become available at /comments.md. Use your read and search tools on those
+        files; this tool does not return the text.
 
         You open it as the person who asked, so a document they cannot access will be
         refused. Tell them that plainly rather than trying another way in.
@@ -85,7 +86,7 @@ def open_document_for(token: str) -> BaseTool:
         Returns:
             A confirmation of what was opened. Example:
             Opened 'v2-04-21-2025- cern-for-ai-for-full-review.docx' at /main.md:
-            366 paragraphs, 4 comments at /comments.md. Modified 2026-08-04T13:31:28Z.
+            648 lines, 4 comments at /comments.md. Modified 2026-08-04T13:31:28Z.
         """
 
         try:
@@ -125,7 +126,7 @@ def document_files(document: documents.LoadedDocument, url: str) -> dict[str, An
     """
 
     return {
-        MAIN_DOCUMENT: create_file_data(number_paragraphs(document.paragraphs)),
+        MAIN_DOCUMENT: create_file_data(document.markdown),
         # Written with the document, never separately, so that a later turn can name what
         # it is holding and re-read it as whoever is asking then.
         DOCUMENT_SOURCE: create_file_data(url),
@@ -179,10 +180,9 @@ def describe(document: documents.LoadedDocument) -> str:
     to a machine-named file and defeat the mounting above.
     """
 
-    parts = [
-        f"Opened '{document.name}' at {MAIN_DOCUMENT}: "
-        f"{len(document.paragraphs)} paragraphs"
-    ]
+    # Lines rather than paragraphs, because that is the unit the read and search tools
+    # report positions in -- so the size given here is in the same currency.
+    parts = [f"Opened '{document.name}' at {MAIN_DOCUMENT}: {document.lines} lines"]
     if document.comments:
         parts.append(f", {len(document.comments)} comments at {COMMENTS_DOCUMENT}")
     parts.append(".")

--- a/lib/agents/tools/sharepoint.py
+++ b/lib/agents/tools/sharepoint.py
@@ -1,35 +1,33 @@
-"""Opening a SharePoint document mid-run.
+"""Opening SharePoint documents mid-run.
 
-An agent answering a question from Teams is not told which document to read, so it
-opens one itself from a link in the message.
+An agent answering a question from Teams is not told which document to read. It is given
+the links found in the message and decides which to open, where to put it, and whether
+what it already has is still good enough.
 
 Only from a link. Finding a document by name was built and removed: matching names
 means searching somewhere, and anything the service can search is wider than what the
 person asking may be allowed to read. A link is something they already had.
 
-The tool is built per run, bound to one identity, by ``open_document_for(token)``.
-That is deliberate: the token belongs to the person who asked, so a run cannot read
-anything they could not, and there is no module-level tool that would read as the
-service instead. The model never sees the token -- it is closed over, not a parameter.
+Both tools are built per run, bound to one identity, by the factories below. That is
+deliberate: the token belongs to the person who asked, so a run cannot read anything they
+could not, and there is no module-level tool that would read as the service instead. The
+model never sees the token -- it is closed over, not a parameter.
 
-``open_document`` mounts the document at ``/main.md`` rather than returning its text.
-Two reasons, and the second is the one that decides it:
+``open_document`` mounts the document rather than returning its text, because a tool
+result over roughly 80,000 characters is evicted by the filesystem middleware to
+``/large_tool_results/{tool_call_id}``, and real documents here run to that size. The
+agent chooses the path, under ``DOCUMENTS`` so that one thread can hold several documents
+-- two revisions, or two different files -- without them overwriting each other.
 
-- ``/main.md`` is the path every other agent and skill in this codebase reads, holding
-  the same markdown that the workflow path mounts there. The line numbers in
-  ``skills/issues/SKILL.md`` are *defined* relative to it, and the read and search tools
-  report positions in lines, so nothing needs numbering into the text itself.
-- A tool result over roughly 80,000 characters is evicted by the filesystem
-  middleware to ``/large_tool_results/{tool_call_id}``. Real documents here run to
-  that size, so returning the body would scatter it to a machine-generated path
-  instead of the one the skills expect.
-
-A mount outlives its turn once a conversation is checkpointed, so the link is written
-beside it at ``DOCUMENT_SOURCE``: that is how a later turn knows what to re-read, and as
-whom.
+``check_document`` is the cheap counterpart: metadata only, no download. It answers
+whether a document has changed since the agent last read it, and because Graph applies
+the asker's own permissions to the lookup, a refusal answers whether *this* person may
+read it at all. Both matter across turns: a conversation persists, so a mounted document
+may have been edited since, and may have been loaded for somebody else in the thread.
 """
 
 import logging
+import re
 from typing import Any, Optional
 
 from deepagents.backends.utils import create_file_data
@@ -38,7 +36,7 @@ from langchain.tools import BaseTool, ToolRuntime, tool
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 
-from lib.services.microsoft.graph import documents
+from lib.services.microsoft.graph import client, documents
 from lib.services.microsoft.graph.client import (
     DocumentNotAllowed,
     GraphError,
@@ -47,47 +45,87 @@ from lib.services.microsoft.graph.client import (
 
 logger = logging.getLogger(__name__)
 
-MAIN_DOCUMENT = "/main.md"
-COMMENTS_DOCUMENT = "/comments.md"
+# Documents live under one prefix so a model-chosen path cannot land anywhere else --
+# most of all not over a skill, which shares this filesystem and is the agent's own
+# instructions.
+DOCUMENTS = "/documents"
 
-# Which document is at MAIN_DOCUMENT, written beside it rather than in a table that could
-# drift out of step with what is actually mounted.
-DOCUMENT_SOURCE = "/main.source"
+_SAFE_NAME = re.compile(r"^[\w][\w .()-]*$")
+
+
+def document_path(path: str) -> str:
+    """The mount path for a document, or a refusal explaining the convention.
+
+    Raises ``ValueError`` with something the model can act on. Validated rather than
+    trusted because ``files`` is one namespace shared with ``/skills/``: a path of
+    ``/skills/issues/SKILL.md`` would overwrite the instructions the agent is following.
+    """
+
+    # A bare name is accepted and placed under the prefix; anything that would land
+    # elsewhere is refused rather than quietly relocated.
+    name = path.strip().removeprefix(f"{DOCUMENTS}/")
+    if "/" in name:
+        raise ValueError(
+            f"paths must be directly under {DOCUMENTS}/, like {DOCUMENTS}/v3.md"
+        )
+    if not name.endswith(".md"):
+        raise ValueError(f"the path must end in .md, like {DOCUMENTS}/v3.md")
+    if not _SAFE_NAME.match(name.removesuffix(".md")):
+        raise ValueError(
+            "the file name may only contain letters, numbers, spaces, dots, dashes, "
+            "brackets and underscores"
+        )
+    return f"{DOCUMENTS}/{name}"
+
+
+def comments_path(path: str) -> str:
+    """Where a document's comments go: beside it, named after it.
+
+    Per document rather than one shared file, so a thread holding two documents cannot
+    answer about one from the other's comments.
+    """
+
+    return f"{path.removesuffix('.md')}.comments.md"
 
 
 def open_document_for(token: str) -> BaseTool:
-    """The document-opening tool, reading as whoever ``token`` belongs to.
-
-    A factory rather than a module-level tool so the identity is chosen per run and
-    cannot be omitted. Under a Teams SSO token this is what makes the bot no more
-    privileged than the person who asked: Graph refuses a document they cannot open,
-    and the refusal comes back as something the agent explains.
-    """
+    """The document-opening tool, reading as whoever ``token`` belongs to."""
 
     @tool()
     async def open_document(
-        url: str, runtime: ToolRuntime[Any, FilesystemState]
+        url: str, path: str, runtime: ToolRuntime[Any, FilesystemState]
     ) -> Command | str:
         """
-        Open a Word document so you can read it. Do this before answering about one.
+        Open a Word document from a SharePoint link so you can read it.
 
-        The document becomes available at /main.md as markdown: headings, tables and
-        emphasis are preserved, so its structure is readable. Any comments already on
-        it become available at /comments.md. Use your read and search tools on those
-        files; this tool does not return the text.
+        The document is saved as markdown at the path you choose, with its headings,
+        tables and emphasis intact. Any comments on it are saved alongside, at the same
+        path with `.comments.md` instead of `.md`. Use your read and search tools on
+        those files; this tool does not return the text.
 
         You open it as the person who asked, so a document they cannot access will be
         refused. Tell them that plainly rather than trying another way in.
 
+        There is no way to look a document up by name: without a link, ask for one.
+
         Args:
-            url: The document's SharePoint link, as pasted by the person asking. There
-                is no way to look a document up by name; without a link, ask for one.
+            url: The document's SharePoint link, as pasted by the person asking.
+            path: Where to save it, directly under /documents/ and ending in .md — for
+                example /documents/v3-cern-for-ai.md. Name it after the document so you
+                can tell them apart later. Opening two documents, or two revisions of
+                one, means two different paths. Re-opening the same document at the same
+                path replaces it, which is how you refresh a stale copy.
 
         Returns:
-            A confirmation of what was opened. Example:
-            Opened 'v2-04-21-2025- cern-for-ai-for-full-review.docx' at /main.md:
-            648 lines, 4 comments at /comments.md. Modified 2026-08-04T13:31:28Z.
+            A confirmation of what was opened and where. Example:
+            Opened 'v3-cern-for-ai.docx' at /documents/v3-cern-for-ai.md: 648 lines.
+            Modified 2026-08-07T17:56:47Z.
         """
+
+        try:
+            destination = document_path(path)
+        except ValueError as error:
+            return f"I could not save it there: {error}"
 
         try:
             document = await documents.load(url, token=token)
@@ -100,15 +138,17 @@ def open_document_for(token: str) -> BaseTool:
             logger.exception("could not open %s", redacted(url))
             return f"I could not open that document: {error}"
 
+        logger.info("opened %s at %s", redacted(url), destination)
+
         # A Command is how a tool writes into the agent's filesystem; the built-in
         # write_file does the same. The files key merges, so this adds rather than
         # replaces, and mounting the same path twice overwrites it.
         return Command(
             update={
-                "files": document_files(document, url),
+                "files": document_files(document, destination),
                 "messages": [
                     ToolMessage(
-                        content=describe(document),
+                        content=describe(document, destination),
                         tool_call_id=runtime.tool_call_id,
                     )
                 ],
@@ -118,53 +158,64 @@ def open_document_for(token: str) -> BaseTool:
     return open_document
 
 
-def document_files(document: documents.LoadedDocument, url: str) -> dict[str, Any]:
-    """A document as the agent's filesystem holds it.
+def check_document_for(token: str) -> BaseTool:
+    """The freshness-and-access tool, asking as whoever ``token`` belongs to."""
 
-    Shared by the tool and by the per-turn re-read, so the two cannot mount a document
-    differently -- what needs clearing is not obvious from either call site alone.
-    """
+    @tool()
+    async def check_document(url: str) -> str:
+        """
+        Check when a document was last changed, without downloading it.
 
+        Cheap: this reads only the document's details, not its contents. Use it on a
+        document you opened in an earlier turn to find out whether it has been edited
+        since — compare the time it returns with the time reported when you opened it.
+
+        It also answers whether the person asking now can reach the document at all,
+        because it looks it up as them. A refusal here means they cannot read it, so do
+        not answer from a copy you opened earlier for somebody else.
+
+        Args:
+            url: The document's SharePoint link.
+
+        Returns:
+            The document's name and when it was last modified. Example:
+            'v3-cern-for-ai.docx' was last modified 2026-08-07T17:56:47Z.
+        """
+
+        try:
+            item = await client.resolve(url, token=token)
+        except DocumentNotAllowed as error:
+            return f"I am not allowed to read that document: {error}"
+        except GraphError as error:
+            logger.info("could not check %s: %s", redacted(url), error)
+            return f"I could not check that document: {error}"
+        except Exception as error:  # noqa: BLE001 - the model decides what to do next
+            logger.exception("could not check %s", redacted(url))
+            return f"I could not check that document: {error}"
+
+        name = item.get("name") or "the document"
+        modified = item.get("lastModifiedDateTime")
+        if not modified:
+            return f"'{name}' exists and you can read it, but it reports no edit time."
+        return f"'{name}' was last modified {modified}."
+
+    return check_document
+
+
+def document_files(document: documents.LoadedDocument, path: str) -> dict[str, Any]:
+    """A document as the agent's filesystem holds it, at ``path``."""
+
+    comments = comments_path(path)
     return {
-        MAIN_DOCUMENT: create_file_data(document.markdown),
-        # Written with the document, never separately, so that a later turn can name what
-        # it is holding and re-read it as whoever is asking then.
-        DOCUMENT_SOURCE: create_file_data(url),
-        # Comments are cleared when there are none rather than left out: a thread that
-        # opens a second document would otherwise keep answering from the first one's.
-        COMMENTS_DOCUMENT: (
+        path: create_file_data(document.markdown),
+        # Cleared when there are none rather than left out: re-opening a document whose
+        # comments have been resolved would otherwise keep answering from the old ones.
+        comments: (
             create_file_data(format_comments(document.comments))
             if document.comments
             else None
         ),
     }
-
-
-def evict_document() -> dict[str, None]:
-    """Deletion markers for every file a document mounts.
-
-    ``None`` is how the filesystem reducer spells a delete. The source goes with the
-    body, or it would name a document that is no longer there.
-    """
-
-    return {MAIN_DOCUMENT: None, COMMENTS_DOCUMENT: None, DOCUMENT_SOURCE: None}
-
-
-def mounted_document(files: Optional[dict[str, Any]]) -> Optional[str]:
-    """The URL of the document currently mounted at ``MAIN_DOCUMENT``, if any.
-
-    Read from ``DOCUMENT_SOURCE`` rather than from the newest ``open_document`` call: a
-    refused open writes nothing, so the newest call can name a document that was never
-    loaded while the previous one is still mounted.
-    """
-
-    if not files:
-        return None
-    source = files.get(DOCUMENT_SOURCE)
-    if not source or MAIN_DOCUMENT not in files:
-        return None
-    url = "\n".join(source.get("content") or []).strip()
-    return url or None
 
 
 def format_comments(comments: list[tuple[str, str]]) -> str:
@@ -173,18 +224,19 @@ def format_comments(comments: list[tuple[str, str]]) -> str:
     return "\n\n".join(f"{author}: {text}" for author, text in comments)
 
 
-def describe(document: documents.LoadedDocument) -> str:
-    """What was opened, without any of its content.
+def describe(document: documents.LoadedDocument, path: str) -> str:
+    """What was opened and where, without any of its content.
 
-    Kept to a summary on purpose: a tool result carrying the body would be evicted
-    to a machine-named file and defeat the mounting above.
+    Kept to a summary on purpose: a tool result carrying the body would be evicted to a
+    machine-named file and defeat the mounting above. The modified time is included
+    because it is what ``check_document`` is later compared against.
     """
 
     # Lines rather than paragraphs, because that is the unit the read and search tools
     # report positions in -- so the size given here is in the same currency.
-    parts = [f"Opened '{document.name}' at {MAIN_DOCUMENT}: {document.lines} lines"]
+    parts = [f"Opened '{document.name}' at {path}: {document.lines} lines"]
     if document.comments:
-        parts.append(f", {len(document.comments)} comments at {COMMENTS_DOCUMENT}")
+        parts.append(f", {len(document.comments)} comments at {comments_path(path)}")
     parts.append(".")
     if document.last_modified:
         parts.append(f" Modified {document.last_modified}.")

--- a/lib/agents/tools/sharepoint.py
+++ b/lib/agents/tools/sharepoint.py
@@ -21,10 +21,14 @@ Two reasons, and the second is the one that decides it:
   middleware to ``/large_tool_results/{tool_call_id}``. Real documents here run to
   that size, so returning the body would scatter it to a machine-generated path
   instead of the one the skills expect.
+
+A mount outlives its turn once a conversation is checkpointed, so the link is written
+beside it at ``DOCUMENT_SOURCE``: that is how a later turn knows what to re-read, and as
+whom.
 """
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from deepagents.backends.utils import create_file_data
 from deepagents.middleware.filesystem import FilesystemState
@@ -44,6 +48,10 @@ logger = logging.getLogger(__name__)
 
 MAIN_DOCUMENT = "/main.md"
 COMMENTS_DOCUMENT = "/comments.md"
+
+# Which document is at MAIN_DOCUMENT, written beside it rather than in a table that could
+# drift out of step with what is actually mounted.
+DOCUMENT_SOURCE = "/main.source"
 
 
 def open_document_for(token: str) -> BaseTool:
@@ -91,20 +99,12 @@ def open_document_for(token: str) -> BaseTool:
             logger.exception("could not open %s", redacted(url))
             return f"I could not open that document: {error}"
 
-        files: dict[str, Any] = {
-            MAIN_DOCUMENT: create_file_data(number_paragraphs(document.paragraphs))
-        }
-        if document.comments:
-            files[COMMENTS_DOCUMENT] = create_file_data(
-                format_comments(document.comments)
-            )
-
         # A Command is how a tool writes into the agent's filesystem; the built-in
         # write_file does the same. The files key merges, so this adds rather than
         # replaces, and mounting the same path twice overwrites it.
         return Command(
             update={
-                "files": files,
+                "files": document_files(document, url),
                 "messages": [
                     ToolMessage(
                         content=describe(document),
@@ -115,6 +115,55 @@ def open_document_for(token: str) -> BaseTool:
         )
 
     return open_document
+
+
+def document_files(document: documents.LoadedDocument, url: str) -> dict[str, Any]:
+    """A document as the agent's filesystem holds it.
+
+    Shared by the tool and by the per-turn re-read, so the two cannot mount a document
+    differently -- what needs clearing is not obvious from either call site alone.
+    """
+
+    return {
+        MAIN_DOCUMENT: create_file_data(number_paragraphs(document.paragraphs)),
+        # Written with the document, never separately, so that a later turn can name what
+        # it is holding and re-read it as whoever is asking then.
+        DOCUMENT_SOURCE: create_file_data(url),
+        # Comments are cleared when there are none rather than left out: a thread that
+        # opens a second document would otherwise keep answering from the first one's.
+        COMMENTS_DOCUMENT: (
+            create_file_data(format_comments(document.comments))
+            if document.comments
+            else None
+        ),
+    }
+
+
+def evict_document() -> dict[str, None]:
+    """Deletion markers for every file a document mounts.
+
+    ``None`` is how the filesystem reducer spells a delete. The source goes with the
+    body, or it would name a document that is no longer there.
+    """
+
+    return {MAIN_DOCUMENT: None, COMMENTS_DOCUMENT: None, DOCUMENT_SOURCE: None}
+
+
+def mounted_document(files: Optional[dict[str, Any]]) -> Optional[str]:
+    """The URL of the document currently mounted at ``MAIN_DOCUMENT``, if any.
+
+    Read from ``DOCUMENT_SOURCE`` rather than from the newest ``open_document`` call: a
+    refused open writes nothing, so the newest call can name a document that was never
+    loaded while the previous one is still mounted.
+    """
+
+    if not files:
+        return None
+    source = files.get(DOCUMENT_SOURCE)
+    if not source or MAIN_DOCUMENT not in files:
+        return None
+    url = "\n".join(source.get("content") or []).strip()
+    return url or None
 
 
 def format_comments(comments: list[tuple[str, str]]) -> str:

--- a/lib/api/main.py
+++ b/lib/api/main.py
@@ -14,6 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastmcp.utilities.lifespan import combine_lifespans
 
+from lib.agents.checkpointer import close_checkpointer_pool
 from lib.api.mcp.server import mcp_app, mcp_auth
 from lib.api.mcp_middlewares import MCPTrailingSlashMiddleware
 from lib.api.tus_middleware import TusTerminationMiddleware
@@ -61,6 +62,10 @@ async def lifespan(app: FastAPI):
             await reaper_task
         except asyncio.CancelledError:
             pass
+        # The agent checkpointer holds its own psycopg pool, opened lazily by the first
+        # run that asks for one. Closing it here is what stops a reload from leaking
+        # connections; a process that never opened it has nothing to close.
+        await close_checkpointer_pool()
 
 
 app = FastAPI(

--- a/lib/api/routers/microsoft/teams.py
+++ b/lib/api/routers/microsoft/teams.py
@@ -14,10 +14,11 @@ One way in: ``/messages``, the bot's endpoint. It authenticates with the token t
 Bot Connector presents, acknowledges immediately, and posts the answer into the same
 thread about a minute later.
 
-Which document to read is not decided here. A link in the message is passed along as
-a hint and the agent opens it itself. A link is the only way in: naming a document
-without linking to it gets a request for the link, because searching on someone's
-behalf could reach documents they cannot open.
+Which document to read is not decided here. Every link in the message is passed along as
+a candidate and the agent opens what it needs, because which one is meant depends on what
+was asked. A link is the only way in: naming a document without linking to it gets a
+request for the link, because searching on someone's behalf could reach documents they
+cannot open.
 
 Two other transports were tried and removed. An outgoing webhook needed a Workflows
 flow to post answers and could only reply in a separate message. A transport-neutral
@@ -117,15 +118,16 @@ async def _answer_into_thread(
     question: str,
     author: str,
     conversation: str,
-    document_hint: Optional[str],
+    document_urls: list[str],
     graph_token: str,
 ) -> None:
     """Ask, and post the answer back into the thread the question came from.
 
-    The document is not loaded here. The link is part of the question, so the agent
-    opens it through its own tool -- which also means a document that is missing, not
-    allowed, or not readable *by the person asking* comes back as something the agent
-    can explain, rather than as an exception this function has to translate.
+    No document is loaded here, and none is chosen. The links found in the message go
+    along as candidates and the agent opens what it needs -- which also means a document
+    that is missing, not allowed, or not readable *by the person asking* comes back as
+    something the agent can explain, rather than as an exception this function has to
+    translate.
 
     Detached from the request, so nothing here can return an error to a caller. A
     failure is posted into the conversation instead: leaving someone waiting for a
@@ -144,7 +146,7 @@ async def _answer_into_thread(
             # ``;messageid=`` suffix per reply chain, so separate chains are separate
             # conversations without anything having to parse it.
             thread_id=conversation,
-            document_hint=document_hint,
+            document_urls=document_urls,
             asked_by=author,
             user_id=author,
         )
@@ -194,16 +196,17 @@ async def _on_question(context: Any, state: Any) -> None:
     await context.send_activity("Looking at that now — I will follow up here shortly.")
 
     # From the activity, not the question: Teams shows a pasted link as a
-    # hyperlink and keeps the href out of the text entirely.
-    document_url = bot.document_url_in(context.activity)
+    # hyperlink and keeps the href out of the text entirely. All of them, because
+    # choosing between them is the agent's job.
+    document_urls = bot.document_urls_in(context.activity)
     logger.info(
-        "Teams bot question from %s: %r (document: %s, reading as %s)",
+        "Teams bot question from %s: %r (links: %s, reading as %s)",
         author,
         question[:120],
-        redacted(document_url) if document_url else "none found",
+        ", ".join(redacted(url) for url in document_urls) or "none found",
         "the asker" if bot.reads_as_the_user() else "the service",
     )
-    if not document_url and ".doc" in question.lower():
+    if not document_urls and ".doc" in question.lower():
         # Someone named a document but no href was found anywhere in the activity.
         # Teams keeps a rendered hyperlink's href in an attachment rather than in
         # the text, and which attachment depends on how the link was shared, so
@@ -240,7 +243,7 @@ async def _on_question(context: Any, state: Any) -> None:
             question,
             author,
             conversation,
-            document_url,
+            document_urls,
             graph_token,
         )
     )

--- a/lib/api/routers/microsoft/teams.py
+++ b/lib/api/routers/microsoft/teams.py
@@ -139,9 +139,13 @@ async def _answer_into_thread(
         answer = await answer_question(
             question=question,
             graph_token=graph_token,
+            # The Teams conversation *is* the agent's thread, which is what makes a
+            # follow-up here a follow-up there. In a channel this id already carries a
+            # ``;messageid=`` suffix per reply chain, so separate chains are separate
+            # conversations without anything having to parse it.
+            thread_id=conversation,
             document_hint=document_hint,
             asked_by=author,
-            thread_id=conversation,
             user_id=author,
         )
     except Exception:  # noqa: BLE001 - nobody upstream to hand this to

--- a/lib/services/microsoft/graph/documents.py
+++ b/lib/services/microsoft/graph/documents.py
@@ -1,9 +1,14 @@
-"""A SharePoint document, loaded and read as text.
+"""A SharePoint document, loaded as markdown.
 
-The backend holds a real .docx here rather than the Flat OPC an add-in sends, so
-``docx-editor`` opens it directly and none of the adapter in
+The backend holds a real .docx here rather than the Flat OPC an add-in sends, so both
+readers below open it directly and none of the adapter in
 ``lib/services/microsoft/word/word_package.py`` is involved. That is the one clear
 simplification of loading documents server-side.
+
+Two readers, because neither does both jobs. **markitdown** produces the body, the same
+converter the rest of the app uses for a main document -- headings, tables and emphasis
+survive, where a paragraph-by-paragraph read flattens them into indistinguishable
+strings. **docx-editor** produces the comments, which markitdown does not extract.
 
 Read-only. Writing back is refused by SharePoint with 423 while anyone has the
 document open, so it is not offered here at all.
@@ -19,6 +24,7 @@ from typing import Optional
 from docx_editor import Document
 from pydantic import BaseModel, Field
 
+from lib.services.converters.base import convert_to_markdown
 from lib.services.microsoft.graph import client
 
 logger = logging.getLogger(__name__)
@@ -29,8 +35,8 @@ class LoadedDocument(BaseModel):
 
     name: str
     url: str
-    paragraphs: list[str] = Field(
-        description="Every paragraph in order, so positions can be referred to"
+    markdown: str = Field(
+        description="The document as markdown, with its structure intact"
     )
     comments: list[tuple[str, str]] = Field(
         default_factory=list, description="(author, text), threads and replies alike"
@@ -39,16 +45,17 @@ class LoadedDocument(BaseModel):
     size_bytes: int = 0
 
     @property
-    def text(self) -> str:
-        return "\n".join(self.paragraphs)
+    def lines(self) -> int:
+        """How long the document is, in the units the agent's tools count in."""
+
+        return len(self.markdown.splitlines())
 
 
-def _read(path: Path, work: Path) -> tuple[list[str], list[tuple[str, str]]]:
-    """Paragraphs and comments, via docx-editor on a real file."""
+def _read_comments(path: Path, work: Path) -> list[tuple[str, str]]:
+    """Comments and their replies, flattened, via docx-editor on a real file."""
 
     doc = Document.open(path, author="Draft Detective", workspace_dir=str(work / "ws"))
     try:
-        paragraphs = [info.text for info in doc.list_paragraphs_structured(limit=None)]
         comments: list[tuple[str, str]] = []
         for comment in doc.list_comments():
             comments.append((comment.author, comment.text))
@@ -56,7 +63,7 @@ def _read(path: Path, work: Path) -> tuple[list[str], list[tuple[str, str]]]:
                 comments.append((reply.author, reply.text))
     finally:
         doc.close()
-    return paragraphs, comments
+    return comments
 
 
 async def load(url: str, *, token: str) -> LoadedDocument:
@@ -84,16 +91,17 @@ async def load(url: str, *, token: str) -> LoadedDocument:
     try:
         path = work / "document.docx"
         path.write_bytes(payload)
+        markdown = await convert_to_markdown(str(path), converter="markitdown")
         # docx-editor is synchronous and unzips into a workspace, so it does not
         # belong on the event loop.
-        paragraphs, comments = await asyncio.to_thread(_read, path, work)
+        comments = await asyncio.to_thread(_read_comments, path, work)
     finally:
         shutil.rmtree(work, ignore_errors=True)
 
     return LoadedDocument(
         name=str(item.get("name") or "document.docx"),
         url=url,
-        paragraphs=paragraphs,
+        markdown=markdown,
         comments=comments,
         last_modified=item.get("lastModifiedDateTime"),
         size_bytes=len(payload),

--- a/lib/services/microsoft/teams/bot.py
+++ b/lib/services/microsoft/teams/bot.py
@@ -364,20 +364,27 @@ def _scannable(activity: Activity) -> Iterator[str]:
             yield attachment.content_url
 
 
-def document_url_in(activity: Activity) -> Optional[str]:
-    """A SharePoint link to a document in this message, if there is one.
+def document_urls_in(activity: Activity) -> list[str]:
+    """Every SharePoint link in this message, in the order they were found.
+
+    All of them rather than the first, because which one is meant is a question about
+    the conversation -- "compare these two", "the second one" -- and that is the agent's
+    to answer, not a regex's. They are candidates handed over, not a decision made here.
 
     Trailing punctuation is trimmed: Teams decorates a pasted link, and an href in
-    HTML arrives escaped, so the match is cleaned rather than used raw.
+    HTML arrives escaped, so a match is cleaned rather than used raw. Duplicates are
+    dropped because the same link appears in the text, the HTML and the card.
     """
 
+    found: list[str] = []
     for text in _scannable(activity):
         for match in _SHAREPOINT_URL.finditer(html.unescape(text)):
             url = match.group(0).rstrip(").,;'\"")
             if any(marker in url.lower() for marker in _NOT_A_DOCUMENT):
                 continue
-            return url
-    return None
+            if url not in found:
+                found.append(url)
+    return found
 
 
 def reference_for(activity: Activity) -> ConversationReference:

--- a/tests/unit/agents/test_checkpointer.py
+++ b/tests/unit/agents/test_checkpointer.py
@@ -10,6 +10,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from psycopg import OperationalError
+from psycopg_pool import AsyncConnectionPool
 
 from lib.agents import checkpointer as checkpointer_module
 from lib.agents.checkpointer import (
@@ -25,9 +27,15 @@ run_setup = checkpointer_module._run_setup
 
 @pytest.fixture(autouse=True)
 def reset_pool_state() -> Any:
-    """Reset the module's opened flag and stub everything that touches Postgres."""
+    """Reset the module's flags and stub everything that touches Postgres.
+
+    Note what is mocked: ``open`` and ``close`` are the two methods carrying psycopg's
+    "a closed pool cannot be reopened" rule, so no test here can observe it. That rule is
+    asserted against a real pool in ``TestClosingIsFinal`` instead.
+    """
 
     checkpointer_module._opened = False
+    checkpointer_module._ready = False
     with (
         patch.object(checkpointer_pool, "open", new_callable=AsyncMock) as mock_open,
         patch.object(checkpointer_pool, "close", new_callable=AsyncMock) as mock_close,
@@ -37,6 +45,7 @@ def reset_pool_state() -> Any:
     ):
         yield mock_open, mock_close, mock_setup
     checkpointer_module._opened = False
+    checkpointer_module._ready = False
 
 
 class TestTheSharedPool:
@@ -92,24 +101,53 @@ class TestTheSharedPool:
         assert mock_setup.await_count == 1
 
 
-class TestShutdown:
+class TestClosingIsFinal:
+    """Shutting down ends checkpointing in this process, and cannot be undone.
+
+    This replaces a test that asserted the opposite -- that a later call reopens the pool
+    -- which passed only because the fixture mocks ``open`` and ``close``. psycopg allows
+    neither, so the real constraint is pinned against a real pool here.
+    """
+
     @pytest.mark.asyncio
-    async def test_closing_lets_a_later_call_reopen(
+    async def test_psycopg_refuses_to_reopen_a_closed_pool(self) -> None:
+        """The fact everything else in this class follows from.
+
+        Its own pool, never connected to anything: the refusal is bookkeeping inside
+        psycopg_pool and needs no database.
+        """
+
+        pool: Any = AsyncConnectionPool(
+            conninfo="postgresql://nobody@127.0.0.1:1/none",
+            min_size=0,
+            max_size=2,
+            open=False,
+        )
+        await pool.open(wait=False)
+        await pool.open(wait=False)  # opening an open pool is fine
+        await pool.close()
+
+        with pytest.raises(OperationalError, match="cannot be reused"):
+            await pool.open(wait=False)
+
+    @pytest.mark.asyncio
+    async def test_closing_does_not_claim_the_pool_could_reopen(
         self, reset_pool_state: Any
     ) -> None:
-        """A reload closes the pool; the next run must still work."""
+        """``_opened`` stays true after closing, because the pool is used up.
 
-        mock_open, mock_close, mock_setup = reset_pool_state
+        Resetting it would invite the next call to open a pool psycopg will refuse.
+        """
+
+        _, mock_close, _ = reset_pool_state
 
         async with get_checkpointer():
             pass
         await close_checkpointer_pool()
-        async with get_checkpointer():
-            pass
 
         assert mock_close.await_count == 1
-        assert mock_open.await_count == 2
-        assert mock_setup.await_count == 2
+        assert checkpointer_module._opened is True
+        assert checkpointer_module._ready is False
 
     @pytest.mark.asyncio
     async def test_closing_what_was_never_opened_does_nothing(
@@ -122,6 +160,64 @@ class TestShutdown:
         await close_checkpointer_pool()
 
         assert mock_close.await_count == 0
+
+
+class TestWhenSetupFails:
+    """A failed setup must leave a pool that shutdown can still close.
+
+    The pool is open by then, so losing track of it leaks connections. Closing it to tidy
+    up is not the fix: it could never be reopened, turning one slow advisory lock into
+    every later turn failing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_pool_is_still_closable(self, reset_pool_state: Any) -> None:
+        _, mock_close, mock_setup = reset_pool_state
+        mock_setup.side_effect = RuntimeError("could not acquire the advisory lock")
+
+        with pytest.raises(RuntimeError):
+            async with get_checkpointer():
+                pass
+
+        assert checkpointer_module._opened is True, "shutdown must know to close it"
+
+        await close_checkpointer_pool()
+
+        assert mock_close.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_the_pool_is_not_closed_behind_our_back(
+        self, reset_pool_state: Any
+    ) -> None:
+        """Closing here would make the failure permanent rather than transient."""
+
+        _, mock_close, mock_setup = reset_pool_state
+        mock_setup.side_effect = RuntimeError("a blip")
+
+        with pytest.raises(RuntimeError):
+            async with get_checkpointer():
+                pass
+
+        assert mock_close.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_the_next_call_retries_setup_without_reopening(
+        self, reset_pool_state: Any
+    ) -> None:
+        """What makes a transient failure transient."""
+
+        mock_open, _, mock_setup = reset_pool_state
+        mock_setup.side_effect = [RuntimeError("a blip"), None]
+
+        with pytest.raises(RuntimeError):
+            async with get_checkpointer():
+                pass
+        async with get_checkpointer():
+            pass
+
+        assert mock_setup.await_count == 2, "setup is retried"
+        assert mock_open.await_count == 1, "but the pool is opened only once"
+        assert checkpointer_module._ready is True
 
 
 class TestSetupAcrossWorkers:

--- a/tests/unit/agents/test_checkpointer.py
+++ b/tests/unit/agents/test_checkpointer.py
@@ -1,0 +1,189 @@
+"""Tests for the shared checkpointer pool.
+
+Two invariants, both easy to break by writing the obvious thing instead: one pool shared
+by every saver, and a fresh saver per call so each run gets its own lock. They fail
+silently -- as connection exhaustion, or as unexplained latency -- so they are asserted.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.agents import checkpointer as checkpointer_module
+from lib.agents.checkpointer import (
+    checkpointer_pool,
+    close_checkpointer_pool,
+    get_checkpointer,
+)
+
+# Captured before the autouse fixture below replaces it, so the tests that are *about*
+# setup exercise the real thing rather than their own stub.
+run_setup = checkpointer_module._run_setup
+
+
+@pytest.fixture(autouse=True)
+def reset_pool_state() -> Any:
+    """Reset the module's opened flag and stub everything that touches Postgres."""
+
+    checkpointer_module._opened = False
+    with (
+        patch.object(checkpointer_pool, "open", new_callable=AsyncMock) as mock_open,
+        patch.object(checkpointer_pool, "close", new_callable=AsyncMock) as mock_close,
+        patch.object(
+            checkpointer_module, "_run_setup", new_callable=AsyncMock
+        ) as mock_setup,
+    ):
+        yield mock_open, mock_close, mock_setup
+    checkpointer_module._opened = False
+
+
+class TestTheSharedPool:
+    @pytest.mark.asyncio
+    async def test_savers_share_the_pool(self) -> None:
+        async with get_checkpointer() as saver_a:
+            async with get_checkpointer() as saver_b:
+                assert saver_a.conn is checkpointer_pool
+                assert saver_b.conn is checkpointer_pool
+
+    @pytest.mark.asyncio
+    async def test_savers_are_distinct_so_runs_do_not_queue(self) -> None:
+        """Each saver's lock is its own, or one thread's write blocks every other."""
+
+        async with get_checkpointer() as saver_a:
+            async with get_checkpointer() as saver_b:
+                assert saver_a is not saver_b
+                assert saver_a.lock is not saver_b.lock
+
+    @pytest.mark.asyncio
+    async def test_the_pool_is_opened_and_verified_once(
+        self, reset_pool_state: Any
+    ) -> None:
+        mock_open, _, mock_setup = reset_pool_state
+
+        for _ in range(3):
+            async with get_checkpointer():
+                pass
+
+        assert mock_open.await_count == 1
+        assert mock_setup.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_simultaneous_first_use_still_opens_once(
+        self, reset_pool_state: Any
+    ) -> None:
+        """The double-checked lock, under the case it exists for.
+
+        Every worker's first checkpointed run can arrive at once after a deploy.
+        """
+
+        mock_open, _, mock_setup = reset_pool_state
+
+        async def use() -> Any:
+            async with get_checkpointer() as saver:
+                return saver
+
+        savers = await asyncio.gather(*[use() for _ in range(20)])
+
+        assert len(savers) == 20
+        assert all(saver.conn is checkpointer_pool for saver in savers)
+        assert mock_open.await_count == 1
+        assert mock_setup.await_count == 1
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_closing_lets_a_later_call_reopen(
+        self, reset_pool_state: Any
+    ) -> None:
+        """A reload closes the pool; the next run must still work."""
+
+        mock_open, mock_close, mock_setup = reset_pool_state
+
+        async with get_checkpointer():
+            pass
+        await close_checkpointer_pool()
+        async with get_checkpointer():
+            pass
+
+        assert mock_close.await_count == 1
+        assert mock_open.await_count == 2
+        assert mock_setup.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_closing_what_was_never_opened_does_nothing(
+        self, reset_pool_state: Any
+    ) -> None:
+        """A process may never open the pool, and shutdown still runs there."""
+
+        _, mock_close, _ = reset_pool_state
+
+        await close_checkpointer_pool()
+
+        assert mock_close.await_count == 0
+
+
+class TestSetupAcrossWorkers:
+    """``setup()`` is a migration runner, and four workers race it on a fresh database.
+
+    ``checkpoint_migrations.v`` is a primary key, so two workers reading the same
+    version both try to insert it and one dies on a duplicate key. The advisory lock is
+    what makes that impossible, and it has to be released by hand: the pool runs in
+    autocommit, so nothing else ever will.
+    """
+
+    @pytest.mark.asyncio
+    async def test_setup_runs_under_an_advisory_lock_and_releases_it(self) -> None:
+        connection = MagicMock()
+        connection.execute = AsyncMock()
+        pool_connection = MagicMock()
+        pool_connection.__aenter__ = AsyncMock(return_value=connection)
+        pool_connection.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.object(
+                checkpointer_pool, "connection", MagicMock(return_value=pool_connection)
+            ),
+            patch.object(
+                checkpointer_module.AsyncPostgresSaver,
+                "setup",
+                new_callable=AsyncMock,
+            ) as setup,
+        ):
+            await run_setup()
+
+        statements = [call.args[0] for call in connection.execute.await_args_list]
+        keys = [call.args[1] for call in connection.execute.await_args_list]
+
+        assert "pg_advisory_lock" in statements[0]
+        assert "pg_advisory_unlock" in statements[-1]
+        assert setup.await_count == 1
+        assert keys[0] == keys[-1] == (checkpointer_module.SETUP_LOCK_KEY,)
+
+    @pytest.mark.asyncio
+    async def test_the_lock_is_released_even_when_setup_fails(self) -> None:
+        """Otherwise a failed deploy leaves every other worker waiting on it."""
+
+        connection = MagicMock()
+        connection.execute = AsyncMock()
+        pool_connection = MagicMock()
+        pool_connection.__aenter__ = AsyncMock(return_value=connection)
+        pool_connection.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.object(
+                checkpointer_pool, "connection", MagicMock(return_value=pool_connection)
+            ),
+            patch.object(
+                checkpointer_module.AsyncPostgresSaver,
+                "setup",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("migration failed"),
+            ),
+            pytest.raises(RuntimeError, match="migration failed"),
+        ):
+            await run_setup()
+
+        statements = [call.args[0] for call in connection.execute.await_args_list]
+        assert "pg_advisory_unlock" in statements[-1]

--- a/tests/unit/agents/test_teams_agent.py
+++ b/tests/unit/agents/test_teams_agent.py
@@ -60,13 +60,13 @@ def agent_returning(answer: str, state: Optional[dict[str, Any]] = None) -> Magi
     return fake
 
 
-def loaded_document(paragraphs: Optional[list[str]] = None) -> LoadedDocument:
+def loaded_document(markdown: str = "## A heading\n\nA paragraph.") -> LoadedDocument:
     """What Graph hands back when the document is re-read."""
 
     return LoadedDocument(
         name="a.docx",
         url=DOCUMENT_URL,
-        paragraphs=paragraphs if paragraphs is not None else ["A paragraph."],
+        markdown=markdown,
         comments=[],
         last_modified="2026-08-11T13:31:28Z",
         size_bytes=1024,
@@ -78,7 +78,7 @@ def thread_with_document(url: str = DOCUMENT_URL) -> dict[str, Any]:
 
     return {
         "files": {
-            MAIN_DOCUMENT: {"content": ["[0] A paragraph."]},
+            MAIN_DOCUMENT: {"content": ["## A heading", "", "A paragraph."]},
             DOCUMENT_SOURCE: {"content": [url]},
         },
         "messages": [],
@@ -377,7 +377,7 @@ class TestRereadingTheDocumentEachTurn:
     @pytest.mark.asyncio
     async def test_the_document_is_read_again_as_the_person_asking(self) -> None:
         agent = agent_returning("an answer", state=thread_with_document())
-        load = AsyncMock(return_value=loaded_document(["Rewritten since last turn."]))
+        load = AsyncMock(return_value=loaded_document("Rewritten since last turn."))
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
         ), patch.object(teams_agent.documents, "load", load):
@@ -398,14 +398,14 @@ class TestRereadingTheDocumentEachTurn:
         """The failure this exists to prevent: answering from text since rewritten."""
 
         stale = thread_with_document()
-        stale["files"][MAIN_DOCUMENT] = {"content": ["[0] The old wording."]}
+        stale["files"][MAIN_DOCUMENT] = {"content": ["The old wording."]}
         agent = agent_returning("an answer", state=stale)
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
         ), patch.object(
             teams_agent.documents,
             "load",
-            AsyncMock(return_value=loaded_document(["The new wording."])),
+            AsyncMock(return_value=loaded_document("The new wording.")),
         ):
             await answer_question(
                 "does this overclaim?", graph_token=TOKEN, thread_id=THREAD

--- a/tests/unit/agents/test_teams_agent.py
+++ b/tests/unit/agents/test_teams_agent.py
@@ -1,35 +1,28 @@
 """Tests for the agent that answers Teams questions.
 
 It differs from the Word agent in one structural way: it is not given a document.
-Opening one is its own job, so what is asserted here is that it gets the tool to do
-that and mounts only the skills up front -- the skills middleware reads those once
-before the run, so a tool cannot supply them later.
+Deciding which to open, and where to put it, is its own job -- so what is asserted here
+is that it gets the tools and the candidate links, and that only the skills are mounted
+up front, since the skills middleware reads those once before the run and a tool cannot
+supply them later.
 
 The prompt assertions are narrow on purpose. A link is the only way to reach a
 document, and the failure they guard against is the model filling that gap itself:
 answering from a file name, or guessing at a URL.
 
-The persistence tests carry the most weight: a document is re-read every turn, because it
-may have been edited and because the next asker may not be allowed to open it. Both
-failures are silent -- a stale or unauthorised answer reads perfectly well.
+A conversation persists, so documents opened in earlier turns are still here. That is
+deliberate, and it is why the agent is given ``check_document``: a kept copy may have
+been edited since, and may have been opened for somebody else in the thread.
 """
 
 from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-from lib.agents import teams_agent
 from lib.agents.teams_agent import answer_question, answer_text
-from lib.agents.tools.sharepoint import (
-    COMMENTS_DOCUMENT,
-    DOCUMENT_SOURCE,
-    MAIN_DOCUMENT,
-)
-from lib.services.microsoft.graph.client import DocumentNotAllowed, GraphError
-from lib.services.microsoft.graph.documents import LoadedDocument
+from lib.agents.tools import sharepoint
 
 # Every run reads as somebody; the tests do not care who.
 TOKEN = "a-user-token"
@@ -41,11 +34,8 @@ def agent_returning(answer: str, state: Optional[dict[str, Any]] = None) -> Magi
     """A deep agent whose last message is the answer.
 
     Returns the whole history the way a checkpointed run does -- the question and then
-    the reply -- because what is read back out is now the messages rather than a
-    structured field.
-
-    ``state`` is what a checkpointer would restore for this thread, which is how the
-    tests stand in for an earlier turn without running one.
+    the reply -- because what is read back out is the messages rather than a structured
+    field.
     """
 
     fake = MagicMock()
@@ -60,34 +50,9 @@ def agent_returning(answer: str, state: Optional[dict[str, Any]] = None) -> Magi
     return fake
 
 
-def loaded_document(markdown: str = "## A heading\n\nA paragraph.") -> LoadedDocument:
-    """What Graph hands back when the document is re-read."""
-
-    return LoadedDocument(
-        name="a.docx",
-        url=DOCUMENT_URL,
-        markdown=markdown,
-        comments=[],
-        last_modified="2026-08-11T13:31:28Z",
-        size_bytes=1024,
-    )
-
-
-def thread_with_document(url: str = DOCUMENT_URL) -> dict[str, Any]:
-    """State as it stands after some earlier turn opened a document."""
-
-    return {
-        "files": {
-            MAIN_DOCUMENT: {"content": ["## A heading", "", "A paragraph."]},
-            DOCUMENT_SOURCE: {"content": [url]},
-        },
-        "messages": [],
-    }
-
-
 @pytest.fixture(autouse=True)
 def checkpointer() -> Any:
-    """Stand in for the saver, since every answer now belongs to a thread.
+    """Stand in for the saver, since every answer belongs to a thread.
 
     Nothing here is about the pool -- ``test_checkpointer.py`` covers that -- but every
     call opens one, so it is patched for the whole module rather than per test.
@@ -105,23 +70,8 @@ def checkpointer() -> Any:
 
 class TestWhatTheAgentIsGiven:
     @pytest.mark.asyncio
-    async def test_it_gets_the_tool_to_open_a_document(self) -> None:
-        """Opening from a link, and nothing that searches by name."""
-
-        with patch("lib.agents.teams_agent.build_llm"), patch(
-            "lib.agents.teams_agent.create_deep_agent",
-            return_value=agent_returning("an answer"),
-        ) as build:
-            await answer_question(
-                "does this overclaim?", graph_token=TOKEN, thread_id=THREAD
-            )
-
-        tools = build.call_args.kwargs["tools"]
-        assert {tool.name for tool in tools} == {"open_document"}
-
-    @pytest.mark.asyncio
     async def test_no_document_is_mounted_up_front(self) -> None:
-        """The document arrives through the tool; only skills are mounted."""
+        """Documents arrive through the tool; only skills are mounted."""
 
         agent = agent_returning("an answer")
         with patch("lib.agents.teams_agent.build_llm"), patch(
@@ -132,40 +82,10 @@ class TestWhatTheAgentIsGiven:
             )
 
         files = agent.ainvoke.call_args[0][0]["files"]
-        assert "/main.md" not in files, "the agent opens its own document"
+        assert not any(path.startswith("/documents/") for path in files)
         assert any(path.startswith("/skills/") for path in files), (
             "skills must be mounted before the run; a tool cannot add them"
         )
-
-    @pytest.mark.asyncio
-    async def test_a_pasted_link_is_passed_through_as_a_hint(self) -> None:
-        agent = agent_returning("an answer")
-        url = "https://x.sharepoint.com/sites/X/a.docx"
-        with patch("lib.agents.teams_agent.build_llm"), patch(
-            "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ):
-            await answer_question(
-                "is this right?",
-                graph_token=TOKEN,
-                thread_id=THREAD,
-                document_hint=url,
-            )
-
-        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
-        assert url in prompt
-
-    @pytest.mark.asyncio
-    async def test_without_a_link_the_prompt_says_nothing_about_one(self) -> None:
-        agent = agent_returning("an answer")
-        with patch("lib.agents.teams_agent.build_llm"), patch(
-            "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ):
-            await answer_question(
-                "check the CERN paper", graph_token=TOKEN, thread_id=THREAD
-            )
-
-        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
-        assert "They linked to this document" not in prompt
 
     @pytest.mark.asyncio
     async def test_the_asker_is_named_in_the_prompt(self) -> None:
@@ -367,171 +287,48 @@ class TestContinuingAConversation:
         assert "Draft Detective" in build.call_args.kwargs["system_prompt"]
 
 
-class TestRereadingTheDocumentEachTurn:
-    """A continuing thread re-reads its document instead of keeping the mounted copy.
-
-    Two independent reasons, both covered below: it may have been edited since, and a
-    checkpoint carries no memory of whose access loaded it.
-    """
+class TestTheLinksHandedOver:
+    """Every link in the message, as candidates. The agent decides which is meant."""
 
     @pytest.mark.asyncio
-    async def test_the_document_is_read_again_as_the_person_asking(self) -> None:
-        agent = agent_returning("an answer", state=thread_with_document())
-        load = AsyncMock(return_value=loaded_document("Rewritten since last turn."))
+    async def test_one_link_is_named_in_the_prompt(self) -> None:
+        agent = agent_returning("an answer")
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ), patch.object(teams_agent.documents, "load", load):
-            await answer_question(
-                "and the second one?", graph_token=TOKEN, thread_id=THREAD
-            )
-
-        assert load.await_args is not None
-        assert load.await_args.args[0] == DOCUMENT_URL, "the thread's own document"
-        assert load.await_args.kwargs["token"] == TOKEN, "read as the asker"
-
-        files = agent.ainvoke.call_args[0][0]["files"]
-        body = "\n".join(files[MAIN_DOCUMENT]["content"])
-        assert "Rewritten since last turn." in body, "the fresh copy, not the old"
-
-    @pytest.mark.asyncio
-    async def test_a_stale_copy_is_replaced_rather_than_merged(self) -> None:
-        """The failure this exists to prevent: answering from text since rewritten."""
-
-        stale = thread_with_document()
-        stale["files"][MAIN_DOCUMENT] = {"content": ["The old wording."]}
-        agent = agent_returning("an answer", state=stale)
-        with patch("lib.agents.teams_agent.build_llm"), patch(
-            "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ), patch.object(
-            teams_agent.documents,
-            "load",
-            AsyncMock(return_value=loaded_document("The new wording.")),
         ):
             await answer_question(
-                "does this overclaim?", graph_token=TOKEN, thread_id=THREAD
-            )
-
-        files = agent.ainvoke.call_args[0][0]["files"]
-        body = "\n".join(files[MAIN_DOCUMENT]["content"])
-        assert "The old wording." not in body
-        assert "The new wording." in body
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "failure",
-        [
-            GraphError("could not find a.docx: 403"),
-            DocumentNotAllowed("outside the site paths this service may read"),
-            TimeoutError("graph took too long"),
-        ],
-        ids=[
-            "graph refuses this person",
-            "the allowlist no longer covers it",
-            "a timeout",
-        ],
-    )
-    async def test_a_document_that_cannot_be_read_is_given_up(
-        self, failure: Exception
-    ) -> None:
-        """Fail closed. A refusal and a timeout are indistinguishable from here, and
-        keeping the copy would answer someone from a document they may not open."""
-
-        agent = agent_returning("an answer", state=thread_with_document())
-        with patch("lib.agents.teams_agent.build_llm"), patch(
-            "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ), patch.object(
-            teams_agent.documents, "load", AsyncMock(side_effect=failure)
-        ):
-            await answer_question(
-                "what does paragraph 12 say?",
-                graph_token="somebody-elses-token",
-                thread_id=THREAD,
-            )
-
-        files = agent.ainvoke.call_args[0][0]["files"]
-        assert files[MAIN_DOCUMENT] is None
-        assert files[COMMENTS_DOCUMENT] is None
-        assert files[DOCUMENT_SOURCE] is None
-
-    @pytest.mark.asyncio
-    async def test_the_agent_is_told_not_to_answer_from_the_history(self) -> None:
-        """Dropping the file is not enough: what was quoted from it is still above."""
-
-        agent = agent_returning("an answer", state=thread_with_document())
-        with patch("lib.agents.teams_agent.build_llm"), patch(
-            "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ), patch.object(
-            teams_agent.documents, "load", AsyncMock(side_effect=GraphError("403"))
-        ):
-            await answer_question(
-                "what does paragraph 12 say?",
-                graph_token="somebody-elses-token",
-                thread_id=THREAD,
-            )
-
-        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
-        assert "could not be opened for the person asking now" in prompt
-        assert "Do not answer from what was said about it earlier" in prompt
-
-    @pytest.mark.asyncio
-    async def test_the_notice_does_not_claim_they_lack_access(self) -> None:
-        """A timeout is not a permission finding, and saying so would be a falsehood."""
-
-        agent = agent_returning("an answer", state=thread_with_document())
-        with patch("lib.agents.teams_agent.build_llm"), patch(
-            "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ), patch.object(
-            teams_agent.documents, "load", AsyncMock(side_effect=TimeoutError("slow"))
-        ):
-            await answer_question(
-                "what does it say?", graph_token=TOKEN, thread_id=THREAD
-            )
-
-        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
-        assert "may not have access, or it may have moved" in prompt
-
-    @pytest.mark.asyncio
-    async def test_a_new_link_closes_the_old_document(self) -> None:
-        """The agent will open the new one; the old must not linger unread."""
-
-        agent = agent_returning("an answer", state=thread_with_document())
-        load = AsyncMock(return_value=loaded_document())
-        with patch("lib.agents.teams_agent.build_llm"), patch(
-            "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ), patch.object(teams_agent.documents, "load", load):
-            await answer_question(
-                "what about this one?",
+                "is this right?",
                 graph_token=TOKEN,
                 thread_id=THREAD,
-                document_hint="https://x.sharepoint.com/sites/X/different.docx",
+                document_urls=[DOCUMENT_URL],
             )
-
-        files = agent.ainvoke.call_args[0][0]["files"]
-        assert files[MAIN_DOCUMENT] is None, "the old document goes"
-        assert load.await_count == 0, "the tool opens the new one, not this"
 
         prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
-        assert "could not be opened" not in prompt, "nothing went wrong here"
+        assert DOCUMENT_URL in prompt
+        assert "They linked to this document" in prompt
 
     @pytest.mark.asyncio
-    async def test_a_thread_with_no_document_reads_nothing(self) -> None:
-        """The common case -- a first question, or a conversation about nothing yet."""
+    async def test_several_links_are_all_offered(self) -> None:
+        """"Compare these two" is unanswerable if only the first survives."""
 
-        agent = agent_returning("an answer", state={"files": {}, "messages": []})
-        load = AsyncMock()
+        second = "https://x.sharepoint.com/sites/X/b.docx"
+        agent = agent_returning("an answer")
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
-        ), patch.object(teams_agent.documents, "load", load):
+        ):
             await answer_question(
-                "what can you do?", graph_token=TOKEN, thread_id=THREAD
+                "compare these",
+                graph_token=TOKEN,
+                thread_id=THREAD,
+                document_urls=[DOCUMENT_URL, second],
             )
 
-        assert load.await_count == 0
+        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
+        assert DOCUMENT_URL in prompt and second in prompt
+        assert "They linked to these documents" in prompt
 
     @pytest.mark.asyncio
-    async def test_every_turn_reads_the_thread_before_answering(self) -> None:
-        """The check cannot be skipped, so the state is always looked at first."""
-
+    async def test_no_links_says_nothing_about_them(self) -> None:
         agent = agent_returning("an answer")
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
@@ -540,7 +337,85 @@ class TestRereadingTheDocumentEachTurn:
                 "what can you do?", graph_token=TOKEN, thread_id=THREAD
             )
 
-        assert agent.aget_state.await_count == 1
+        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
+        assert "They linked to" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_loaded_before_the_agent_runs(self) -> None:
+        """The agent opens what it needs. A link in the message is not a decision.
+
+        A question about a document nobody asked about would otherwise cost a download
+        every turn -- and the router would be choosing, which is what it cannot do well.
+        """
+
+        load = AsyncMock()
+        agent = agent_returning("an answer")
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ), patch.object(sharepoint.documents, "load", load):
+            await answer_question(
+                "what can you do?",
+                graph_token=TOKEN,
+                thread_id=THREAD,
+                document_urls=[DOCUMENT_URL],
+            )
+
+        assert load.await_count == 0
+        assert agent.ainvoke.call_args[0][0]["files"].keys() == {
+            path for path in agent.ainvoke.call_args[0][0]["files"] if "/skills/" in path
+        }, "skills only; documents arrive through the tool"
+
+
+class TestTheToolsTheAgentGets:
+    @pytest.mark.asyncio
+    async def test_it_can_open_and_check_a_document(self) -> None:
+        """Checking is what makes a kept copy safe to use in a later turn."""
+
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent",
+            return_value=agent_returning("an answer"),
+        ) as build:
+            await answer_question("hello?", graph_token=TOKEN, thread_id=THREAD)
+
+        assert {tool.name for tool in build.call_args.kwargs["tools"]} == {
+            "open_document",
+            "check_document",
+        }
+
+    @pytest.mark.asyncio
+    async def test_both_tools_read_as_the_asker(self) -> None:
+        """One process serves many people, so neither tool may outlive its identity.
+
+        Asserted by driving the tools the agent was actually handed, rather than by
+        trusting that the factories were called with the right token.
+        """
+
+        opened = MagicMock(
+            markdown="body", comments=[], name="a.docx", lines=1, last_modified="then"
+        )
+        load = AsyncMock(return_value=opened)
+        resolve = AsyncMock(return_value={"name": "a.docx"})
+
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent",
+            return_value=agent_returning("an answer"),
+        ) as build:
+            await answer_question("hello?", graph_token="carlos", thread_id=THREAD)
+
+            tools = {tool.name: tool for tool in build.call_args.kwargs["tools"]}
+            with patch.object(sharepoint.documents, "load", load):
+                await tools["open_document"].coroutine(
+                    "https://x/a.docx",
+                    "/documents/a.md",
+                    MagicMock(tool_call_id="call_1"),
+                )
+            with patch.object(sharepoint.client, "resolve", resolve):
+                await tools["check_document"].coroutine("https://x/a.docx")
+
+        assert load.await_args is not None
+        assert load.await_args.kwargs["token"] == "carlos"
+        assert resolve.await_args is not None
+        assert resolve.await_args.kwargs["token"] == "carlos"
 
 
 class TestThePrompt:

--- a/tests/unit/agents/test_teams_agent.py
+++ b/tests/unit/agents/test_teams_agent.py
@@ -8,29 +8,99 @@ before the run, so a tool cannot supply them later.
 The prompt assertions are narrow on purpose. A link is the only way to reach a
 document, and the failure they guard against is the model filling that gap itself:
 answering from a file name, or guessing at a URL.
+
+The persistence tests carry the most weight: a document is re-read every turn, because it
+may have been edited and because the next asker may not be allowed to open it. Both
+failures are silent -- a stale or unauthorised answer reads perfectly well.
 """
 
+from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from lib.agents.teams_agent import QuestionReply, answer_question
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from lib.agents import teams_agent
+from lib.agents.teams_agent import answer_question, answer_text
+from lib.agents.tools.sharepoint import (
+    COMMENTS_DOCUMENT,
+    DOCUMENT_SOURCE,
+    MAIN_DOCUMENT,
+)
+from lib.services.microsoft.graph.client import DocumentNotAllowed, GraphError
+from lib.services.microsoft.graph.documents import LoadedDocument
 
 # Every run reads as somebody; the tests do not care who.
 TOKEN = "a-user-token"
+THREAD = "19:abc@thread.tacv2;messageid=1754"
+DOCUMENT_URL = "https://x.sharepoint.com/sites/X/a.docx"
 
 
-def agent_returning(answer: str) -> MagicMock:
-    """A deep agent that produces one structured answer."""
+def agent_returning(answer: str, state: Optional[dict[str, Any]] = None) -> MagicMock:
+    """A deep agent whose last message is the answer.
+
+    Returns the whole history the way a checkpointed run does -- the question and then
+    the reply -- because what is read back out is now the messages rather than a
+    structured field.
+
+    ``state`` is what a checkpointer would restore for this thread, which is how the
+    tests stand in for an earlier turn without running one.
+    """
 
     fake = MagicMock()
     fake.ainvoke = AsyncMock(
         return_value={
-            "messages": [],
-            "structured_response": QuestionReply(answer=answer),
+            "messages": [HumanMessage(content="a question"), AIMessage(content=answer)],
         }
     )
+    snapshot = MagicMock()
+    snapshot.values = state if state is not None else {}
+    fake.aget_state = AsyncMock(return_value=snapshot)
     return fake
+
+
+def loaded_document(paragraphs: Optional[list[str]] = None) -> LoadedDocument:
+    """What Graph hands back when the document is re-read."""
+
+    return LoadedDocument(
+        name="a.docx",
+        url=DOCUMENT_URL,
+        paragraphs=paragraphs if paragraphs is not None else ["A paragraph."],
+        comments=[],
+        last_modified="2026-08-11T13:31:28Z",
+        size_bytes=1024,
+    )
+
+
+def thread_with_document(url: str = DOCUMENT_URL) -> dict[str, Any]:
+    """State as it stands after some earlier turn opened a document."""
+
+    return {
+        "files": {
+            MAIN_DOCUMENT: {"content": ["[0] A paragraph."]},
+            DOCUMENT_SOURCE: {"content": [url]},
+        },
+        "messages": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def checkpointer() -> Any:
+    """Stand in for the saver, since every answer now belongs to a thread.
+
+    Nothing here is about the pool -- ``test_checkpointer.py`` covers that -- but every
+    call opens one, so it is patched for the whole module rather than per test.
+    """
+
+    saver = MagicMock()
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=saver)
+    context.__aexit__ = AsyncMock(return_value=False)
+    with patch(
+        "lib.agents.teams_agent.get_checkpointer", MagicMock(return_value=context)
+    ) as opened:
+        yield opened
 
 
 class TestWhatTheAgentIsGiven:
@@ -42,7 +112,9 @@ class TestWhatTheAgentIsGiven:
             "lib.agents.teams_agent.create_deep_agent",
             return_value=agent_returning("an answer"),
         ) as build:
-            await answer_question("does this overclaim?", graph_token=TOKEN)
+            await answer_question(
+                "does this overclaim?", graph_token=TOKEN, thread_id=THREAD
+            )
 
         tools = build.call_args.kwargs["tools"]
         assert {tool.name for tool in tools} == {"open_document"}
@@ -55,7 +127,9 @@ class TestWhatTheAgentIsGiven:
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
         ):
-            await answer_question("does this overclaim?", graph_token=TOKEN)
+            await answer_question(
+                "does this overclaim?", graph_token=TOKEN, thread_id=THREAD
+            )
 
         files = agent.ainvoke.call_args[0][0]["files"]
         assert "/main.md" not in files, "the agent opens its own document"
@@ -70,9 +144,14 @@ class TestWhatTheAgentIsGiven:
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
         ):
-            await answer_question("is this right?", graph_token=TOKEN, document_hint=url)
+            await answer_question(
+                "is this right?",
+                graph_token=TOKEN,
+                thread_id=THREAD,
+                document_hint=url,
+            )
 
-        prompt = agent.ainvoke.call_args[0][0]["messages"][1].content
+        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
         assert url in prompt
 
     @pytest.mark.asyncio
@@ -81,9 +160,11 @@ class TestWhatTheAgentIsGiven:
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
         ):
-            await answer_question("check the CERN paper", graph_token=TOKEN)
+            await answer_question(
+                "check the CERN paper", graph_token=TOKEN, thread_id=THREAD
+            )
 
-        prompt = agent.ainvoke.call_args[0][0]["messages"][1].content
+        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
         assert "They linked to this document" not in prompt
 
     @pytest.mark.asyncio
@@ -92,9 +173,89 @@ class TestWhatTheAgentIsGiven:
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=agent
         ):
-            await answer_question("hello?", graph_token=TOKEN, asked_by="Carlos Bonetti")
+            await answer_question(
+                "hello?",
+                graph_token=TOKEN,
+                thread_id=THREAD,
+                asked_by="Carlos Bonetti",
+            )
 
-        assert "Carlos Bonetti" in agent.ainvoke.call_args[0][0]["messages"][1].content
+        assert "Carlos Bonetti" in agent.ainvoke.call_args[0][0]["messages"][0].content
+
+
+class TestReadingTheAnswerOutOfTheMessages:
+    """No ``response_format``: the answer is the last thing the model said.
+
+    Which puts the burden on reading it back correctly, and a persisted thread makes one
+    of those cases dangerous rather than merely wrong.
+    """
+
+    def test_the_last_thing_said_is_the_answer(self) -> None:
+        assert (
+            answer_text(
+                [
+                    HumanMessage(content="first?"),
+                    AIMessage(content="an old answer"),
+                    HumanMessage(content="second?"),
+                    AIMessage(content="the new answer"),
+                ]
+            )
+            == "the new answer"
+        )
+
+    def test_markdown_survives_intact(self) -> None:
+        """The reason for dropping the JSON wrapper, so it is worth asserting."""
+
+        markdown = '## Findings\n\n1. **GDP** is undefined at "the total GDP" [70]\n'
+
+        assert answer_text([HumanMessage(content="?"), AIMessage(content=markdown)]) == (
+            markdown.strip()
+        )
+
+    def test_reasoning_blocks_are_not_part_of_the_answer(self) -> None:
+        """Reasoning-model output arrives as blocks beside the text."""
+
+        message = AIMessage(
+            content=[
+                {"type": "reasoning", "summary": "let me think about the abbreviations"},
+                {"type": "text", "text": "GDP is never defined."},
+            ]
+        )
+
+        assert answer_text([HumanMessage(content="?"), message]) == "GDP is never defined."
+
+    def test_a_turn_ending_in_a_tool_call_is_not_an_answer(self) -> None:
+        """It reached the recursion limit mid-work, so there is nothing to post."""
+
+        working = AIMessage(
+            content="",
+            tool_calls=[{"name": "open_document", "args": {"url": "u"}, "id": "1"}],
+        )
+
+        assert answer_text([HumanMessage(content="?"), working]) == ""
+
+    def test_it_never_reaches_back_into_an_earlier_turn(self) -> None:
+        """The dangerous case, and only possible because the thread is persisted.
+
+        A turn that produces no text must come back empty rather than re-posting the
+        previous turn's answer as though it were a reply to the new question.
+        """
+
+        history = [
+            HumanMessage(content="what does paragraph 12 say?"),
+            AIMessage(content="Paragraph 12 says the budget tripled."),
+            HumanMessage(content="and paragraph 13?"),
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "read_file", "args": {}, "id": "2"}],
+            ),
+            ToolMessage(content="…", tool_call_id="2"),
+        ]
+
+        assert answer_text(history) == ""
+
+    def test_nothing_at_all_is_empty_rather_than_an_error(self) -> None:
+        assert answer_text([]) == ""
 
 
 class TestTheAnswer:
@@ -104,7 +265,11 @@ class TestTheAnswer:
             "lib.agents.teams_agent.create_deep_agent",
             return_value=agent_returning("It overclaims in two places."),
         ):
-            answer = await answer_question("does this overclaim?", graph_token=TOKEN)
+            answer = await answer_question(
+                "does this overclaim?",
+                graph_token=TOKEN,
+                thread_id=THREAD,
+            )
 
         assert answer.failed is False
         assert answer.text == "It overclaims in two places."
@@ -115,7 +280,11 @@ class TestTheAnswer:
             "lib.agents.teams_agent.create_deep_agent",
             return_value=agent_returning("   "),
         ):
-            answer = await answer_question("does this overclaim?", graph_token=TOKEN)
+            answer = await answer_question(
+                "does this overclaim?",
+                graph_token=TOKEN,
+                thread_id=THREAD,
+            )
 
         assert answer.failed is True and answer.text == ""
 
@@ -123,14 +292,255 @@ class TestTheAnswer:
     async def test_a_crash_is_reported_rather_than_raised(self) -> None:
         """The caller is a background task with nobody to hand an exception to."""
 
-        broken = MagicMock()
+        broken = agent_returning("never gets this far")
         broken.ainvoke = AsyncMock(side_effect=RuntimeError("upstream timeout"))
         with patch("lib.agents.teams_agent.build_llm"), patch(
             "lib.agents.teams_agent.create_deep_agent", return_value=broken
         ):
-            answer = await answer_question("does this overclaim?", graph_token=TOKEN)
+            answer = await answer_question(
+                "does this overclaim?",
+                graph_token=TOKEN,
+                thread_id=THREAD,
+            )
 
         assert answer.failed is True and "upstream timeout" in (answer.error or "")
+
+
+class TestContinuingAConversation:
+    """One Teams thread is one LangGraph thread, which is the whole feature."""
+
+    @pytest.mark.asyncio
+    async def test_one_id_keys_the_checkpoint_and_the_langfuse_session(self) -> None:
+        """Both, from one parameter: a conversation is findable in the trace view under
+        the same id it is stored under."""
+
+        agent = agent_returning("an answer")
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ):
+            await answer_question(
+                "and the second one?", graph_token=TOKEN, thread_id=THREAD
+            )
+
+        config = agent.ainvoke.call_args.kwargs["config"]
+        assert config["configurable"]["thread_id"] == THREAD
+        assert config["metadata"]["langfuse_session_id"] == THREAD
+
+    @pytest.mark.asyncio
+    async def test_a_checkpointer_is_given_to_the_agent(self) -> None:
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent",
+            return_value=agent_returning("an answer"),
+        ) as build:
+            await answer_question(
+                "and the second one?", graph_token=TOKEN, thread_id=THREAD
+            )
+
+        assert build.call_args.kwargs["checkpointer"] is not None
+
+    @pytest.mark.asyncio
+    async def test_a_thread_is_not_optional(self) -> None:
+        """No opting out, so there is no second path where a document is unchecked."""
+
+        # Loosely typed so that omitting the argument -- the thing under test -- does not
+        # need a type: ignore for what mypy is right to reject.
+        called: Any = answer_question
+
+        with pytest.raises(TypeError, match="thread_id"):
+            await called("does this overclaim?", graph_token=TOKEN)
+
+    @pytest.mark.asyncio
+    async def test_the_system_prompt_is_not_a_message(self) -> None:
+        """It would be checkpointed, and re-appended on every single turn."""
+
+        agent = agent_returning("an answer")
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ) as build:
+            await answer_question(
+                "does this overclaim?", graph_token=TOKEN, thread_id=THREAD
+            )
+
+        messages = agent.ainvoke.call_args[0][0]["messages"]
+        assert len(messages) == 1, "only the new question belongs in a persisted thread"
+        assert messages[0].type == "human"
+        assert "Draft Detective" in build.call_args.kwargs["system_prompt"]
+
+
+class TestRereadingTheDocumentEachTurn:
+    """A continuing thread re-reads its document instead of keeping the mounted copy.
+
+    Two independent reasons, both covered below: it may have been edited since, and a
+    checkpoint carries no memory of whose access loaded it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_document_is_read_again_as_the_person_asking(self) -> None:
+        agent = agent_returning("an answer", state=thread_with_document())
+        load = AsyncMock(return_value=loaded_document(["Rewritten since last turn."]))
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ), patch.object(teams_agent.documents, "load", load):
+            await answer_question(
+                "and the second one?", graph_token=TOKEN, thread_id=THREAD
+            )
+
+        assert load.await_args is not None
+        assert load.await_args.args[0] == DOCUMENT_URL, "the thread's own document"
+        assert load.await_args.kwargs["token"] == TOKEN, "read as the asker"
+
+        files = agent.ainvoke.call_args[0][0]["files"]
+        body = "\n".join(files[MAIN_DOCUMENT]["content"])
+        assert "Rewritten since last turn." in body, "the fresh copy, not the old"
+
+    @pytest.mark.asyncio
+    async def test_a_stale_copy_is_replaced_rather_than_merged(self) -> None:
+        """The failure this exists to prevent: answering from text since rewritten."""
+
+        stale = thread_with_document()
+        stale["files"][MAIN_DOCUMENT] = {"content": ["[0] The old wording."]}
+        agent = agent_returning("an answer", state=stale)
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ), patch.object(
+            teams_agent.documents,
+            "load",
+            AsyncMock(return_value=loaded_document(["The new wording."])),
+        ):
+            await answer_question(
+                "does this overclaim?", graph_token=TOKEN, thread_id=THREAD
+            )
+
+        files = agent.ainvoke.call_args[0][0]["files"]
+        body = "\n".join(files[MAIN_DOCUMENT]["content"])
+        assert "The old wording." not in body
+        assert "The new wording." in body
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            GraphError("could not find a.docx: 403"),
+            DocumentNotAllowed("outside the site paths this service may read"),
+            TimeoutError("graph took too long"),
+        ],
+        ids=[
+            "graph refuses this person",
+            "the allowlist no longer covers it",
+            "a timeout",
+        ],
+    )
+    async def test_a_document_that_cannot_be_read_is_given_up(
+        self, failure: Exception
+    ) -> None:
+        """Fail closed. A refusal and a timeout are indistinguishable from here, and
+        keeping the copy would answer someone from a document they may not open."""
+
+        agent = agent_returning("an answer", state=thread_with_document())
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ), patch.object(
+            teams_agent.documents, "load", AsyncMock(side_effect=failure)
+        ):
+            await answer_question(
+                "what does paragraph 12 say?",
+                graph_token="somebody-elses-token",
+                thread_id=THREAD,
+            )
+
+        files = agent.ainvoke.call_args[0][0]["files"]
+        assert files[MAIN_DOCUMENT] is None
+        assert files[COMMENTS_DOCUMENT] is None
+        assert files[DOCUMENT_SOURCE] is None
+
+    @pytest.mark.asyncio
+    async def test_the_agent_is_told_not_to_answer_from_the_history(self) -> None:
+        """Dropping the file is not enough: what was quoted from it is still above."""
+
+        agent = agent_returning("an answer", state=thread_with_document())
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ), patch.object(
+            teams_agent.documents, "load", AsyncMock(side_effect=GraphError("403"))
+        ):
+            await answer_question(
+                "what does paragraph 12 say?",
+                graph_token="somebody-elses-token",
+                thread_id=THREAD,
+            )
+
+        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
+        assert "could not be opened for the person asking now" in prompt
+        assert "Do not answer from what was said about it earlier" in prompt
+
+    @pytest.mark.asyncio
+    async def test_the_notice_does_not_claim_they_lack_access(self) -> None:
+        """A timeout is not a permission finding, and saying so would be a falsehood."""
+
+        agent = agent_returning("an answer", state=thread_with_document())
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ), patch.object(
+            teams_agent.documents, "load", AsyncMock(side_effect=TimeoutError("slow"))
+        ):
+            await answer_question(
+                "what does it say?", graph_token=TOKEN, thread_id=THREAD
+            )
+
+        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
+        assert "may not have access, or it may have moved" in prompt
+
+    @pytest.mark.asyncio
+    async def test_a_new_link_closes_the_old_document(self) -> None:
+        """The agent will open the new one; the old must not linger unread."""
+
+        agent = agent_returning("an answer", state=thread_with_document())
+        load = AsyncMock(return_value=loaded_document())
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ), patch.object(teams_agent.documents, "load", load):
+            await answer_question(
+                "what about this one?",
+                graph_token=TOKEN,
+                thread_id=THREAD,
+                document_hint="https://x.sharepoint.com/sites/X/different.docx",
+            )
+
+        files = agent.ainvoke.call_args[0][0]["files"]
+        assert files[MAIN_DOCUMENT] is None, "the old document goes"
+        assert load.await_count == 0, "the tool opens the new one, not this"
+
+        prompt = agent.ainvoke.call_args[0][0]["messages"][0].content
+        assert "could not be opened" not in prompt, "nothing went wrong here"
+
+    @pytest.mark.asyncio
+    async def test_a_thread_with_no_document_reads_nothing(self) -> None:
+        """The common case -- a first question, or a conversation about nothing yet."""
+
+        agent = agent_returning("an answer", state={"files": {}, "messages": []})
+        load = AsyncMock()
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ), patch.object(teams_agent.documents, "load", load):
+            await answer_question(
+                "what can you do?", graph_token=TOKEN, thread_id=THREAD
+            )
+
+        assert load.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_every_turn_reads_the_thread_before_answering(self) -> None:
+        """The check cannot be skipped, so the state is always looked at first."""
+
+        agent = agent_returning("an answer")
+        with patch("lib.agents.teams_agent.build_llm"), patch(
+            "lib.agents.teams_agent.create_deep_agent", return_value=agent
+        ):
+            await answer_question(
+                "what can you do?", graph_token=TOKEN, thread_id=THREAD
+            )
+
+        assert agent.aget_state.await_count == 1
 
 
 class TestThePrompt:

--- a/tests/unit/services/test_teams_bot.py
+++ b/tests/unit/services/test_teams_bot.py
@@ -211,12 +211,16 @@ class TestTheFollowUpActivity:
             Activity.model_validate(continuation.model_dump())
 
 
-class TestFindingTheDocument:
+class TestFindingTheLinks:
     """A link is the only way to reach a document, so failing to spot one is fatal.
 
     The case that broke in Teams: the link was there, visibly, but only as a
     hyperlink -- so ``activity.text`` held the file name and the bot asked for a link
     that had already been sent.
+
+    Every link is returned rather than the first. Which one is meant depends on what was
+    asked -- "compare these two", "the second one" -- so that decision belongs to the
+    agent, and picking one here would throw away the others before it could.
     """
 
     def message(
@@ -227,28 +231,54 @@ class TestFindingTheDocument:
         )
 
     def test_a_pasted_sharepoint_link_is_found(self) -> None:
-        found = bot.document_url_in(
+        found = bot.document_urls_in(
             self.message(
                 "have a look at "
                 "https://contoso.sharepoint.com/sites/X/Shared%20Documents/a.docx"
                 " please"
             )
         )
-        assert found is not None and found.endswith("a.docx")
+        assert len(found) == 1 and found[0].endswith("a.docx")
+
+    def test_every_link_is_returned_in_order(self) -> None:
+        """So "compare these two" is answerable, and "the second one" means something."""
+
+        found = bot.document_urls_in(
+            self.message(
+                "compare https://x.sharepoint.com/sites/X/v2.docx with "
+                "https://x.sharepoint.com/sites/X/v3.docx"
+            )
+        )
+
+        assert found == [
+            "https://x.sharepoint.com/sites/X/v2.docx",
+            "https://x.sharepoint.com/sites/X/v3.docx",
+        ]
+
+    def test_the_same_link_is_not_offered_twice(self) -> None:
+        """Teams repeats it: once in the text, again in the HTML, again in the card."""
+
+        url = "https://x.sharepoint.com/sites/X/a.docx"
+        activity = self.message(
+            f"look at {url}",
+            [Attachment(content_type="text/html", content=f'<a href="{url}">a</a>')],
+        )
+
+        assert bot.document_urls_in(activity) == [url]
 
     def test_trailing_punctuation_is_trimmed(self) -> None:
         """Teams decorates pasted links, and the URL must not absorb the full stop."""
 
-        found = bot.document_url_in(
+        found = bot.document_urls_in(
             self.message("see https://x.sharepoint.com/sites/X/a.docx.")
         )
-        assert found == "https://x.sharepoint.com/sites/X/a.docx"
+        assert found == ["https://x.sharepoint.com/sites/X/a.docx"]
 
     def test_a_message_with_no_link_finds_nothing(self) -> None:
-        assert bot.document_url_in(self.message("does this overclaim?")) is None
+        assert bot.document_urls_in(self.message("does this overclaim?")) == []
 
-    def test_a_non_sharepoint_link_is_not_taken_as_the_document(self) -> None:
-        assert bot.document_url_in(self.message("see https://example.com/a.docx")) is None
+    def test_a_non_sharepoint_link_is_not_taken_as_a_document(self) -> None:
+        assert bot.document_urls_in(self.message("see https://example.com/a.docx")) == []
 
     def test_a_link_rendered_as_a_hyperlink_is_found_in_the_html(self) -> None:
         """The reported bug. The text is the file name; the href is in an attachment."""
@@ -267,10 +297,9 @@ class TestFindingTheDocument:
             ],
         )
 
-        found = bot.document_url_in(activity)
-        assert found == (
+        assert bot.document_urls_in(activity) == [
             "https://contoso.sharepoint.com/sites/Reviews/Drafts/v3-CERN.docx"
-        )
+        ]
 
     def test_an_escaped_query_string_survives_the_html(self) -> None:
         """An href arrives escaped, so ``&amp;`` would truncate the link's parameters."""
@@ -288,8 +317,8 @@ class TestFindingTheDocument:
             ],
         )
 
-        found = bot.document_url_in(activity)
-        assert found is not None and found.endswith("?d=w123&csf=1&web=1")
+        found = bot.document_urls_in(activity)
+        assert len(found) == 1 and found[0].endswith("?d=w123&csf=1&web=1")
 
     def test_a_link_in_an_unfurled_card_is_found(self) -> None:
         """Teams turns a pasted document link into a card; shape varies by card type."""
@@ -310,11 +339,11 @@ class TestFindingTheDocument:
             ],
         )
 
-        assert bot.document_url_in(activity) == (
+        assert bot.document_urls_in(activity) == [
             "https://x.sharepoint.com/sites/X/DD/v3-CERN.docx"
-        )
+        ]
 
-    def test_a_cards_thumbnail_is_not_mistaken_for_the_document(self) -> None:
+    def test_a_cards_thumbnail_is_not_mistaken_for_a_document(self) -> None:
         """The preview image lives on the same host and would resolve to the wrong thing."""
 
         activity = self.message(
@@ -334,10 +363,14 @@ class TestFindingTheDocument:
             ],
         )
 
-        assert bot.document_url_in(activity) is None
+        assert bot.document_urls_in(activity) == []
 
-    def test_the_visible_text_wins_over_an_attachment(self) -> None:
-        """What someone typed is more faithful than what Teams generated around it."""
+    def test_the_visible_text_comes_first(self) -> None:
+        """What someone typed is more faithful than what Teams generated around it.
+
+        Both are offered now, so the ordering is the whole signal: the agent reads the
+        list in order and the typed link leads it.
+        """
 
         activity = self.message(
             "compare https://x.sharepoint.com/sites/X/typed.docx",
@@ -349,7 +382,10 @@ class TestFindingTheDocument:
             ],
         )
 
-        assert bot.document_url_in(activity) == "https://x.sharepoint.com/sites/X/typed.docx"
+        assert bot.document_urls_in(activity) == [
+            "https://x.sharepoint.com/sites/X/typed.docx",
+            "https://x.sharepoint.com/sites/X/card.docx",
+        ]
 
 
 class TestAMalformedActivity:

--- a/tests/unit/test_teams_endpoints.py
+++ b/tests/unit/test_teams_endpoints.py
@@ -33,7 +33,7 @@ class TestWhenAnsweringFails:
             teams.bot, "post_later", posted
         ):
             await teams._answer_into_thread(
-                "ref", "does this overclaim?", "Carlos", "19:x", None, "token"
+                "ref", "does this overclaim?", "Carlos", "19:x", [], "token"
             )
 
         posted.assert_awaited_once()
@@ -53,7 +53,7 @@ class TestWhenAnsweringFails:
             teams, "answer_question", AsyncMock(side_effect=RuntimeError("upstream"))
         ), patch.object(teams.bot, "post_later", posted):
             await teams._answer_into_thread(
-                "ref", "does this overclaim?", "Carlos", "19:x", None, "token"
+                "ref", "does this overclaim?", "Carlos", "19:x", [], "token"
             )
 
         posted.assert_awaited_once()
@@ -67,7 +67,7 @@ class TestWhenAnsweringFails:
         with patch.object(
             teams, "answer_question", AsyncMock(side_effect=RuntimeError("upstream"))
         ), patch.object(teams.bot, "post_later", AsyncMock()):
-            await teams._answer_into_thread("ref", "q", "Carlos", "19:x", None, "t")
+            await teams._answer_into_thread("ref", "q", "Carlos", "19:x", [], "t")
 
     @pytest.mark.asyncio
     async def test_the_question_is_truncated_in_the_log(self) -> None:
@@ -79,7 +79,7 @@ class TestWhenAnsweringFails:
         ), patch.object(teams.bot, "post_later", AsyncMock()), patch.object(
             teams.logger, "exception"
         ) as logged:
-            await teams._answer_into_thread("ref", question, "C", "19:x", None, "t")
+            await teams._answer_into_thread("ref", question, "C", "19:x", [], "t")
 
         assert logged.call_args is not None
         assert len(logged.call_args[0][1]) == 120

--- a/tests/unit/tools/test_sharepoint.py
+++ b/tests/unit/tools/test_sharepoint.py
@@ -142,13 +142,19 @@ class TestOpeningADocument:
         assert "Carlos: is this right?" in body_of(files, "/comments.md")
 
     @pytest.mark.asyncio
-    async def test_no_comments_means_no_comments_file(self) -> None:
+    async def test_no_comments_clears_any_previous_ones(self) -> None:
+        """A ``None`` is the reducer's delete, not an oversight.
+
+        A conversation persists, so a second document opened in the same thread would
+        otherwise inherit the first one's comments and be answered about from them.
+        """
+
         with patch.object(
             sharepoint.documents, "load", AsyncMock(return_value=document())
         ):
             result = await call(opener(), "https://x/a.docx", runtime())
 
-        assert "/comments.md" not in mounted(result)
+        assert mounted(result)["/comments.md"] is None
 
     @pytest.mark.asyncio
     async def test_a_document_outside_the_allowlist_is_refused_in_words(self) -> None:
@@ -174,6 +180,117 @@ class TestOpeningADocument:
             result = await call(opener(), "https://x/a.docx", runtime())
 
         assert isinstance(result, str) and "boom" in result
+
+
+class TestRememberingWhichDocumentIsOpen:
+    """A mount outlives its turn, so a later turn has to know what it is looking at.
+
+    That is what re-authorises a persisted conversation: the next question may come from
+    someone else, and the document has to be re-checked against *them*. The URL is
+    written with the document rather than anywhere else, so the two cannot disagree.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_link_is_written_beside_the_document(self) -> None:
+        url = "https://x.sharepoint.com/sites/X/a.docx"
+        with patch.object(
+            sharepoint.documents, "load", AsyncMock(return_value=document())
+        ):
+            result = await call(opener(), url, runtime())
+
+        assert body_of(mounted(result), sharepoint.DOCUMENT_SOURCE) == url
+
+    @pytest.mark.asyncio
+    async def test_it_is_read_back_from_the_state_it_was_written_to(self) -> None:
+        url = "https://x.sharepoint.com/sites/X/a.docx"
+        with patch.object(
+            sharepoint.documents, "load", AsyncMock(return_value=document())
+        ):
+            result = await call(opener(), url, runtime())
+
+        assert sharepoint.mounted_document(mounted(result)) == url
+
+    def test_nothing_open_means_nothing_to_re_check(self) -> None:
+        assert sharepoint.mounted_document(None) is None
+        assert sharepoint.mounted_document({}) is None
+
+    def test_a_source_without_a_document_does_not_count(self) -> None:
+        """Whatever produced that state, there is no mounted document to authorise."""
+
+        files = {sharepoint.DOCUMENT_SOURCE: {"content": ["https://x/a.docx"]}}
+
+        assert sharepoint.mounted_document(files) is None
+
+    def test_a_document_without_a_source_does_not_count(self) -> None:
+        """Fails closed: unable to name the document, so unable to re-check it.
+
+        Reachable only from state written before the source file existed. Returning the
+        URL-less document as readable would skip the check entirely, so it reads as
+        "nothing mounted" and the agent opens it again from the link.
+        """
+
+        files = {"/main.md": {"content": ["[0] A."]}}
+
+        assert sharepoint.mounted_document(files) is None
+
+    @pytest.mark.asyncio
+    async def test_a_refused_open_leaves_the_previous_document_named(self) -> None:
+        """The reason the URL is not taken from the newest tool call.
+
+        A refused open mounts nothing, so the document still loaded is the earlier one.
+        Trusting the newest call would re-check a document that was never there and
+        leave the mounted one unauthorised.
+        """
+
+        first = "https://x.sharepoint.com/sites/X/first.docx"
+        with patch.object(
+            sharepoint.documents, "load", AsyncMock(return_value=document())
+        ):
+            opened = mounted(await call(opener(), first, runtime()))
+
+        with patch.object(
+            sharepoint.documents,
+            "load",
+            AsyncMock(side_effect=GraphError("could not download second.docx: 403")),
+        ):
+            refused = await call(
+                opener(), "https://x.sharepoint.com/sites/X/second.docx", runtime()
+            )
+
+        assert isinstance(refused, str), "a refusal mounts nothing"
+        assert sharepoint.mounted_document(opened) == first
+
+
+class TestMountingAndUnmounting:
+    """The tool and the per-turn re-read share these, so they cannot mount differently.
+
+    Which matters most for what gets *cleared*: a thread that moves to another document,
+    or gives one up, must not keep a file belonging to the previous one.
+    """
+
+    def test_a_document_without_comments_clears_a_previous_one(self) -> None:
+        files = sharepoint.document_files(document(), "https://x/a.docx")
+
+        assert files[sharepoint.COMMENTS_DOCUMENT] is None
+
+    def test_giving_up_a_document_removes_its_source_too(self) -> None:
+        """A source left behind would name a document that is no longer mounted."""
+
+        evicted = sharepoint.evict_document()
+
+        assert set(evicted) == {
+            sharepoint.MAIN_DOCUMENT,
+            sharepoint.COMMENTS_DOCUMENT,
+            sharepoint.DOCUMENT_SOURCE,
+        }
+        assert all(value is None for value in evicted.values())
+
+    def test_everything_a_mount_writes_can_be_unwritten(self) -> None:
+        """The two have to stay in step, or a stale file survives being evicted."""
+
+        mounted_paths = set(sharepoint.document_files(document(), "https://x/a.docx"))
+
+        assert mounted_paths == set(sharepoint.evict_document())
 
 
 class TestALinkIsTheOnlyWayIn:

--- a/tests/unit/tools/test_sharepoint.py
+++ b/tests/unit/tools/test_sharepoint.py
@@ -72,13 +72,15 @@ def runtime() -> MagicMock:
 
 
 def document(
-    paragraphs: Optional[list[str]] = None,
+    markdown: Optional[str] = None,
     comments: Optional[list[tuple[str, str]]] = None,
 ) -> LoadedDocument:
     return LoadedDocument(
         name="v2-cern-for-ai.docx",
         url="https://x.sharepoint.com/sites/X/Shared%20Documents/v2-cern-for-ai.docx",
-        paragraphs=paragraphs if paragraphs is not None else ["First.", "Second."],
+        markdown=(
+            markdown if markdown is not None else "## A heading\n\nFirst.\n\nSecond."
+        ),
         comments=comments or [],
         last_modified="2026-08-04T13:31:28Z",
         size_bytes=180097,
@@ -100,16 +102,38 @@ class TestOpeningADocument:
         assert "/main.md" in mounted(result)
 
     @pytest.mark.asyncio
-    async def test_the_mounted_text_carries_paragraph_numbers(self) -> None:
+    async def test_the_mounted_text_keeps_the_document_structure(self) -> None:
+        """Markdown, not a flat list of paragraphs.
+
+        Headings and tables are how the agent navigates and how a skill tells one part
+        of a document from another, so losing them to a paragraph-by-paragraph read is
+        the regression this guards.
+        """
+
+        markdown = (
+            "## Abbreviations\n\n| AI | artificial intelligence |\n\nBody **text**."
+        )
         with patch.object(
-            sharepoint.documents,
-            "load",
-            AsyncMock(return_value=document(["Alpha.", "Beta."])),
+            sharepoint.documents, "load", AsyncMock(return_value=document(markdown))
         ):
             result = await call(opener(), "https://x/a.docx", runtime())
 
         body = body_of(mounted(result), "/main.md")
-        assert "[0] Alpha." in body and "[1] Beta." in body
+        assert body == markdown, "mounted verbatim, with nothing numbered into it"
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_prefixed_onto_the_lines(self) -> None:
+        """The read tool numbers lines itself, so a second scheme only competes."""
+
+        with patch.object(
+            sharepoint.documents,
+            "load",
+            AsyncMock(return_value=document("Alpha.\n\nBeta.")),
+        ):
+            result = await call(opener(), "https://x/a.docx", runtime())
+
+        body = body_of(mounted(result), "/main.md")
+        assert "[0]" not in body and "[1]" not in body
 
     @pytest.mark.asyncio
     async def test_the_body_is_not_in_the_tool_message(self) -> None:
@@ -118,13 +142,13 @@ class TestOpeningADocument:
         with patch.object(
             sharepoint.documents,
             "load",
-            AsyncMock(return_value=document(["A distinctive sentence."])),
+            AsyncMock(return_value=document("A distinctive sentence.")),
         ):
             result = await call(opener(), "https://x/a.docx", runtime())
 
         message = message_of(result)
         assert "distinctive sentence" not in message
-        assert "1 paragraphs" in message and "/main.md" in message
+        assert "1 lines" in message and "/main.md" in message
 
     @pytest.mark.asyncio
     async def test_comments_are_mounted_separately_when_present(self) -> None:

--- a/tests/unit/tools/test_sharepoint.py
+++ b/tests/unit/tools/test_sharepoint.py
@@ -1,13 +1,20 @@
-"""Tests for the tool that opens a SharePoint document from a link.
+"""Tests for the tools that open and check SharePoint documents.
 
-Three things carry weight here. The document must be *mounted* at ``/main.md`` rather
-than returned, because a tool result over roughly 80,000 characters is evicted to a
-machine-named file and every skill's line numbers are defined against ``/main.md``.
+Four things carry weight here.
+
+A document must be *mounted* rather than returned, because a tool result over roughly
+80,000 characters is evicted to a machine-named file, and real documents run to that size.
+
+The agent chooses the path, so the path must be **validated**: ``files`` is one namespace
+shared with ``/skills/``, and a path of ``/skills/issues/SKILL.md`` would overwrite the
+instructions the agent is following.
+
 A link must remain the only way in: there is deliberately no lookup by name, so a name
-cannot reach a document the person asking could not already open. And the tool must
-carry the identity it was built with all the way to Graph -- that token is what makes
-the bot no more privileged than the asker, so losing it is a security regression
-rather than a bug in a feature.
+cannot reach a document the person asking could not already open.
+
+And both tools must carry the identity they were built with all the way to Graph -- that
+token is what makes the bot no more privileged than the asker, so losing it is a security
+regression rather than a bug in a feature.
 """
 
 from typing import Any, Optional
@@ -20,14 +27,18 @@ from lib.agents.tools import sharepoint
 from lib.services.microsoft.graph.client import DocumentNotAllowed, GraphError
 from lib.services.microsoft.graph.documents import LoadedDocument
 
-
 TOKEN = "a-user-token"
+PATH = "/documents/v2-cern-for-ai.md"
 
 
 def opener(token: str = TOKEN) -> Any:
     """The tool as a run gets it: built for one identity."""
 
     return sharepoint.open_document_for(token)
+
+
+def checker(token: str = TOKEN) -> Any:
+    return sharepoint.check_document_for(token)
 
 
 async def call(tool: Any, *args: Any) -> Any:
@@ -44,7 +55,9 @@ async def call(tool: Any, *args: Any) -> Any:
 def mounted(result: Any) -> dict[str, Any]:
     """The files a Command mounts, having checked it is a Command that mounts some."""
 
-    assert isinstance(result, Command), f"expected a Command, got {type(result).__name__}"
+    assert isinstance(
+        result, Command
+    ), f"expected a Command, got {type(result).__name__}: {result}"
     assert result.update is not None, "a Command that updates nothing mounts nothing"
     return dict(result.update["files"])
 
@@ -87,234 +100,255 @@ def document(
     )
 
 
+def loading(document_or_error: Any) -> Any:
+    """Patch ``documents.load`` with a result or a failure."""
+
+    if isinstance(document_or_error, BaseException):
+        return patch.object(
+            sharepoint.documents, "load", AsyncMock(side_effect=document_or_error)
+        )
+    return patch.object(
+        sharepoint.documents, "load", AsyncMock(return_value=document_or_error)
+    )
+
+
 class TestOpeningADocument:
     @pytest.mark.asyncio
-    async def test_the_document_is_mounted_at_main_md(self) -> None:
-        """Where every other agent and every skill expects to find it."""
+    async def test_the_document_is_mounted_where_the_agent_asked(self) -> None:
+        with loading(document()):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
 
-        with patch.object(
-            sharepoint.documents, "load", AsyncMock(return_value=document())
-        ):
-            result = await call(
-                opener(), "https://x.sharepoint.com/sites/X/a.docx", runtime()
-            )
-
-        assert "/main.md" in mounted(result)
+        assert PATH in mounted(result)
 
     @pytest.mark.asyncio
     async def test_the_mounted_text_keeps_the_document_structure(self) -> None:
         """Markdown, not a flat list of paragraphs.
 
-        Headings and tables are how the agent navigates and how a skill tells one part
-        of a document from another, so losing them to a paragraph-by-paragraph read is
-        the regression this guards.
+        Headings and tables are how the agent navigates and how a skill tells one part of
+        a document from another, so losing them is the regression this guards.
         """
 
         markdown = (
             "## Abbreviations\n\n| AI | artificial intelligence |\n\nBody **text**."
         )
-        with patch.object(
-            sharepoint.documents, "load", AsyncMock(return_value=document(markdown))
-        ):
-            result = await call(opener(), "https://x/a.docx", runtime())
+        with loading(document(markdown)):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
 
-        body = body_of(mounted(result), "/main.md")
-        assert body == markdown, "mounted verbatim, with nothing numbered into it"
+        assert body_of(mounted(result), PATH) == markdown
 
     @pytest.mark.asyncio
     async def test_nothing_is_prefixed_onto_the_lines(self) -> None:
         """The read tool numbers lines itself, so a second scheme only competes."""
 
-        with patch.object(
-            sharepoint.documents,
-            "load",
-            AsyncMock(return_value=document("Alpha.\n\nBeta.")),
-        ):
-            result = await call(opener(), "https://x/a.docx", runtime())
+        with loading(document("Alpha.\n\nBeta.")):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
 
-        body = body_of(mounted(result), "/main.md")
+        body = body_of(mounted(result), PATH)
         assert "[0]" not in body and "[1]" not in body
 
     @pytest.mark.asyncio
     async def test_the_body_is_not_in_the_tool_message(self) -> None:
         """A result carrying the body would be evicted to a machine-named file."""
 
-        with patch.object(
-            sharepoint.documents,
-            "load",
-            AsyncMock(return_value=document("A distinctive sentence.")),
-        ):
-            result = await call(opener(), "https://x/a.docx", runtime())
+        with loading(document("A distinctive sentence.")):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
 
         message = message_of(result)
         assert "distinctive sentence" not in message
-        assert "1 lines" in message and "/main.md" in message
+        assert "1 lines" in message and PATH in message
 
     @pytest.mark.asyncio
-    async def test_comments_are_mounted_separately_when_present(self) -> None:
-        with patch.object(
-            sharepoint.documents,
-            "load",
-            AsyncMock(
-                return_value=document(comments=[("Carlos", "is this right?")])
-            ),
-        ):
-            result = await call(opener(), "https://x/a.docx", runtime())
+    async def test_the_modified_time_is_reported_so_it_can_be_compared_later(
+        self,
+    ) -> None:
+        """``check_document`` is only useful against a time the agent already has."""
+
+        with loading(document()):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
+
+        assert "2026-08-04T13:31:28Z" in message_of(result)
+
+    @pytest.mark.asyncio
+    async def test_comments_are_mounted_beside_the_document(self) -> None:
+        with loading(document(comments=[("Carlos", "is this right?")])):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
 
         files = mounted(result)
-        assert "/comments.md" in files
-        assert "Carlos: is this right?" in body_of(files, "/comments.md")
+        beside = "/documents/v2-cern-for-ai.comments.md"
+        assert beside in files
+        assert "Carlos: is this right?" in body_of(files, beside)
+
+    @pytest.mark.asyncio
+    async def test_each_document_gets_its_own_comments_file(self) -> None:
+        """One shared comments file would answer about one document from another's."""
+
+        with loading(document(comments=[("Carlos", "on v2")])):
+            first = mounted(await call(opener(), "https://x/v2.docx", PATH, runtime()))
+        with loading(document(comments=[("Ana", "on v3")])):
+            second = mounted(
+                await call(opener(), "https://x/v3.docx", "/documents/v3.md", runtime())
+            )
+
+        assert set(first) & set(second) == set(), "no path is shared between the two"
 
     @pytest.mark.asyncio
     async def test_no_comments_clears_any_previous_ones(self) -> None:
         """A ``None`` is the reducer's delete, not an oversight.
 
-        A conversation persists, so a second document opened in the same thread would
-        otherwise inherit the first one's comments and be answered about from them.
+        Re-opening a document whose comments have been resolved must not keep answering
+        from the ones it had before.
         """
 
-        with patch.object(
-            sharepoint.documents, "load", AsyncMock(return_value=document())
-        ):
-            result = await call(opener(), "https://x/a.docx", runtime())
+        with loading(document()):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
 
-        assert mounted(result)["/comments.md"] is None
+        assert mounted(result)["/documents/v2-cern-for-ai.comments.md"] is None
 
     @pytest.mark.asyncio
     async def test_a_document_outside_the_allowlist_is_refused_in_words(self) -> None:
         """The model has to be able to explain the refusal, so it gets a string."""
 
-        with patch.object(
-            sharepoint.documents,
-            "load",
-            AsyncMock(side_effect=DocumentNotAllowed("evil.com is not allowed")),
-        ):
-            result = await call(
-                opener(), "https://evil.com/a.docx", runtime()
-            )
+        with loading(DocumentNotAllowed("evil.com is not allowed")):
+            result = await call(opener(), "https://evil.com/a.docx", PATH, runtime())
 
         assert isinstance(result, str)
         assert "not allowed" in result
 
     @pytest.mark.asyncio
     async def test_an_unexpected_failure_is_reported_not_raised(self) -> None:
-        with patch.object(
-            sharepoint.documents, "load", AsyncMock(side_effect=RuntimeError("boom"))
-        ):
-            result = await call(opener(), "https://x/a.docx", runtime())
+        with loading(RuntimeError("boom")):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
 
         assert isinstance(result, str) and "boom" in result
 
 
-class TestRememberingWhichDocumentIsOpen:
-    """A mount outlives its turn, so a later turn has to know what it is looking at.
+class TestChoosingWhereItGoes:
+    """The path comes from the model, so it is validated rather than trusted.
 
-    That is what re-authorises a persisted conversation: the next question may come from
-    someone else, and the document has to be re-checked against *them*. The URL is
-    written with the document rather than anywhere else, so the two cannot disagree.
+    ``files`` is a single namespace holding the skills as well as the documents, so an
+    unchecked path is a way for the agent to overwrite its own instructions.
     """
 
-    @pytest.mark.asyncio
-    async def test_the_link_is_written_beside_the_document(self) -> None:
-        url = "https://x.sharepoint.com/sites/X/a.docx"
-        with patch.object(
-            sharepoint.documents, "load", AsyncMock(return_value=document())
-        ):
-            result = await call(opener(), url, runtime())
+    def test_a_bare_name_is_placed_under_the_documents_prefix(self) -> None:
+        assert sharepoint.document_path("v3.md") == "/documents/v3.md"
 
-        assert body_of(mounted(result), sharepoint.DOCUMENT_SOURCE) == url
+    def test_a_path_that_is_already_right_is_left_alone(self) -> None:
+        assert sharepoint.document_path("/documents/v3.md") == "/documents/v3.md"
 
-    @pytest.mark.asyncio
-    async def test_it_is_read_back_from_the_state_it_was_written_to(self) -> None:
-        url = "https://x.sharepoint.com/sites/X/a.docx"
-        with patch.object(
-            sharepoint.documents, "load", AsyncMock(return_value=document())
-        ):
-            result = await call(opener(), url, runtime())
+    def test_spaces_and_brackets_in_a_document_name_are_allowed(self) -> None:
+        """Real file names have them, and refusing would be a nuisance for no gain."""
 
-        assert sharepoint.mounted_document(mounted(result)) == url
+        assert sharepoint.document_path("/documents/v3-cern (final).md") == (
+            "/documents/v3-cern (final).md"
+        )
 
-    def test_nothing_open_means_nothing_to_re_check(self) -> None:
-        assert sharepoint.mounted_document(None) is None
-        assert sharepoint.mounted_document({}) is None
-
-    def test_a_source_without_a_document_does_not_count(self) -> None:
-        """Whatever produced that state, there is no mounted document to authorise."""
-
-        files = {sharepoint.DOCUMENT_SOURCE: {"content": ["https://x/a.docx"]}}
-
-        assert sharepoint.mounted_document(files) is None
-
-    def test_a_document_without_a_source_does_not_count(self) -> None:
-        """Fails closed: unable to name the document, so unable to re-check it.
-
-        Reachable only from state written before the source file existed. Returning the
-        URL-less document as readable would skip the check entirely, so it reads as
-        "nothing mounted" and the agent opens it again from the link.
-        """
-
-        files = {"/main.md": {"content": ["[0] A."]}}
-
-        assert sharepoint.mounted_document(files) is None
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/skills/issues/SKILL.md",
+            "/main.md",
+            "/documents/sub/x.md",
+            "../../etc/passwd.md",
+            "/documents/x.txt",
+            "/documents/.hidden.md",
+        ],
+        ids=[
+            "over a skill",
+            "outside the prefix",
+            "nested",
+            "traversal",
+            "not markdown",
+            "a dotfile",
+        ],
+    )
+    def test_anything_that_would_land_elsewhere_is_refused(self, path: str) -> None:
+        with pytest.raises(ValueError):
+            sharepoint.document_path(path)
 
     @pytest.mark.asyncio
-    async def test_a_refused_open_leaves_the_previous_document_named(self) -> None:
-        """The reason the URL is not taken from the newest tool call.
+    async def test_a_bad_path_is_explained_rather_than_raised(self) -> None:
+        """The model can correct itself from the message; an exception ends the run."""
 
-        A refused open mounts nothing, so the document still loaded is the earlier one.
-        Trusting the newest call would re-check a document that was never there and
-        leave the mounted one unauthorised.
-        """
-
-        first = "https://x.sharepoint.com/sites/X/first.docx"
-        with patch.object(
-            sharepoint.documents, "load", AsyncMock(return_value=document())
-        ):
-            opened = mounted(await call(opener(), first, runtime()))
-
-        with patch.object(
-            sharepoint.documents,
-            "load",
-            AsyncMock(side_effect=GraphError("could not download second.docx: 403")),
-        ):
-            refused = await call(
-                opener(), "https://x.sharepoint.com/sites/X/second.docx", runtime()
+        load = AsyncMock(return_value=document())
+        with patch.object(sharepoint.documents, "load", load):
+            result = await call(
+                opener(), "https://x/a.docx", "/skills/issues/SKILL.md", runtime()
             )
 
-        assert isinstance(refused, str), "a refusal mounts nothing"
-        assert sharepoint.mounted_document(opened) == first
+        assert isinstance(result, str)
+        assert "/documents/" in result
+        assert load.await_count == 0, "refused before anything was downloaded"
 
 
-class TestMountingAndUnmounting:
-    """The tool and the per-turn re-read share these, so they cannot mount differently.
+class TestCheckingADocument:
+    """The cheap counterpart: has it changed, and may this person still read it.
 
-    Which matters most for what gets *cleared*: a thread that moves to another document,
-    or gives one up, must not keep a file belonging to the previous one.
+    Both questions matter because a conversation persists -- a mounted document may have
+    been edited since, and may have been opened for somebody else in the thread.
     """
 
-    def test_a_document_without_comments_clears_a_previous_one(self) -> None:
-        files = sharepoint.document_files(document(), "https://x/a.docx")
+    def resolving(self, item_or_error: Any) -> Any:
+        if isinstance(item_or_error, BaseException):
+            return patch.object(
+                sharepoint.client, "resolve", AsyncMock(side_effect=item_or_error)
+            )
+        return patch.object(
+            sharepoint.client, "resolve", AsyncMock(return_value=item_or_error)
+        )
 
-        assert files[sharepoint.COMMENTS_DOCUMENT] is None
+    @pytest.mark.asyncio
+    async def test_it_reports_the_name_and_when_it_changed(self) -> None:
+        with self.resolving(
+            {"name": "v3.docx", "lastModifiedDateTime": "2026-08-13T09:00:00Z"}
+        ):
+            result = await call(checker(), "https://x/v3.docx")
 
-    def test_giving_up_a_document_removes_its_source_too(self) -> None:
-        """A source left behind would name a document that is no longer mounted."""
+        assert "v3.docx" in result and "2026-08-13T09:00:00Z" in result
 
-        evicted = sharepoint.evict_document()
+    @pytest.mark.asyncio
+    async def test_it_does_not_download_the_document(self) -> None:
+        """The whole point: metadata only, so it is cheap enough to call every turn."""
 
-        assert set(evicted) == {
-            sharepoint.MAIN_DOCUMENT,
-            sharepoint.COMMENTS_DOCUMENT,
-            sharepoint.DOCUMENT_SOURCE,
-        }
-        assert all(value is None for value in evicted.values())
+        load = AsyncMock()
+        with self.resolving({"name": "v3.docx", "lastModifiedDateTime": "x"}):
+            with patch.object(sharepoint.documents, "load", load):
+                await call(checker(), "https://x/v3.docx")
 
-    def test_everything_a_mount_writes_can_be_unwritten(self) -> None:
-        """The two have to stay in step, or a stale file survives being evicted."""
+        assert load.await_count == 0
 
-        mounted_paths = set(sharepoint.document_files(document(), "https://x/a.docx"))
+    @pytest.mark.asyncio
+    async def test_it_asks_as_the_person_who_asked(self) -> None:
+        """Which is what makes a refusal here mean something about *their* access."""
 
-        assert mounted_paths == set(sharepoint.evict_document())
+        resolve = AsyncMock(return_value={"name": "v3.docx"})
+        with patch.object(sharepoint.client, "resolve", resolve):
+            await call(checker("carlos-token"), "https://x/v3.docx")
+
+        assert resolve.await_args is not None
+        assert resolve.await_args.kwargs["token"] == "carlos-token"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            GraphError("could not find v3.docx: 403"),
+            DocumentNotAllowed("outside the site paths this service may read"),
+        ],
+        ids=["graph refuses this person", "outside the allowlist"],
+    )
+    async def test_a_refusal_comes_back_as_words(self, failure: Exception) -> None:
+        with self.resolving(failure):
+            result = await call(checker(), "https://x/v3.docx")
+
+        assert isinstance(result, str)
+        assert "not allowed" in result or "could not check" in result
+
+    @pytest.mark.asyncio
+    async def test_a_document_with_no_edit_time_still_confirms_access(self) -> None:
+        with self.resolving({"name": "v3.docx"}):
+            result = await call(checker(), "https://x/v3.docx")
+
+        assert "you can read it" in result
 
 
 class TestALinkIsTheOnlyWayIn:
@@ -330,25 +364,23 @@ class TestALinkIsTheOnlyWayIn:
     def test_the_tool_tells_the_model_a_link_is_required(self) -> None:
         """Otherwise the model invents a URL when it is only given a name."""
 
-        assert "no way to look a document up by name" in (
-            opener().description or ""
-        )
+        assert "no way to look a document up by name" in (opener().description or "")
 
 
 class TestWhoseAccessIsUsed:
-    """The token the tool was built with is what limits what a run can read.
+    """The token a tool was built with is what limits what a run can read.
 
-    Under Teams SSO it is the asker's, so Graph refuses a document they cannot open.
-    If it were dropped anywhere between the tool and Graph, every read would silently
-    become the service's -- which is the privilege this whole arrangement removes, and
-    it would fail open rather than closed.
+    Under Teams SSO it is the asker's, so Graph refuses a document they cannot open. If
+    it were dropped anywhere between the tool and Graph, every read would silently become
+    the service's -- which is the privilege this whole arrangement removes, and it would
+    fail open rather than closed.
     """
 
     @pytest.mark.asyncio
     async def test_the_token_reaches_the_loader(self) -> None:
         load = AsyncMock(return_value=document())
         with patch.object(sharepoint.documents, "load", load):
-            await call(opener("carlos-token"), "https://x/a.docx", runtime())
+            await call(opener("carlos-token"), "https://x/a.docx", PATH, runtime())
 
         assert load.await_args is not None
         assert load.await_args.kwargs["token"] == "carlos-token"
@@ -359,8 +391,8 @@ class TestWhoseAccessIsUsed:
 
         load = AsyncMock(return_value=document())
         with patch.object(sharepoint.documents, "load", load):
-            await call(opener("first-user"), "https://x/a.docx", runtime())
-            await call(opener("second-user"), "https://x/a.docx", runtime())
+            await call(opener("first-user"), "https://x/a.docx", PATH, runtime())
+            await call(opener("second-user"), "https://x/a.docx", PATH, runtime())
 
         used = [call_.kwargs["token"] for call_ in load.await_args_list]
         assert used == ["first-user", "second-user"]
@@ -369,12 +401,8 @@ class TestWhoseAccessIsUsed:
     async def test_a_refusal_for_this_user_is_explained_not_retried(self) -> None:
         """Graph answers 403 when the asker cannot open it. That is the check working."""
 
-        with patch.object(
-            sharepoint.documents,
-            "load",
-            AsyncMock(side_effect=GraphError("could not download a.docx: 403")),
-        ):
-            result = await call(opener(), "https://x/a.docx", runtime())
+        with loading(GraphError("could not download a.docx: 403")):
+            result = await call(opener(), "https://x/a.docx", PATH, runtime())
 
         assert isinstance(result, str) and "403" in result
 
@@ -383,8 +411,13 @@ class TestWhoseAccessIsUsed:
 
         assert "as the person who asked" in (opener().description or "")
 
+    def test_the_checker_is_told_a_refusal_is_about_the_asker(self) -> None:
+        """Or a refused check reads as a broken tool rather than an answer."""
 
-class TestTheToolSchema:
+        assert "cannot read it" in (checker().description or "")
+
+
+class TestTheToolSchemas:
     def test_the_runtime_and_the_token_are_hidden_from_the_model(self) -> None:
         """The runtime is injected by LangChain; the token is closed over.
 
@@ -392,11 +425,13 @@ class TestTheToolSchema:
         put in an answer.
         """
 
-        assert list(opener().args) == ["url"]
+        assert list(opener().args) == ["url", "path"]
+        assert list(checker().args) == ["url"]
 
-    def test_the_tool_documents_itself(self) -> None:
+    def test_both_tools_document_themselves(self) -> None:
         """The model picks a tool from its description, so an empty one is a bug."""
 
-        description = opener().description
-        assert description and len(description) > 80
-        assert TOKEN not in description
+        for tool in (opener(), checker()):
+            description = tool.description
+            assert description and len(description) > 80
+            assert TOKEN not in description


### PR DESCRIPTION
Closes [RANDZ-636](https://linear.app/ae-studio/issue/RANDZ-636/teams-thread-awareness-persistence)

## Summary

A Teams question was answered from a blank slate — a fresh agent, a fresh message list, nothing kept. So "and the second one?" was unanswerable, and every question about a document needed the link pasted again.

One Teams thread is now one LangGraph thread, checkpointed in Postgres. The document is deliberately *not* carried across turns; only its link is, and every turn re-reads it from SharePoint as whoever is asking then.

## Motivation

Continuity is the feature. The re-read is what makes it safe and correct, for two reasons that each require it on their own:

- **The document changes.** SharePoint is the source of truth and people keep editing, so a copy mounted last turn can be days stale. Answering confidently from text that has since been rewritten is the worst failure available to this path.
- **A Teams thread is shared.** Whoever asks the follow-up need not be whoever opened the document, and state restored from a checkpoint carries no memory of whose access loaded it. Re-reading **is** the permission check, since Graph applies that person's own access — so a current copy and the right to see it arrive together rather than being two things that could be remembered separately. Without this, persistence would have quietly undone RANDZ-634.

Any failure to re-read gives the document up. Fail-closed on purpose: a 403 and a timeout are indistinguishable from here. The notice to the agent deliberately does not assert the person lacks access, which would sometimes be a confident falsehood about someone's permissions.

## What's Changed

### Backend

- **`lib/agents/checkpointer.py`** (new) — an `AsyncPostgresSaver` over a shared `psycopg_pool`. Restores the module deleted in `52ce7bbb`, which retired the checkpointer from *workflows* — single-shot runs where `state_json` is the source of truth. A conversation is the case a checkpointer is actually for; workflows still compile without one. Its hard-won details are kept: a fresh saver per call over one pool (each saver holds its own `asyncio.Lock`), `autocommit`/`prepare_threshold=0`/`dict_row`, and not `from_conn_string`. Adds an advisory lock around `setup()` — `checkpoint_migrations.v` is a primary key, so on a fresh database two of the four workers can race it and one dies on a duplicate key.
- **`lib/agents/teams_agent.py`** — takes a required `thread_id` that keys both the checkpoint and the Langfuse session, so a conversation is findable in the trace view under what it is stored as. `_document_for_this_turn` re-reads the thread's document as the asker, or gives it up. Two changes follow from persistence rather than being incidental:
  - `SYSTEM_PROMPT` moves out of `messages` into `system_prompt=`. A `SystemMessage` in the message list is checkpointed, so it would be appended again every turn.
  - `response_format` is dropped. It wrapped a single markdown string, which made the model JSON-escape entire reviews into a string literal, and put a Pydantic class in every checkpoint that a future langgraph will refuse to deserialize. `answer_text` reads the messages instead — stopping at the most recent question, so a turn that produced no text cannot re-post the previous turn's answer as a reply to a new one.
- **`lib/agents/tools/sharepoint.py`** — the link is written beside the document at `/main.source`, in the same update that mounts it, so a later turn knows what to re-read and as whom. `document_files` / `evict_document` are shared by the tool and the per-turn re-read so the two cannot mount a document differently. Also fixes a latent bug: a document with no comments now clears a previous one's, instead of leaving `/comments.md` from another file.
- **`lib/api/routers/microsoft/teams.py`** — passes the conversation as the thread id.
- **`lib/api/main.py`** — closes the checkpointer pool on lifespan shutdown.

### Frontend

None.

## Risks and Mitigations

- **No migration, deliberately.** `setup()` owns `checkpoints`, `checkpoint_blobs`, `checkpoint_writes` and `checkpoint_migrations`, and `alembic/env.py` already ignores all four. Verified those are the only tables it creates.
- **Storage.** A 4-turn conversation measured ~21 MB, dominated by `messages` (langgraph copies a whole channel per version, so growth is quadratic in turns). Threads are kept indefinitely by choice. Separately, the checkpoint tables already hold ~30 GB from 66,403 workflow-era threads (2025-11 → 2026-07) left behind by the retirement commit — pre-existing, and worth a cleanup pass.
- **Prompt composition changed.** `system_prompt` now precedes deepagents' base prompt where our instructions used to follow it. Deliberate, but it is a real change to what the model sees.
- **Concurrent turns in one thread** can interleave checkpoint writes; langgraph does not lock a thread. Low likelihood, and the failure is a confused history rather than a leak.
- **A re-read per turn** costs one Graph download (a few seconds on an 82 KB document). That is the price of the two correctness properties above; a first question pays nothing.

## Verification

`778 passed, 3 skipped`; `mypy` clean over 400 files. New tests cover the pool invariants, `answer_text` (including the reach-back case), and the re-read paths — fresh copy, stale copy replaced, refusal, timeout, a new link closing the old document.

Verified against real Postgres rather than only mocks: tables at migration version 9, a checkpoint written and restored with messages and `/main.source` intact, thread isolation, `adelete_thread`, and the extraction run over a real 4-turn conversation reconstructed from the tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)