### PR TITLE
feat(analysis-wizard): pre-select recommended assessments and compact the picker (RANDZ-643)

### DIFF
--- a/frontend/app/(authenticated)/new/page.tsx
+++ b/frontend/app/(authenticated)/new/page.tsx
@@ -33,7 +33,9 @@ function WizardContent() {
   // When REQUIRE_API_KEY_CONFIG is true, wizard steps are offset by 1 in the indicator.
   const currentIndicatorStep = isOnApiKeyStep ? 1 : wizard.currentStep + (REQUIRE_API_KEY_CONFIG ? 1 : 0);
 
-  const cardWidthClass = 'max-w-3xl';
+  // The assessment picker lists every category with per-assessment descriptions and
+  // run-time estimates, so it gets more room than the single-file upload step.
+  const cardWidthClass = !isOnApiKeyStep && wizard.currentStep === 2 ? 'max-w-5xl' : 'max-w-3xl';
 
   // Guard against hydration mismatch: the server renders with no user data while the
   // client immediately begins fetching (isLoading differs between SSR and first client
@@ -50,7 +52,7 @@ function WizardContent() {
     <div className="space-y-8">
       <StepIndicator currentStep={currentIndicatorStep} steps={steps} className="mb-8" />
 
-      <Card className={`${cardWidthClass} mx-auto transition-all duration-300`}>
+      <Card className={`${cardWidthClass} mx-auto`}>
         <CardContent className="">
           {isOnApiKeyStep && <StepApiKeyConfig />}
           {!isOnApiKeyStep && wizard.currentStep === 1 && <StepUpload onComplete={wizard.nextStep} />}

--- a/frontend/components/analysis-wizard/wizard-context.tsx
+++ b/frontend/components/analysis-wizard/wizard-context.tsx
@@ -2,7 +2,8 @@
 
 import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react';
 import { WorkflowRunType } from '@/lib/generated-api';
-import { hasSupportingDocumentsRequirement } from '@/components/workflows/utils';
+import { DEFAULT_SELECTED_WORKFLOW_TYPES, hasSupportingDocumentsRequirement } from '@/components/workflows/utils';
+import { useVisibleWorkflowTypes } from '@/lib/hooks/use-visible-workflow-types';
 
 export type PreflightStatus = 'idle' | 'pending' | 'valid' | 'invalid';
 export type WizardStep = 1 | 2;
@@ -37,7 +38,19 @@ export function WizardProvider({ children }: WizardProviderProps) {
   const [preflightStatus, setPreflightStatusState] = useState<WizardState['preflightStatus']>({
     format: 'idle',
   });
-  const [selectedWorkflowTypes, setSelectedWorkflowTypes] = useState<WorkflowRunType[]>([]);
+  // `null` means the user has not touched the assessment checkboxes yet, so the
+  // recommended default set applies. An explicit array — including an empty one,
+  // after unchecking everything — always wins.
+  const [chosenWorkflowTypes, setSelectedWorkflowTypes] = useState<WorkflowRunType[] | null>(null);
+  const { visibleTypes } = useVisibleWorkflowTypes();
+
+  // Intersected with what is actually on offer: an assessment that is hidden for
+  // this user (experimental, opt-in only) must never be started from a checkbox
+  // they cannot see or uncheck.
+  const selectedWorkflowTypes = useMemo(
+    () => chosenWorkflowTypes ?? DEFAULT_SELECTED_WORKFLOW_TYPES.filter((type) => visibleTypes.includes(type)),
+    [chosenWorkflowTypes, visibleTypes],
+  );
 
   const needsReferencesStep = useMemo(
     () => hasSupportingDocumentsRequirement(selectedWorkflowTypes),

--- a/frontend/components/workflows/utils.ts
+++ b/frontend/components/workflows/utils.ts
@@ -62,3 +62,19 @@ export function formatEstimatedDuration(seconds: number | null | undefined): str
   const rounded = hours < 10 ? Math.round(hours * 10) / 10 : Math.round(hours);
   return `~${rounded} hr`;
 }
+
+/**
+ * Assessments pre-selected when a project is created, so the wizard opens on a
+ * sensible default instead of an empty selection. The user can uncheck any of
+ * them.
+ *
+ * Callers must intersect this with the assessments actually on offer (see
+ * `useVisibleWorkflowTypes`) — an experimental assessment listed here is hidden
+ * for users who have not opted in, and pre-selecting a hidden checkbox would
+ * start a workflow the user cannot see or uncheck.
+ */
+export const DEFAULT_SELECTED_WORKFLOW_TYPES: WorkflowRunType[] = [
+  WorkflowRunType.ReferenceValidationV2,
+  WorkflowRunType.AdvocacyToneV2,
+  WorkflowRunType.RecommendationCheck,
+];

--- a/frontend/components/workflows/workflow-config-dialog.tsx
+++ b/frontend/components/workflows/workflow-config-dialog.tsx
@@ -88,7 +88,9 @@ export function WorkflowConfigDialog({ isOpen, type, projectId, onConfirm, onCan
 
   return (
     <Dialog open={isOpen} onOpenChange={onCancel}>
-      <DialogContent className="min-w-2xl max-h-[90vh] overflow-y-auto">
+      {/* Wide enough for the two-column assessment grid this dialog renders when
+          no specific `type` is given. */}
+      <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Start Workflow</DialogTitle>
           <DialogDescription>Please select the workflow configuration to start.</DialogDescription>

--- a/frontend/components/workflows/workflow-type-checkbox.tsx
+++ b/frontend/components/workflows/workflow-type-checkbox.tsx
@@ -108,13 +108,13 @@ export function WorkflowTypeCheckbox({
     <label
       htmlFor={workflowType.type}
       className={cn(
-        'group rounded-xl p-4 cursor-pointer transition-all block border',
+        'group rounded-xl p-3 cursor-pointer transition-all block border h-full',
         'hover:bg-accent/50 hover:border-accent',
         checked ? 'border-primary bg-primary/5' : 'border-border',
         disabled && 'cursor-not-allowed opacity-50',
       )}
     >
-      <div className="flex gap-4">
+      <div className="flex gap-3">
         <div
           className={cn(
             'flex items-center justify-center size-8 rounded-lg shrink-0 transition-colors',
@@ -124,7 +124,7 @@ export function WorkflowTypeCheckbox({
           <Icon className="size-4" />
         </div>
 
-        <div className="flex-1 min-w-0 space-y-1.5">
+        <div className="flex-1 min-w-0 space-y-1">
           <div className="flex items-start justify-between gap-3">
             <span className={cn('text-sm font-medium leading-tight', disabled && 'opacity-70')}>
               {workflowType.name}
@@ -153,9 +153,8 @@ export function WorkflowTypeCheckbox({
           {(estimatedDuration ||
             workflowType.is_experimental ||
             workflowType.needs_web_search ||
-            requiresSupportingFiles ||
-            workflowType.is_qa_screener) && (
-            <div className="flex flex-wrap items-center gap-2 pt-1">
+            requiresSupportingFiles) && (
+            <div className="flex flex-wrap items-center gap-1.5 pt-0.5">
               {estimatedDuration && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -166,21 +165,7 @@ export function WorkflowTypeCheckbox({
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
                     Rough estimate based on how long this assessment has taken on past documents. Actual time varies
-                    with document size and current load.
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {workflowType.is_qa_screener && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Badge variant="default" className="flex items-center gap-1 text-xs bg-blue-600 hover:bg-blue-700">
-                      <ShieldCheck className="size-3" />
-                      QA Screener
-                    </Badge>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="max-w-xs">
-                    This assessment is part of the QA Screener tool, designed for quality assurance screening of
-                    documents.
+                    with document size and current system load.
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/frontend/components/workflows/workflow-type-selector.tsx
+++ b/frontend/components/workflows/workflow-type-selector.tsx
@@ -7,7 +7,6 @@ import { useWorkflowDurationEstimates } from '@/lib/hooks/use-workflow-duration-
 import { Button } from '@/components/ui/button';
 import { WorkflowTypeCheckbox } from './workflow-type-checkbox';
 import { useVisibleWorkflowTypes } from '@/lib/hooks/use-visible-workflow-types';
-import { useExperimentalFeatures } from '@/context/experimental-features-context';
 
 interface WorkflowTypeSelectorProps {
   /** When set, only this workflow type is listed (e.g. config dialog for a specific analysis). */
@@ -36,7 +35,6 @@ export function WorkflowTypeSelector({
 }: WorkflowTypeSelectorProps) {
   const { workflowTypes: allTypes, isPending: isLoadingWorkflowTypes } = useWorkflowTypes();
   const { getEstimatedSeconds } = useWorkflowDurationEstimates(projectId);
-  const { showExperimentalFeatures } = useExperimentalFeatures();
   const { visibleGroups: allVisibleGroups } = useVisibleWorkflowTypes();
 
   const workflowTypes = useMemo(() => {
@@ -46,12 +44,23 @@ export function WorkflowTypeSelector({
     return allTypes.filter((wt) => !wt.is_internal);
   }, [allTypes, restrictToType]);
 
-  // Memoised so the bulk-action lists below get a stable reference to depend on.
+  // Memoised so the derived lists below get a stable reference to depend on.
   const visibleGroups = useMemo(() => (restrictToType ? [] : allVisibleGroups), [restrictToType, allVisibleGroups]);
 
-  const visibleCount = restrictToType
-    ? workflowTypes.filter((wt) => !wt.is_experimental || showExperimentalFeatures).length
-    : visibleGroups.reduce((total, group) => total + group.workflows.length, 0);
+  // Exactly the checkboxes the render path below produces. The header count and
+  // the bulk actions both work off this, so neither can drift from what is on
+  // screen — `selectedTypes` may legitimately hold types this picker does not
+  // list, and counting those would show nonsense like "12/11 selected".
+  const renderedTypes = useMemo(
+    () =>
+      restrictToType
+        ? workflowTypes.map((wt) => wt.type)
+        : visibleGroups.flatMap((group) => group.workflows.map((wt) => wt.type)),
+    [restrictToType, workflowTypes, visibleGroups],
+  );
+
+  const visibleCount = renderedTypes.length;
+  const selectedVisibleCount = renderedTypes.filter((type) => selectedTypes.includes(type)).length;
 
   const handleCheckedChange = (type: WorkflowRunType, checked: boolean) => {
     if (checked) {
@@ -65,11 +74,8 @@ export function WorkflowTypeSelector({
   // Anything else already in `selectedTypes` is left alone, so a caller that
   // seeds the selection with a type this list does not offer keeps it.
   const bulkSelectableTypes = useMemo(
-    () =>
-      visibleGroups.flatMap((group) =>
-        group.workflows.map((wt) => wt.type).filter((type) => !disabledTypes.includes(type)),
-      ),
-    [visibleGroups, disabledTypes],
+    () => renderedTypes.filter((type) => !disabledTypes.includes(type)),
+    [renderedTypes, disabledTypes],
   );
 
   const selectedBulkCount = bulkSelectableTypes.filter((type) => selectedTypes.includes(type)).length;
@@ -104,7 +110,7 @@ export function WorkflowTypeSelector({
               Assessment Type Selection{' '}
               {visibleCount > 0 && (
                 <span className="text-sm font-normal text-muted-foreground">
-                  ({selectedTypes.length}/{visibleCount} selected)
+                  ({selectedVisibleCount}/{visibleCount} selected)
                 </span>
               )}
               <span className="text-destructive ml-1">*</span>

--- a/frontend/components/workflows/workflow-type-selector.tsx
+++ b/frontend/components/workflows/workflow-type-selector.tsx
@@ -4,7 +4,9 @@ import { useMemo } from 'react';
 import { WorkflowRunType, WorkflowTypeDescription } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { useWorkflowDurationEstimates } from '@/lib/hooks/use-workflow-duration-estimates';
+import { Button } from '@/components/ui/button';
 import { WorkflowTypeCheckbox } from './workflow-type-checkbox';
+import { useVisibleWorkflowTypes } from '@/lib/hooks/use-visible-workflow-types';
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
 
 interface WorkflowTypeSelectorProps {
@@ -32,9 +34,10 @@ export function WorkflowTypeSelector({
   headerDescription,
   error,
 }: WorkflowTypeSelectorProps) {
-  const { workflowTypes: allTypes, categories, isPending: isLoadingWorkflowTypes } = useWorkflowTypes();
+  const { workflowTypes: allTypes, isPending: isLoadingWorkflowTypes } = useWorkflowTypes();
   const { getEstimatedSeconds } = useWorkflowDurationEstimates(projectId);
   const { showExperimentalFeatures } = useExperimentalFeatures();
+  const { visibleGroups: allVisibleGroups } = useVisibleWorkflowTypes();
 
   const workflowTypes = useMemo(() => {
     if (restrictToType) {
@@ -43,27 +46,11 @@ export function WorkflowTypeSelector({
     return allTypes.filter((wt) => !wt.is_internal);
   }, [allTypes, restrictToType]);
 
-  const experimentalVisible = showExperimentalFeatures;
-  const typeMap = useMemo(() => new Map(workflowTypes.map((wt) => [wt.type, wt])), [workflowTypes]);
-
-  // Category membership is what decides whether a workflow is on offer here:
-  // anything absent from every category (the peer-review workflows, which are
-  // started from their own tab) is not shown and not counted.
-  const visibleGroups = useMemo(() => {
-    if (restrictToType) return [];
-    return categories
-      .map((category) => ({
-        category,
-        workflows: category.workflows
-          .map((type) => typeMap.get(type as WorkflowRunType))
-          .filter((wt): wt is WorkflowTypeDescription => wt !== undefined)
-          .filter((wt) => experimentalVisible || !wt.is_experimental),
-      }))
-      .filter((group) => group.workflows.length > 0);
-  }, [categories, typeMap, experimentalVisible, restrictToType]);
+  // Memoised so the bulk-action lists below get a stable reference to depend on.
+  const visibleGroups = useMemo(() => (restrictToType ? [] : allVisibleGroups), [restrictToType, allVisibleGroups]);
 
   const visibleCount = restrictToType
-    ? workflowTypes.filter((wt) => !wt.is_experimental || experimentalVisible).length
+    ? workflowTypes.filter((wt) => !wt.is_experimental || showExperimentalFeatures).length
     : visibleGroups.reduce((total, group) => total + group.workflows.length, 0);
 
   const handleCheckedChange = (type: WorkflowRunType, checked: boolean) => {
@@ -72,6 +59,27 @@ export function WorkflowTypeSelector({
     } else {
       onSelectionChange(selectedTypes.filter((t) => t !== type));
     }
+  };
+
+  // Bulk actions only ever touch the checkboxes actually on screen and enabled.
+  // Anything else already in `selectedTypes` is left alone, so a caller that
+  // seeds the selection with a type this list does not offer keeps it.
+  const bulkSelectableTypes = useMemo(
+    () =>
+      visibleGroups.flatMap((group) =>
+        group.workflows.map((wt) => wt.type).filter((type) => !disabledTypes.includes(type)),
+      ),
+    [visibleGroups, disabledTypes],
+  );
+
+  const selectedBulkCount = bulkSelectableTypes.filter((type) => selectedTypes.includes(type)).length;
+
+  const handleSelectAll = () => {
+    onSelectionChange([...selectedTypes, ...bulkSelectableTypes.filter((type) => !selectedTypes.includes(type))]);
+  };
+
+  const handleDeselectAll = () => {
+    onSelectionChange(selectedTypes.filter((type) => !bulkSelectableTypes.includes(type)));
   };
 
   const renderCheckbox = (workflowType: WorkflowTypeDescription) => (
@@ -90,20 +98,45 @@ export function WorkflowTypeSelector({
   return (
     <div className="space-y-4">
       {showHeader && (
-        <div className="space-y-1">
-          <h2 className="text-lg font-semibold">
-            Assessment Type Selection{' '}
-            {visibleCount > 0 && (
-              <span className="text-sm font-normal text-muted-foreground">
-                ({selectedTypes.length}/{visibleCount} selected)
-              </span>
-            )}
-            <span className="text-destructive ml-1">*</span>
-          </h2>
-          {headerDescription && <p className="text-sm text-muted-foreground">{headerDescription}</p>}
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">
+              Assessment Type Selection{' '}
+              {visibleCount > 0 && (
+                <span className="text-sm font-normal text-muted-foreground">
+                  ({selectedTypes.length}/{visibleCount} selected)
+                </span>
+              )}
+              <span className="text-destructive ml-1">*</span>
+            </h2>
+            {headerDescription && <p className="text-sm text-muted-foreground">{headerDescription}</p>}
+          </div>
+
+          {bulkSelectableTypes.length > 1 && (
+            <div className="flex shrink-0 items-center gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                onClick={handleSelectAll}
+                disabled={controlsDisabled || selectedBulkCount === bulkSelectableTypes.length}
+              >
+                Select all
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                onClick={handleDeselectAll}
+                disabled={controlsDisabled || selectedBulkCount === 0}
+              >
+                Deselect all
+              </Button>
+            </div>
+          )}
         </div>
       )}
-      <div className="space-y-2">
+      <div className="space-y-3">
         {isLoadingWorkflowTypes ? (
           <p className="text-sm text-muted-foreground">Loading available workflows...</p>
         ) : restrictToType !== undefined ? (
@@ -118,7 +151,9 @@ export function WorkflowTypeSelector({
           visibleGroups.map(({ category, workflows }) => (
             <div key={category.slug} className="space-y-2">
               <h3 className="text-sm font-semibold text-foreground pt-2">{category.label}</h3>
-              {workflows.map(renderCheckbox)}
+              {/* Two-up on wide viewports: the picker lists a dozen assessments and a
+                  single column made the step an unreasonably long scroll. */}
+              <div className="grid gap-2 sm:grid-cols-2">{workflows.map(renderCheckbox)}</div>
             </div>
           ))
         )}

--- a/frontend/lib/generated-api/index.ts
+++ b/frontend/lib/generated-api/index.ts
@@ -3,6 +3,7 @@
 export {
   appendMessageApiChatThreadsThreadIdMessagesPost,
   approveWorkflowRunApiWorkflowRunsWorkflowRunIdApprovePost,
+  botMessagesApiMicrosoftTeamsMessagesPost,
   cancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPost,
   checkPreflightApiPreflightPost,
   coreHeadRouteTusUuidHead,
@@ -101,6 +102,10 @@ export {
   type BibliographyItemValidation,
   type BibliographyItemValidationV2,
   type BodyStartAnalysisApiStartAnalysisPost,
+  type BotMessagesApiMicrosoftTeamsMessagesPostData,
+  type BotMessagesApiMicrosoftTeamsMessagesPostError,
+  type BotMessagesApiMicrosoftTeamsMessagesPostErrors,
+  type BotMessagesApiMicrosoftTeamsMessagesPostResponses,
   type CancelWorkflowResponse,
   type CancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPostData,
   type CancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPostError,

--- a/frontend/lib/generated-api/sdk.gen.ts
+++ b/frontend/lib/generated-api/sdk.gen.ts
@@ -16,6 +16,9 @@ import type {
   ApproveWorkflowRunApiWorkflowRunsWorkflowRunIdApprovePostData,
   ApproveWorkflowRunApiWorkflowRunsWorkflowRunIdApprovePostErrors,
   ApproveWorkflowRunApiWorkflowRunsWorkflowRunIdApprovePostResponses,
+  BotMessagesApiMicrosoftTeamsMessagesPostData,
+  BotMessagesApiMicrosoftTeamsMessagesPostErrors,
+  BotMessagesApiMicrosoftTeamsMessagesPostResponses,
   CancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPostData,
   CancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPostErrors,
   CancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPostResponses,
@@ -729,16 +732,13 @@ export const cancelWorkflowRunEndpointApiWorkflowRunsWorkflowRunIdCancelPost = <
 /**
  * Get Workflow Types
  *
- * List available workflow types and ordered category display config based on user permissions.
- *
- * QA Screener workflows are only visible to RAND and ADMIN roles.
+ * List available workflow types and the ordered category display config.
  */
 export const getWorkflowTypesApiWorkflowTypesGet = <ThrowOnError extends boolean = true>(
   options?: Options<GetWorkflowTypesApiWorkflowTypesGetData, ThrowOnError>,
 ): RequestResult<GetWorkflowTypesApiWorkflowTypesGetResponses, unknown, ThrowOnError, 'data'> =>
   (options?.client ?? client).get<GetWorkflowTypesApiWorkflowTypesGetResponses, unknown, ThrowOnError, 'data'>({
     responseStyle: 'data',
-    security: [{ scheme: 'bearer', type: 'http' }],
     url: '/api/workflow-types',
     ...options,
   });
@@ -1779,4 +1779,35 @@ export const setApiKeyApiUsersMeApiKeyPut = <ThrowOnError extends boolean = true
       'Content-Type': 'application/json',
       ...options.headers,
     },
+  });
+
+/**
+ * Bot Messages
+ *
+ * The bot's messaging endpoint, called by the Bot Connector.
+ *
+ * The turn acknowledges and ends; the answer follows about a minute later into
+ * the same thread. Keeping the request short is what lets Teams show a reply
+ * immediately instead of waiting on the model.
+ *
+ * Outside ``get_current_user``: the Bot Connector presents its own token, which
+ * the Agents SDK validates. That token is the authentication.
+ */
+export const botMessagesApiMicrosoftTeamsMessagesPost = <ThrowOnError extends boolean = true>(
+  options?: Options<BotMessagesApiMicrosoftTeamsMessagesPostData, ThrowOnError>,
+): RequestResult<
+  BotMessagesApiMicrosoftTeamsMessagesPostResponses,
+  BotMessagesApiMicrosoftTeamsMessagesPostErrors,
+  ThrowOnError,
+  'data'
+> =>
+  (options?.client ?? client).post<
+    BotMessagesApiMicrosoftTeamsMessagesPostResponses,
+    BotMessagesApiMicrosoftTeamsMessagesPostErrors,
+    ThrowOnError,
+    'data'
+  >({
+    responseStyle: 'data',
+    url: '/api/microsoft/teams/messages',
+    ...options,
   });

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -5995,10 +5995,6 @@ export type WorkflowTypeDescription = {
    */
   is_internal: boolean;
   /**
-   * Is Qa Screener
-   */
-  is_qa_screener: boolean;
-  /**
    * Category
    */
   category: string;
@@ -8225,3 +8221,33 @@ export type SetApiKeyApiUsersMeApiKeyPutResponses = {
 
 export type SetApiKeyApiUsersMeApiKeyPutResponse =
   SetApiKeyApiUsersMeApiKeyPutResponses[keyof SetApiKeyApiUsersMeApiKeyPutResponses];
+
+export type BotMessagesApiMicrosoftTeamsMessagesPostData = {
+  body?: never;
+  headers?: {
+    /**
+     * Authorization
+     */
+    authorization?: string | null;
+  };
+  path?: never;
+  query?: never;
+  url: '/api/microsoft/teams/messages';
+};
+
+export type BotMessagesApiMicrosoftTeamsMessagesPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type BotMessagesApiMicrosoftTeamsMessagesPostError =
+  BotMessagesApiMicrosoftTeamsMessagesPostErrors[keyof BotMessagesApiMicrosoftTeamsMessagesPostErrors];
+
+export type BotMessagesApiMicrosoftTeamsMessagesPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: unknown;
+};

--- a/frontend/lib/hooks/use-visible-workflow-types.ts
+++ b/frontend/lib/hooks/use-visible-workflow-types.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { WorkflowCategoryOrder, WorkflowRunType, WorkflowTypeDescription } from '@/lib/generated-api';
+import { useWorkflowTypes } from './use-workflow-types';
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
+
+export interface VisibleWorkflowGroup {
+  category: WorkflowCategoryOrder;
+  workflows: WorkflowTypeDescription[];
+}
+
+/**
+ * The assessments on offer in the picker, grouped by category.
+ *
+ * Category membership is what decides whether a workflow is on offer:
+ * anything absent from every category (the peer-review workflows, which are
+ * started from their own tab) is not listed and not counted. Internal
+ * workflows, and experimental ones for users who have not opted in, are
+ * filtered out as well.
+ */
+export function useVisibleWorkflowTypes() {
+  const { workflowTypes: allTypes, categories, isPending } = useWorkflowTypes();
+  const { showExperimentalFeatures } = useExperimentalFeatures();
+
+  const typeMap = useMemo(
+    () => new Map(allTypes.filter((wt) => !wt.is_internal).map((wt) => [wt.type, wt])),
+    [allTypes],
+  );
+
+  const visibleGroups = useMemo<VisibleWorkflowGroup[]>(
+    () =>
+      categories
+        .map((category) => ({
+          category,
+          workflows: category.workflows
+            .map((type) => typeMap.get(type as WorkflowRunType))
+            .filter((wt): wt is WorkflowTypeDescription => wt !== undefined)
+            .filter((wt) => showExperimentalFeatures || !wt.is_experimental),
+        }))
+        .filter((group) => group.workflows.length > 0),
+    [categories, typeMap, showExperimentalFeatures],
+  );
+
+  const visibleTypes = useMemo<WorkflowRunType[]>(
+    () => visibleGroups.flatMap((group) => group.workflows.map((wt) => wt.type)),
+    [visibleGroups],
+  );
+
+  return { visibleGroups, visibleTypes, isPending };
+}

--- a/lib/api/mcp/tools/workflow_types.py
+++ b/lib/api/mcp/tools/workflow_types.py
@@ -4,7 +4,7 @@ from mcp.types import ToolAnnotations
 
 from lib.api.mcp import helpers
 from lib.api.mcp.instance import mcp
-from lib.services.workflow_types import get_workflow_types_for_user
+from lib.services.workflow_types import get_all_workflow_types
 
 
 @mcp.tool(
@@ -25,5 +25,8 @@ async def list_workflow_types(token: AccessToken = CurrentAccessToken()) -> str:
     categories: ordered list of categories, each with an ordered list of workflow type slugs
     that belong to it — use this to understand grouping and display order.
     """
-    user = await helpers.resolve_user(token)
-    return get_workflow_types_for_user(user).model_dump_json()
+    # The listing is the same for every caller, but resolving the user still
+    # validates the token's identity claims (and provisions the account on a
+    # first call), which is the behaviour every other tool relies on.
+    await helpers.resolve_user(token)
+    return get_all_workflow_types().model_dump_json()

--- a/lib/api/routers/workflow_types.py
+++ b/lib/api/routers/workflow_types.py
@@ -11,7 +11,7 @@ from lib.services.workflow_duration_estimates import (
 )
 from lib.services.workflow_types import (
     WorkflowTypesResponse,
-    get_workflow_types_for_user,
+    get_all_workflow_types,
 )
 
 router = APIRouter(tags=["workflow-types"])
@@ -31,13 +31,9 @@ async def _cached_duration_estimates(
 
 
 @router.get("/api/workflow-types", response_model=WorkflowTypesResponse)
-async def get_workflow_types(user: Optional[User] = Depends(get_current_user_optional)):
-    """
-    List available workflow types and ordered category display config based on user permissions.
-
-    QA Screener workflows are only visible to RAND and ADMIN roles.
-    """
-    return get_workflow_types_for_user(user)
+async def get_workflow_types():
+    """List available workflow types and the ordered category display config."""
+    return get_all_workflow_types()
 
 
 @router.get(

--- a/lib/services/workflow_types.py
+++ b/lib/services/workflow_types.py
@@ -1,6 +1,6 @@
 """Service layer for workflow types."""
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 

--- a/lib/services/workflow_types.py
+++ b/lib/services/workflow_types.py
@@ -1,19 +1,15 @@
 """Service layer for workflow types."""
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List
 
 from pydantic import BaseModel
 
-from lib.models.user import User, UserRole
 from lib.workflows.categories import WORKFLOW_DISPLAY_CONFIG
-from lib.workflows.manifest import QA_SCREENER_WORKFLOWS
 from lib.workflows.models import WorkflowRunType
 from lib.workflows.registry import get_all_manifests
 
 if TYPE_CHECKING:
     from lib.workflows.manifest import WorkflowManifest
-
-QA_SCREENER_ALLOWED_ROLES = {UserRole.ADMIN, UserRole.RAND}
 
 # Derived map: workflow type → category slug, built once from WORKFLOW_DISPLAY_CONFIG.
 _WORKFLOW_CATEGORY_MAP: dict[WorkflowRunType, str] = {
@@ -32,7 +28,6 @@ class WorkflowTypeDescription(BaseModel):
     needs_web_search: bool
     is_experimental: bool
     is_internal: bool
-    is_qa_screener: bool
     category: str
 
     @classmethod
@@ -57,30 +52,18 @@ class WorkflowTypesResponse(BaseModel):
     categories: list[WorkflowCategoryOrder]
 
 
-def can_user_see_qa_screener(user: Optional[User]) -> bool:
-    """Check if a user can see QA Screener workflows."""
-    return user is not None and user.role in QA_SCREENER_ALLOWED_ROLES
+def get_all_workflow_types() -> WorkflowTypesResponse:
+    """Get all workflow types and the ordered category display config.
 
-
-def get_workflow_types_for_user(user: Optional[User]) -> WorkflowTypesResponse:
-    """Get all workflow types and ordered category config visible to a user.
-
-    Filters out QA Screener workflows for users without RAND or ADMIN role.
+    The listing is the same for every caller; experimental workflows are hidden
+    client-side based on the user's own preference, not filtered here.
     """
-    can_see_qa_screener = can_user_see_qa_screener(user)
-    hidden_types = set() if can_see_qa_screener else QA_SCREENER_WORKFLOWS
-
     workflow_types = [
         WorkflowTypeDescription.from_manifest(manifest)
         for manifest in get_all_manifests().values()
-        if manifest.type not in hidden_types
     ]
     categories = [
-        WorkflowCategoryOrder(
-            slug=cat.slug,
-            label=cat.label,
-            workflows=[wf for wf in cat.workflows if wf not in hidden_types],
-        )
+        WorkflowCategoryOrder(slug=cat.slug, label=cat.label, workflows=cat.workflows)
         for cat in WORKFLOW_DISPLAY_CONFIG
     ]
 

--- a/lib/workflows/manifest.py
+++ b/lib/workflows/manifest.py
@@ -15,12 +15,6 @@ from lib.workflows.workflow_types import WorkflowState
 WorkflowStateType = TypeVar("WorkflowStateType", bound=BaseWorkflowState)
 WorkflowConfigType = TypeVar("WorkflowConfigType", bound=BaseWorkflowConfig)
 
-# QA Screener workflows - only visible to RAND and ADMIN roles
-QA_SCREENER_WORKFLOWS = {
-    WorkflowRunType.ADVOCACY_TONE,
-    WorkflowRunType.ABOUT_THIS_GER,
-}
-
 
 class WorkflowManifest[WorkflowStateType, WorkflowConfigType](ABC):
     """Base class for workflow manifests."""
@@ -66,11 +60,6 @@ class WorkflowManifest[WorkflowStateType, WorkflowConfigType](ABC):
     # workflows that fan out heavy per-item LLM calls (e.g. one web-search
     # agent per reference) to stay under provider rate limits.
     max_concurrency: int = env_config.LANGGRAPH_MAX_CONCURRENCY
-
-    @property
-    def is_qa_screener(self) -> bool:
-        """Whether the workflow is part of the QA Screener tool."""
-        return self.type in QA_SCREENER_WORKFLOWS
 
     # List of workflow types that this workflow depends on.
     # Used to determine the order in which the workflows should be run.

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -210,7 +210,6 @@ async def test_list_workflow_types_entry_has_expected_fields(authed_mcp_client: 
         "needs_web_search",
         "is_experimental",
         "is_internal",
-        "is_qa_screener",
         "category",
     }
 


### PR DESCRIPTION
## Summary

Creating a project now opens the "Choose Assessments" step with a recommended set already selected, and that step is laid out to fit on a screen instead of scrolling for 1500px. Along the way the QA Screener flag — which only existed to render a badge — is removed from the backend.

Closes [RANDZ-643](https://linear.app/ae-studio/issue/RANDZ-643/pre-selected-assessments).

## Motivation

The step opened on an empty selection, so every new project required the user to work out which of a dozen assessments they wanted before they could do anything. Pre-selecting the three we'd recommend anyway gives them a working default they can adjust.

That exposed a second problem: a dozen full-width cards in one column made the step an unreasonably long scroll, which is worse when the page now has a default worth reviewing rather than a blank slate.

## What's Changed

### Frontend

- **`components/workflows/utils.ts`** — adds `DEFAULT_SELECTED_WORKFLOW_TYPES`: Reference Error Checker, Advocacy & Tone, Recommendation Check.
- **`lib/hooks/use-visible-workflow-types.ts`** (new) — extracts "which assessments are actually on offer" (category membership, `is_internal`, `is_experimental` plus the user's opt-in) out of the picker so the wizard and the picker can't disagree.
- **`components/analysis-wizard/wizard-context.tsx`** — selection state becomes `WorkflowRunType[] | null`, where `null` means "untouched, use the defaults". Any explicit array wins, including an empty one after unchecking everything, so the defaults never reappear. The default set is intersected with the visible list: pre-checking a hidden experimental assessment would start a workflow the user can neither see nor uncheck.
- **`components/workflows/workflow-type-selector.tsx`** — uses the shared hook instead of duplicating the filter; renders each category as `grid gap-2 sm:grid-cols-2`; adds Select all / Deselect all. Both bulk actions touch only the checkboxes on screen and enabled, leaving any other selected type alone, which matters because the wizard appends `HumanApproval` at submit time.
- **`components/workflows/workflow-type-checkbox.tsx`** — tighter card (`p-3`, smaller internal spacing, `h-full` so paired cards align). Descriptions are **not** truncated. QA Screener badge removed.
- **`app/(authenticated)/new/page.tsx`** — `max-w-5xl` on the assessment step only, and the card's `transition-all duration-300` is dropped so the step change snaps instead of animating through intermediate widths.
- **`components/workflows/workflow-config-dialog.tsx`** — `min-w-2xl` → `sm:max-w-4xl`. This dialog renders the full two-column picker when opened without a specific `type` (from the Analyses tab). The old `min-w-2xl` also beat `DialogContent`'s own max-width and forced 672px on a 375px phone; the new class overrides the cap instead and leaves the small-screen guard intact.
- **`lib/generated-api/*`** — regenerated.

### Backend

- **`lib/workflows/manifest.py`** — removes the `is_qa_screener` property and the `QA_SCREENER_WORKFLOWS` set.
- **`lib/services/workflow_types.py`** — removes the `is_qa_screener` API field, `QA_SCREENER_ALLOWED_ROLES`, and `can_user_see_qa_screener`. With no per-user filtering left, `get_workflow_types_for_user(user)` becomes `get_all_workflow_types()` (renamed rather than kept, because the router's own endpoint function is already `get_workflow_types`).
- **`lib/api/routers/workflow_types.py`** — call site updated; the endpoint's now-unused optional-auth dependency removed.
- **`lib/api/mcp/tools/workflow_types.py`** — call site updated. Still calls `resolve_user`, which validates the token's identity claims and provisions the account on a first call.
- **`tests/unit/test_mcp_server.py`** — `is_qa_screener` dropped from the expected key set.

## Risks and Mitigations

**QA Screener workflows are now visible to everyone — intended.** `QA_SCREENER_WORKFLOWS` was doing double duty: the badge, and hiding `ADVOCACY_TONE` and `ABOUT_THIS_GER` from anyone outside the ADMIN and RAND roles. We want these available to all users now, so removing the set drops the gating deliberately rather than as a side effect. Concretely, About This (GER) is listed for every user — verified against an unauthenticated `/api/workflow-types`, which returns all 33 types. Legacy `advocacy_tone` also appears in the flat list but stays out of the picker either way, since the picker only renders category members.

No role check remains anywhere in this path, so there is nothing left to reinstate if the decision is ever revisited: it would mean a new filter, not restoring this one.

**Recommendation Check is `is_experimental = True`.** Users without the experimental toggle therefore get two of the three pre-selected defaults, because the default set is intersected with what is actually listed. Dropping that flag is a one-line follow-up if all three should apply universally — unlike the QA Screener question above, this one is still open.

**The endpoint's OpenAPI entry lost its `security` block.** A consequence of removing the unused dependency, so the generated client no longer attaches the auth header to that call. No access control changed: the dependency returned `None` on failure and enforced nothing, and the endpoint no longer reads identity.

**The regenerated client picks up `/api/microsoft/teams/messages`.** Pre-existing drift — the endpoint is in the backend but was missing from the checked-in client. Additive (new types plus one SDK function), nothing references it. Corrected by regenerating rather than hand-editing generated output.

**Select all queues ~11 assessments in one click.** Web search consent still gates submission when any selected assessment needs it. If that's too easy a way to spend compute, a confirmation step or per-category select-all would be the alternative.

## Verification

`uv run mypy lib tests` clean (371 files). `uv run pytest tests/unit/test_mcp_server.py` (14 passed) and `-k workflow_type` (8 passed). Frontend `tsc --noEmit` and `pnpm lint` clean — the 4 remaining lint warnings are pre-existing and in untouched files.

Not verified in a browser: reaching step 2 means uploading a document and creating a real project, which I didn't want to do unprompted. The layout changes are CSS-only and worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

