### PR TITLE
fix(progress): keep per-key locks alive while they are held

### DIFF
--- a/lib/services/keyed_locks.py
+++ b/lib/services/keyed_locks.py
@@ -1,0 +1,50 @@
+"""A registry that hands out one ``asyncio.Lock`` per key.
+
+Serialising work per project / per workflow run needs a lock that every caller
+for the same key can find. Keeping those locks in an ``lru_cache`` bounds memory
+but breaks the guarantee they exist for: an LRU evicts by recency, not by
+whether a lock is currently held, so unrelated keys can push a *held* lock out
+of the cache and the next caller for that key is handed a brand-new lock and
+walks straight into the critical section.
+
+Holding the locks weakly bounds memory the other way round: an entry lives
+exactly as long as somebody is using it (the caller's own reference, plus every
+waiter blocked on it, keeps it alive) and disappears once nobody is.
+
+Callers must therefore keep the lock in a local variable for as long as they
+need it — ``lock = registry.get(key)`` then ``async with lock:`` — which is what
+``async with registry.get(key):`` does anyway.
+"""
+
+import asyncio
+import threading
+import weakref
+from typing import Generic, Hashable, TypeVar
+
+KeyT = TypeVar("KeyT", bound=Hashable)
+
+
+class KeyedLockRegistry(Generic[KeyT]):
+    """Process-wide registry of per-key ``asyncio.Lock`` objects."""
+
+    def __init__(self) -> None:
+        self._locks: weakref.WeakValueDictionary[KeyT, asyncio.Lock] = (
+            weakref.WeakValueDictionary()
+        )
+        # Guards the get-or-create so two callers arriving at the same time
+        # cannot each install a different lock for the same key. The body never
+        # awaits, so this is only ever held for a few instructions.
+        self._guard = threading.Lock()
+
+    def get(self, key: KeyT) -> asyncio.Lock:
+        """Return the lock for ``key``, creating it if nobody holds one."""
+        with self._guard:
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[key] = lock
+            return lock
+
+    def __len__(self) -> int:
+        """Number of locks currently in use (live entries only)."""
+        return len(self._locks)

--- a/lib/services/references.py
+++ b/lib/services/references.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import uuid
 from contextlib import asynccontextmanager
-from functools import lru_cache
 from typing import List, Optional, Tuple, cast
 
 from sqlalchemy import select
@@ -11,6 +10,7 @@ from sqlmodel import col
 from lib.config.database import get_async_db_session
 from lib.models.project import Project
 from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus
+from lib.services.keyed_locks import KeyedLockRegistry
 from lib.services.workflow_runs import (
     create_workflow_run,
     get_project_workflow_run_by_type,
@@ -30,12 +30,15 @@ from lib.workflows.reference_file_matching.state import (
 logger = logging.getLogger(__name__)
 
 
-# Project-level locks to prevent race conditions on concurrent state updates
-# Using LRU cache to limit memory usage - keeps most recently used locks
-@lru_cache(maxsize=128)
+# Project-level locks to prevent race conditions on concurrent state updates.
+# The registry keeps a lock only while it is in use, so memory stays bounded
+# without a lock ever being dropped out from under the caller holding it.
+_project_locks: KeyedLockRegistry[str] = KeyedLockRegistry()
+
+
 def _get_project_lock(project_id: str) -> asyncio.Lock:
-    """Get or create a lock for a specific project (cached with LRU eviction)."""
-    return asyncio.Lock()
+    """Get or create a lock for a specific project."""
+    return _project_locks.get(project_id)
 
 
 @asynccontextmanager

--- a/lib/services/workflow_progress.py
+++ b/lib/services/workflow_progress.py
@@ -4,8 +4,7 @@ import asyncio
 import logging
 import uuid
 from datetime import datetime
-from functools import lru_cache
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,17 +13,21 @@ from sqlmodel import col
 from lib.config.database import get_async_db_session
 from lib.models.workflow_progress import ProgressLevel, WorkflowProgress
 from lib.models.workflow_run import WorkflowRun, WorkflowRunType
+from lib.services.keyed_locks import KeyedLockRegistry
 
 logger = logging.getLogger(__name__)
 
 
-@lru_cache(maxsize=256)
+_progress_locks: KeyedLockRegistry[Tuple[uuid.UUID, str]] = KeyedLockRegistry()
+
+
 def _get_progress_lock(workflow_run_id: uuid.UUID, name: str) -> asyncio.Lock:
     """Get or create a lock for a specific (workflow_run_id, name) combination.
 
-    Uses LRU cache to automatically evict old locks and prevent unbounded memory growth.
+    The registry keeps each lock only while it is in use, which prevents
+    unbounded memory growth without ever evicting a lock somebody is holding.
     """
-    return asyncio.Lock()
+    return _progress_locks.get((workflow_run_id, name))
 
 
 async def create_and_start_progress(

--- a/tests/unit/services/test_keyed_locks.py
+++ b/tests/unit/services/test_keyed_locks.py
@@ -1,0 +1,124 @@
+"""Unit tests for the per-key asyncio lock registry."""
+
+import asyncio
+import gc
+
+import pytest
+
+from lib.services.keyed_locks import KeyedLockRegistry
+
+
+class TestKeyedLockRegistry:
+    """Tests for KeyedLockRegistry."""
+
+    def test_same_key_returns_the_same_lock(self):
+        registry: KeyedLockRegistry[str] = KeyedLockRegistry()
+
+        lock = registry.get("project-1")
+        assert registry.get("project-1") is lock
+
+    def test_different_keys_get_different_locks(self):
+        registry: KeyedLockRegistry[str] = KeyedLockRegistry()
+
+        assert registry.get("project-1") is not registry.get("project-2")
+
+    def test_tuple_keys_are_supported(self):
+        registry: KeyedLockRegistry[tuple[str, int]] = KeyedLockRegistry()
+
+        lock = registry.get(("run", 1))
+        assert registry.get(("run", 1)) is lock
+        assert registry.get(("run", 2)) is not lock
+
+    def test_held_lock_survives_unrelated_traffic(self):
+        """Other keys must never displace a lock its holder is still using."""
+        registry: KeyedLockRegistry[str] = KeyedLockRegistry()
+
+        lock = registry.get("busy-project")
+        for i in range(1000):
+            registry.get(f"other-project-{i}")
+
+        assert registry.get("busy-project") is lock
+
+    def test_unused_locks_are_dropped(self):
+        """Memory stays bounded: entries go away once nobody references them."""
+        registry: KeyedLockRegistry[str] = KeyedLockRegistry()
+
+        for i in range(100):
+            registry.get(f"project-{i}")
+        gc.collect()
+
+        assert len(registry) == 0
+
+    def test_lock_in_use_is_kept(self):
+        registry: KeyedLockRegistry[str] = KeyedLockRegistry()
+
+        held = registry.get("project-1")
+        for i in range(100):
+            registry.get(f"project-other-{i}")
+        gc.collect()
+
+        assert len(registry) == 1
+        assert registry.get("project-1") is held
+
+    @pytest.mark.asyncio
+    async def test_serializes_callers_sharing_a_key(self):
+        registry: KeyedLockRegistry[str] = KeyedLockRegistry()
+        concurrent = 0
+        max_concurrent = 0
+
+        async def critical_section() -> None:
+            nonlocal concurrent, max_concurrent
+            lock = registry.get("project-1")
+            async with lock:
+                concurrent += 1
+                max_concurrent = max(max_concurrent, concurrent)
+                await asyncio.sleep(0)
+                concurrent -= 1
+
+        await asyncio.gather(*(critical_section() for _ in range(5)))
+
+        assert max_concurrent == 1
+
+    @pytest.mark.asyncio
+    async def test_serializes_even_while_other_keys_are_busy(self):
+        """The regression: churn on other keys must not unlock a held key."""
+        registry: KeyedLockRegistry[str] = KeyedLockRegistry()
+        concurrent = 0
+        max_concurrent = 0
+
+        async def critical_section(worker: int) -> None:
+            nonlocal concurrent, max_concurrent
+            lock = registry.get("project-1")
+            async with lock:
+                concurrent += 1
+                max_concurrent = max(max_concurrent, concurrent)
+                # Traffic from other projects arriving mid-update.
+                for i in range(500):
+                    registry.get(f"other-project-{worker}-{i}")
+                await asyncio.sleep(0)
+                concurrent -= 1
+
+        await asyncio.gather(critical_section(1), critical_section(2))
+
+        assert max_concurrent == 1
+
+    @pytest.mark.asyncio
+    async def test_different_keys_run_in_parallel(self):
+        """Serialisation is per key: unrelated keys must not block each other."""
+        registry: KeyedLockRegistry[str] = KeyedLockRegistry()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def first() -> None:
+            lock = registry.get("project-1")
+            async with lock:
+                started.set()
+                await release.wait()
+
+        async def second() -> None:
+            await started.wait()
+            lock = registry.get("project-2")
+            async with lock:
+                release.set()
+
+        await asyncio.wait_for(asyncio.gather(first(), second()), timeout=1)

--- a/tests/unit/services/test_service_lock_registries.py
+++ b/tests/unit/services/test_service_lock_registries.py
@@ -1,0 +1,89 @@
+"""The service-level lock registries must stay exclusive under key churn.
+
+Both registries hand out one lock per key while a critical section reads,
+modifies and writes shared state. Traffic on unrelated keys — other projects,
+other workflow runs — must never let a second caller into the same key's
+critical section.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from lib.services.references import _get_project_lock, _project_lock
+from lib.services.workflow_progress import _get_progress_lock
+
+
+class TestProjectLock:
+    """Tests for the per-project lock used by the reference services."""
+
+    @pytest.mark.asyncio
+    async def test_serializes_while_other_projects_are_busy(self):
+        concurrent = 0
+        max_concurrent = 0
+
+        async def update_reference_state(worker: int) -> None:
+            nonlocal concurrent, max_concurrent
+            async with _project_lock("project-under-test"):
+                concurrent += 1
+                max_concurrent = max(max_concurrent, concurrent)
+                for i in range(500):
+                    _get_project_lock(f"other-project-{worker}-{i}")
+                await asyncio.sleep(0)
+                concurrent -= 1
+
+        await asyncio.gather(update_reference_state(1), update_reference_state(2))
+
+        assert max_concurrent == 1
+
+    @pytest.mark.asyncio
+    async def test_does_not_block_other_projects(self):
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def holder() -> None:
+            async with _project_lock("project-a"):
+                started.set()
+                await release.wait()
+
+        async def other() -> None:
+            await started.wait()
+            async with _project_lock("project-b"):
+                release.set()
+
+        await asyncio.wait_for(asyncio.gather(holder(), other()), timeout=1)
+
+
+class TestProgressLock:
+    """Tests for the per-(workflow run, node name) progress lock."""
+
+    @pytest.mark.asyncio
+    async def test_serializes_while_other_runs_are_busy(self):
+        concurrent = 0
+        max_concurrent = 0
+        workflow_run_id = uuid.uuid4()
+        name = "Extract references"
+
+        async def get_or_create(worker: int) -> None:
+            nonlocal concurrent, max_concurrent
+            lock = _get_progress_lock(workflow_run_id, name)
+            async with lock:
+                concurrent += 1
+                max_concurrent = max(max_concurrent, concurrent)
+                for i in range(500):
+                    _get_progress_lock(uuid.uuid4(), f"node-{worker}-{i}")
+                await asyncio.sleep(0)
+                concurrent -= 1
+
+        await asyncio.gather(get_or_create(1), get_or_create(2))
+
+        assert max_concurrent == 1
+
+    def test_is_scoped_to_run_and_name(self):
+        workflow_run_id = uuid.uuid4()
+        lock = _get_progress_lock(workflow_run_id, "node-a")
+
+        assert _get_progress_lock(workflow_run_id, "node-a") is lock
+        assert _get_progress_lock(workflow_run_id, "node-b") is not lock
+        assert _get_progress_lock(uuid.uuid4(), "node-a") is not lock


### PR DESCRIPTION
This PR proposes keeping the per-project and per-workflow-run locks alive while they are held, so traffic on unrelated keys can no longer evict a lock a coroutine is currently inside. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/360. You can sign in with your GitHub ID to claim ownership of the project.

## What goes wrong today

`lib/services/workflow_progress._get_progress_lock` and `lib/services/references._get_project_lock` both hand out one `asyncio.Lock` per key out of an `lru_cache` (256 and 128 entries). An LRU evicts by recency, not by whether a lock is currently held — so ordinary traffic on other keys can push a *held* lock out of the cache, and the next caller for that same key is handed a brand-new lock and walks straight into the critical section next to the holder.

Both call sites document the guarantee that eviction quietly removes. `get_or_create_progress` says "the lock serializes access so only one coroutine can create/update at a time for a given key", and `_project_lock` says "this ensures that concurrent operations on the same project's reference state are serialized". The critical sections behind them are read-modify-write: `get_or_create_progress` looks for an active row and either increments `total_steps` or inserts one, and `add_file_to_reference` / `remove_file_from_references` rebuild the match list and persist it. Losing exclusion there means duplicate progress rows, or a lost `total_steps` increment so `increment_and_complete_if_done` never reaches the total and the entry stays open — and, on the reference side, a link the user just made being overwritten by a concurrent update.

The progress lock is the exposed one: `@register_node` calls `get_or_create_progress` for **every** node of every workflow, so a busy run churns through its 256 keys quickly, and the fan-out nodes that share a name are exactly the ones that need the lock.

## Reproducing it on `dev` (8af0df12)

Two coroutines share one key; while inside the critical section they touch other keys, as concurrent work on other projects and runs would. Save as `repro_lock.py` at the repo root and run `uv run python repro_lock.py`:

```python
import asyncio
import uuid

from lib.services.references import _get_project_lock, _project_lock
from lib.services.workflow_progress import _get_progress_lock

async def project_lock_repro() -> int:
    concurrent = max_concurrent = 0
    async def op(n: int) -> None:
        nonlocal concurrent, max_concurrent
        async with _project_lock("same-project"):
            concurrent += 1
            max_concurrent = max(max_concurrent, concurrent)
            for i in range(200):
                _get_project_lock(f"other-project-{n}-{i}")
            await asyncio.sleep(0)
            concurrent -= 1
    await asyncio.gather(op(1), op(2))
    return max_concurrent

async def progress_lock_repro() -> int:
    concurrent = max_concurrent = 0
    run_id, name = uuid.uuid4(), "Extract references"
    async def op(n: int) -> None:
        nonlocal concurrent, max_concurrent
        lock = _get_progress_lock(run_id, name)
        async with lock:
            concurrent += 1
            max_concurrent = max(max_concurrent, concurrent)
            for i in range(300):
                _get_progress_lock(uuid.uuid4(), f"node-{n}-{i}")
            await asyncio.sleep(0)
            concurrent -= 1
    await asyncio.gather(op(1), op(2))
    return max_concurrent

async def main() -> None:
    print("references._project_lock       : max coroutines inside =", await project_lock_repro())
    print("workflow_progress progress lock: max coroutines inside =", await progress_lock_repro())

asyncio.run(main())
```

On `dev` both critical sections admit two coroutines at once:

```
references._project_lock       : max coroutines inside = 2
workflow_progress progress lock: max coroutines inside = 2
```

## The change

`lib/services/keyed_locks.py` adds a small `KeyedLockRegistry` that holds its locks weakly: an entry lives exactly as long as somebody is using it — the holder's own reference plus every waiter blocked on it — and is dropped as soon as nobody is. That bounds memory the way the LRU was meant to, without a lock ever being taken away from the caller inside it. The get-or-create is guarded by a `threading.Lock` (no awaits in the body) so two callers arriving together cannot install different locks for the same key, which is the one thing `lru_cache` did give you.

The two call sites keep their names and signatures, so nothing else changes: `_get_project_lock(project_id)` and `_get_progress_lock(workflow_run_id, name)` still return the lock for that key, and callers still bind it to a local before `async with`, which is what keeps the entry alive. The registry follows the shape `lib/services/postgres_rate_limiter._get_bucket_lock` already uses for its per-bucket locks. Worth stating plainly: this is in-process exclusion, exactly as before — serialising across web workers would need the database, and is not what this changes.

## Verification

`tests/unit/services/test_service_lock_registries.py` exercises both call sites under the churn above, and fails on the current tree:

```
FAILED tests/unit/services/test_service_lock_registries.py::TestProgressLock::test_serializes_while_other_runs_are_busy
FAILED tests/unit/services/test_service_lock_registries.py::TestProjectLock::test_serializes_while_other_projects_are_busy
2 failed, 2 passed
```

With the fix applied, all four pass, alongside `tests/unit/services/test_keyed_locks.py` covering the registry itself: same lock per key, distinct locks per key, a held lock surviving a thousand other keys, unused entries dropped after `gc.collect()`, mutual exclusion, and — the property worth protecting — two different keys still running in parallel rather than serialising behind one another.

Full `tests/unit` before the change: `788 passed, 3 skipped`. After: `801 passed, 3 skipped` — the 13 added tests, no new failures. `uv run mypy .` reports `Success: no issues found in 403 source files`. Only the lines this PR touches were formatted, so the `black` job sees nothing else.

## How this was managed

This work was tracked as a story on a board imported from this repository's own issues and pull requests: [Keep per-key locks alive while they are held](https://eastagiletracker.com/projects/360/stories/221219), on the board at https://eastagiletracker.com/projects/360 (653 stories imported, with 5 labels).

![board](https://raw.githubusercontent.com/eastagiletracker/draft-detective/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
