### PR TITLE
feat(results): surface assessment findings in the Assessments tab

### DIFF
--- a/frontend/components/results/components/generic-workflow-results.tsx
+++ b/frontend/components/results/components/generic-workflow-results.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { WorkflowIssuesList } from '@/components/results/components/workflow-issues-list';
+import { EmptyState } from '@/components/shared/empty-state';
+import { NavigateToExplorerButton } from '@/components/shared/navigate-to-explorer-button';
+import { Issue, ProjectDetailed, WorkflowRunDetail } from '@/lib/generated-api';
+import { isWorkflowCancelled, isWorkflowFailed, isWorkflowProcessing } from '@/lib/workflow-state';
+import { Ban, HistoryIcon, Loader2, XCircle } from 'lucide-react';
+import { useMemo } from 'react';
+
+interface GenericWorkflowResultsProps {
+  project: ProjectDetailed;
+  workflowRun: WorkflowRunDetail;
+  workflowName: string;
+  onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
+}
+
+/**
+ * Results for assessments with no bespoke visualisation: the issues the run
+ * reported, or an all-clear when it found none.
+ *
+ * These used to show only a pointer to the Document Explorer, which made the
+ * findings of a completed assessment invisible from the tab that lists it.
+ */
+export function GenericWorkflowResults({
+  project,
+  workflowRun,
+  workflowName,
+  onNavigateToDocumentExplorer,
+}: GenericWorkflowResultsProps) {
+  const runId = workflowRun.run.id;
+  const runType = workflowRun.run.type;
+  const allIssues = useMemo(() => project.issues ?? [], [project.issues]);
+  const issues = useMemo<Issue[]>(
+    () => allIssues.filter((issue) => issue.workflow_run_id === runId),
+    [allIssues, runId],
+  );
+
+  // Only the newest run of a type keeps its issues; earlier ones are archived
+  // and never reach the client. Without this an old run would claim an
+  // all-clear it never earned.
+  const isSuperseded =
+    issues.length === 0 &&
+    allIssues.some((issue) => issue.workflow_type === runType && issue.workflow_run_id !== runId);
+
+  if (isWorkflowProcessing(workflowRun)) {
+    return (
+      <EmptyState
+        icon={<Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />}
+        message="Assessing Document…"
+        description={`The ${workflowName} assessment is currently running. Results will appear here once complete.`}
+      />
+    );
+  }
+
+  if (isWorkflowCancelled(workflowRun)) {
+    return (
+      <EmptyState
+        icon={<Ban className="h-8 w-8 text-muted-foreground mx-auto" />}
+        message="Assessment Cancelled"
+        description={`The ${workflowName} assessment was cancelled before it could complete.`}
+      />
+    );
+  }
+
+  if (isWorkflowFailed(workflowRun)) {
+    return (
+      <EmptyState
+        icon={<XCircle className="h-8 w-8 text-red-600 mx-auto" />}
+        message="Assessment Failed"
+        description={
+          workflowRun.run.failure_message ??
+          `The ${workflowName} assessment failed before it could complete. Please retry it.`
+        }
+      />
+    );
+  }
+
+  if (isSuperseded) {
+    return (
+      <EmptyState
+        icon={<HistoryIcon className="h-8 w-8 text-muted-foreground mx-auto" />}
+        message="Superseded Run"
+        description={`A more recent ${workflowName} run has replaced these results. Select the latest run to see its findings.`}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <NavigateToExplorerButton
+          onClick={() => onNavigateToDocumentExplorer()}
+          label="See these findings inline in the Document Explorer"
+        />
+      </div>
+      <WorkflowIssuesList issues={issues} onNavigateToDocumentExplorer={onNavigateToDocumentExplorer} />
+    </div>
+  );
+}

--- a/frontend/components/results/components/generic-workflow-results.tsx
+++ b/frontend/components/results/components/generic-workflow-results.tsx
@@ -87,14 +87,16 @@ export function GenericWorkflowResults({
   }
 
   return (
-    <div className="space-y-3">
-      <div className="flex justify-end">
+    <WorkflowIssuesList
+      issues={issues}
+      onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+      headerAction={
         <NavigateToExplorerButton
           onClick={() => onNavigateToDocumentExplorer()}
           label="See these findings inline in the Document Explorer"
+          className="mt-0 -ml-2"
         />
-      </div>
-      <WorkflowIssuesList issues={issues} onNavigateToDocumentExplorer={onNavigateToDocumentExplorer} />
-    </div>
+      }
+    />
   );
 }

--- a/frontend/components/results/components/issue-count-badge.tsx
+++ b/frontend/components/results/components/issue-count-badge.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { SeverityEnum } from '@/lib/generated-api';
+import { ReportedIssuesSummary } from '@/lib/health-status';
+import { cn } from '@/lib/utils';
+import {
+  CheckCircleIcon,
+  CircleAlertIcon,
+  LucideProps,
+  MessageCircleWarningIcon,
+  TriangleAlertIcon,
+} from 'lucide-react';
+
+// Icons match SeverityBadge so a given severity reads the same across the app.
+// Colours are foreground-only here: this sits inline with the assessment title,
+// where a filled badge would shout over the title itself.
+const severityDisplay: Record<
+  SeverityEnum,
+  { icon: React.ComponentType<LucideProps>; label: string; className: string }
+> = {
+  [SeverityEnum.None]: { icon: CheckCircleIcon, label: 'passing', className: 'text-green-700' },
+  [SeverityEnum.Low]: { icon: MessageCircleWarningIcon, label: 'low', className: 'text-blue-600' },
+  [SeverityEnum.Medium]: { icon: TriangleAlertIcon, label: 'medium', className: 'text-yellow-600' },
+  [SeverityEnum.High]: { icon: CircleAlertIcon, label: 'high', className: 'text-red-600' },
+};
+
+/** Most severe first — the order the breakdown is read in. */
+const REPORTED_TIERS = [SeverityEnum.High, SeverityEnum.Medium, SeverityEnum.Low];
+
+/**
+ * Compact count of the issues one assessment reported.
+ *
+ * Shows the size of the *most severe* tier rather than the total, so the colour
+ * and the number always describe the same thing: "7 in red" means seven
+ * high-severity issues, not thirty-four issues of which some are high. The full
+ * breakdown is one hover away.
+ */
+export function IssueCountBadge({ summary }: { summary: ReportedIssuesSummary }) {
+  const severity = summary.maxSeverity ?? SeverityEnum.None;
+  const { icon: Icon, className } = severityDisplay[severity];
+  const headline = summary.maxSeverity ? summary.counts[summary.maxSeverity] : 0;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            'inline-flex shrink-0 items-center gap-0.5 text-xs font-semibold tabular-nums cursor-help',
+            className,
+          )}
+        >
+          <Icon className="size-3.5" />
+          {headline}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {summary.total === 0 ? (
+          <p>No issues reported</p>
+        ) : (
+          <div className="space-y-1">
+            <p className="font-medium">
+              {summary.total} reported {summary.total === 1 ? 'issue' : 'issues'}
+            </p>
+            <ul>
+              {REPORTED_TIERS.filter((tier) => summary.counts[tier] > 0).map((tier) => {
+                const { icon: TierIcon, label } = severityDisplay[tier];
+                return (
+                  <li key={tier} className="flex items-center gap-1.5">
+                    <TierIcon className="size-3" />
+                    <span className="tabular-nums">{summary.counts[tier]}</span> {label}
+                  </li>
+                );
+              })}
+            </ul>
+            <p className="opacity-70">Passing checks and resolved issues are not counted.</p>
+          </div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/components/results/components/workflow-issues-list.tsx
+++ b/frontend/components/results/components/workflow-issues-list.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { DocumentIssueCard } from '@/components/results/components/document-issue-card';
+import { Card, CardContent } from '@/components/ui/card';
+import { SeverityFilter } from '@/components/results/components/severity-filter';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Issue, SeverityEnum } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import { CheckCircle2, ChevronDownIcon } from 'lucide-react';
+import { useState } from 'react';
+
+interface WorkflowIssuesListProps {
+  issues: Issue[];
+  onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
+}
+
+/**
+ * The issues one assessment reported, or an all-clear when it found nothing.
+ *
+ * Passing checks (severity `none`) are collapsed behind a disclosure, so an
+ * assessment that verified 717 abbreviations and flagged 3 reads as three
+ * issues — and does not mount 717 cards to say so.
+ */
+export function WorkflowIssuesList({ issues, onNavigateToDocumentExplorer }: WorkflowIssuesListProps) {
+  const [showInformational, setShowInformational] = useState(false);
+  // Empty means no filter, matching the document explorer's severity toggles.
+  const [severityFilter, setSeverityFilter] = useState<SeverityEnum[]>([]);
+
+  const realIssues = issues.filter((i) => i.severity !== SeverityEnum.None);
+  const informational = issues.filter((i) => i.severity === SeverityEnum.None);
+  const visibleIssues =
+    severityFilter.length === 0 ? realIssues : realIssues.filter((i) => severityFilter.includes(i.severity));
+  const isFiltered = visibleIssues.length !== realIssues.length;
+
+  const handleSelect = (issue: Issue) => {
+    if (typeof issue.start_line === 'number' && typeof issue.end_line === 'number') {
+      onNavigateToDocumentExplorer([issue.start_line, issue.end_line]);
+    } else {
+      onNavigateToDocumentExplorer();
+    }
+  };
+
+  return (
+    <>
+      {realIssues.length === 0 ? (
+        <Card className="border-green-200 bg-green-50/30 dark:bg-green-950/30 dark:border-green-900">
+          <CardContent className="flex items-center gap-3 py-6">
+            <div className="h-10 w-10 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center flex-shrink-0">
+              <CheckCircle2 className="h-5 w-5 text-green-600" />
+            </div>
+            <div>
+              <p className="text-sm font-medium">All Checks Passed</p>
+              <p className="text-xs text-muted-foreground">No issues were found in the document.</p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <section className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-sm font-medium text-muted-foreground">
+              {isFiltered
+                ? `${visibleIssues.length} of ${realIssues.length} Issues`
+                : `${realIssues.length} Issue${realIssues.length !== 1 ? 's' : ''} Found`}
+            </h3>
+            <SeverityFilter value={severityFilter} onChange={setSeverityFilter} />
+          </div>
+          {visibleIssues.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">No issues match the selected severities.</p>
+          ) : (
+            <div className="space-y-2">
+              {visibleIssues.map((issue) => (
+                <DocumentIssueCard key={issue.id} issue={issue} onSelect={handleSelect} />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {informational.length > 0 && (
+        <Collapsible open={showInformational} onOpenChange={setShowInformational} className="mt-4 space-y-2">
+          <CollapsibleTrigger className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer">
+            <ChevronDownIcon className={cn('size-3.5 transition-transform', !showInformational && '-rotate-90')} />
+            {informational.length} Informational Item{informational.length !== 1 ? 's' : ''}
+          </CollapsibleTrigger>
+          <CollapsibleContent className="space-y-2">
+            {informational.map((issue) => (
+              <DocumentIssueCard key={issue.id} issue={issue} onSelect={handleSelect} />
+            ))}
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </>
+  );
+}

--- a/frontend/components/results/components/workflow-issues-list.tsx
+++ b/frontend/components/results/components/workflow-issues-list.tsx
@@ -42,41 +42,25 @@ export function WorkflowIssuesList({ issues, onNavigateToDocumentExplorer, heade
     }
   };
 
-  const hasHeader = headerAction !== undefined || realIssues.length > 0;
-
   return (
     <div className="space-y-2">
-      {/* One row: the caller's action on the left, count and filter on the
-          right. Rendered for an all-clear too, so the action does not vanish
-          when an assessment happens to find nothing. */}
-      {hasHeader && (
-        <div className="flex items-center gap-2">
-          {headerAction}
-          {realIssues.length > 0 && (
-            <>
-              <h3 className="ml-auto text-sm font-medium text-muted-foreground">
-                {isFiltered
-                  ? `${visibleIssues.length} of ${realIssues.length} issues`
-                  : `${realIssues.length} issue${realIssues.length !== 1 ? 's' : ''} found`}
-              </h3>
-              <SeverityFilter value={severityFilter} onChange={setSeverityFilter} />
-            </>
-          )}
-        </div>
-      )}
-
       {realIssues.length === 0 ? (
-        <Card className="border-green-200 bg-green-50/30 dark:bg-green-950/30 dark:border-green-900">
-          <CardContent className="flex items-center gap-3 py-6">
-            <div className="h-10 w-10 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center flex-shrink-0">
-              <CheckCircle2 className="h-5 w-5 text-green-600" />
-            </div>
-            <div>
-              <p className="text-sm font-medium">All Checks Passed</p>
-              <p className="text-xs text-muted-foreground">No issues were found in the document.</p>
-            </div>
-          </CardContent>
-        </Card>
+        <>
+          {/* Kept outside the header row below: an all-clear has no count or
+              filter to show, but the action must not vanish with them. */}
+          {headerAction}
+          <Card className="border-green-200 bg-green-50/30 dark:bg-green-950/30 dark:border-green-900">
+            <CardContent className="flex items-center gap-3 py-6">
+              <div className="h-10 w-10 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center flex-shrink-0">
+                <CheckCircle2 className="h-5 w-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">All Checks Passed</p>
+                <p className="text-xs text-muted-foreground">No issues were found in the document.</p>
+              </div>
+            </CardContent>
+          </Card>
+        </>
       ) : (
         <section className="space-y-2">
           <div className="flex items-center gap-2">

--- a/frontend/components/results/components/workflow-issues-list.tsx
+++ b/frontend/components/results/components/workflow-issues-list.tsx
@@ -12,6 +12,8 @@ import { useState } from 'react';
 interface WorkflowIssuesListProps {
   issues: Issue[];
   onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
+  /** Rendered at the left of the header row, opposite the count and filter. */
+  headerAction?: React.ReactNode;
 }
 
 /**
@@ -21,7 +23,7 @@ interface WorkflowIssuesListProps {
  * assessment that verified 717 abbreviations and flagged 3 reads as three
  * issues — and does not mount 717 cards to say so.
  */
-export function WorkflowIssuesList({ issues, onNavigateToDocumentExplorer }: WorkflowIssuesListProps) {
+export function WorkflowIssuesList({ issues, onNavigateToDocumentExplorer, headerAction }: WorkflowIssuesListProps) {
   const [showInformational, setShowInformational] = useState(false);
   // Empty means no filter, matching the document explorer's severity toggles.
   const [severityFilter, setSeverityFilter] = useState<SeverityEnum[]>([]);
@@ -40,8 +42,29 @@ export function WorkflowIssuesList({ issues, onNavigateToDocumentExplorer }: Wor
     }
   };
 
+  const hasHeader = headerAction !== undefined || realIssues.length > 0;
+
   return (
-    <>
+    <div className="space-y-2">
+      {/* One row: the caller's action on the left, count and filter on the
+          right. Rendered for an all-clear too, so the action does not vanish
+          when an assessment happens to find nothing. */}
+      {hasHeader && (
+        <div className="flex items-center gap-2">
+          {headerAction}
+          {realIssues.length > 0 && (
+            <>
+              <h3 className="ml-auto text-sm font-medium text-muted-foreground">
+                {isFiltered
+                  ? `${visibleIssues.length} of ${realIssues.length} issues`
+                  : `${realIssues.length} issue${realIssues.length !== 1 ? 's' : ''} found`}
+              </h3>
+              <SeverityFilter value={severityFilter} onChange={setSeverityFilter} />
+            </>
+          )}
+        </div>
+      )}
+
       {realIssues.length === 0 ? (
         <Card className="border-green-200 bg-green-50/30 dark:bg-green-950/30 dark:border-green-900">
           <CardContent className="flex items-center gap-3 py-6">
@@ -56,11 +79,12 @@ export function WorkflowIssuesList({ issues, onNavigateToDocumentExplorer }: Wor
         </Card>
       ) : (
         <section className="space-y-2">
-          <div className="flex items-center justify-between gap-2">
-            <h3 className="text-sm font-medium text-muted-foreground">
+          <div className="flex items-center gap-2">
+            {headerAction}
+            <h3 className="ml-auto mr-1 text-sm font-medium text-muted-foreground">
               {isFiltered
-                ? `${visibleIssues.length} of ${realIssues.length} Issues`
-                : `${realIssues.length} Issue${realIssues.length !== 1 ? 's' : ''} Found`}
+                ? `${visibleIssues.length} of ${realIssues.length} issues`
+                : `${realIssues.length} issue${realIssues.length !== 1 ? 's' : ''}`}
             </h3>
             <SeverityFilter value={severityFilter} onChange={setSeverityFilter} />
           </div>
@@ -80,7 +104,7 @@ export function WorkflowIssuesList({ issues, onNavigateToDocumentExplorer }: Wor
         <Collapsible open={showInformational} onOpenChange={setShowInformational} className="mt-4 space-y-2">
           <CollapsibleTrigger className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer">
             <ChevronDownIcon className={cn('size-3.5 transition-transform', !showInformational && '-rotate-90')} />
-            {informational.length} Informational Item{informational.length !== 1 ? 's' : ''}
+            {informational.length} informational item{informational.length !== 1 ? 's' : ''}
           </CollapsibleTrigger>
           <CollapsibleContent className="space-y-2">
             {informational.map((issue) => (
@@ -89,6 +113,6 @@ export function WorkflowIssuesList({ issues, onNavigateToDocumentExplorer }: Wor
           </CollapsibleContent>
         </Collapsible>
       )}
-    </>
+    </div>
   );
 }

--- a/frontend/components/results/tabs/analyses-tab.tsx
+++ b/frontend/components/results/tabs/analyses-tab.tsx
@@ -93,6 +93,7 @@ export function AnalysesTab({
     <div className="flex h-full gap-4">
       <WorkflowListSidebar
         workflowDetails={filteredWorkflowDetails}
+        issues={projectDetail.issues ?? []}
         selectedWorkflowType={selectedWorkflowType}
         onSelectWorkflowType={handleSelectWorkflowType}
         onStartNewAnalysis={handleStartNewAnalysis}

--- a/frontend/components/results/tabs/workflow-list-sidebar.tsx
+++ b/frontend/components/results/tabs/workflow-list-sidebar.tsx
@@ -1,23 +1,32 @@
 'use client';
 
+import { IssueCountBadge } from '@/components/results/components/issue-count-badge';
 import { Button } from '@/components/ui/button';
 import { StatusIndicator } from '@/components/ui/status-indicator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { WorkflowRunDetail, WorkflowRunType } from '@/lib/generated-api';
+import { Issue, WorkflowRunDetail, WorkflowRunType } from '@/lib/generated-api';
+import { summarizeReportedIssues } from '@/lib/health-status';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { cn } from '@/lib/utils';
-import { getDisplayStatus, hasBlockingErrors, hasCurrentRunErrors, isWorkflowFailed } from '@/lib/workflow-state';
+import {
+  getDisplayStatus,
+  hasBlockingErrors,
+  hasCurrentRunErrors,
+  isWorkflowFailed,
+  isWorkflowProcessing,
+} from '@/lib/workflow-state';
 import { formatDistanceToNow } from 'date-fns';
 import { AlertTriangleIcon, ChevronDownIcon, InfoIcon, PlusIcon, XCircleIcon } from 'lucide-react';
 import { useState } from 'react';
 
 interface WorkflowListItemProps {
   workflowDetail: WorkflowRunDetail;
+  issues: Issue[];
   isSelected: boolean;
   onSelect: () => void;
 }
 
-function WorkflowListItem({ workflowDetail, isSelected, onSelect }: WorkflowListItemProps) {
+function WorkflowListItem({ workflowDetail, issues, isSelected, onSelect }: WorkflowListItemProps) {
   const displayStatus = getDisplayStatus(workflowDetail);
   const hasErrors = hasBlockingErrors(workflowDetail);
   // Recovered failures: the run completed, so flag them without the error tone.
@@ -25,6 +34,10 @@ function WorkflowListItem({ workflowDetail, isSelected, onSelect }: WorkflowList
   const hasFailed = isWorkflowFailed(workflowDetail);
   const failureMessage = workflowDetail.run.failure_message;
   const { getWorkflowTypeName } = useWorkflowTypes();
+  // A run still working has nothing final to count, so no badge until it settles.
+  const issuesSummary = isWorkflowProcessing(workflowDetail)
+    ? null
+    : summarizeReportedIssues(issues, workflowDetail.run.type);
 
   return (
     <button
@@ -65,6 +78,11 @@ function WorkflowListItem({ workflowDetail, isSelected, onSelect }: WorkflowList
               </TooltipContent>
             </Tooltip>
           )}
+          {issuesSummary && (
+            <span className="ml-auto pl-2">
+              <IssueCountBadge summary={issuesSummary} />
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2 justify-between">
           <div className="text-xs text-muted-foreground">
@@ -79,6 +97,7 @@ function WorkflowListItem({ workflowDetail, isSelected, onSelect }: WorkflowList
 
 interface WorkflowListSidebarProps {
   workflowDetails: WorkflowRunDetail[];
+  issues: Issue[];
   selectedWorkflowType: WorkflowRunType | null;
   onSelectWorkflowType: (type: WorkflowRunType) => void;
   onStartNewAnalysis: () => void;
@@ -87,6 +106,7 @@ interface WorkflowListSidebarProps {
 
 export function WorkflowListSidebar({
   workflowDetails,
+  issues,
   selectedWorkflowType,
   onSelectWorkflowType,
   onStartNewAnalysis,
@@ -114,6 +134,7 @@ export function WorkflowListSidebar({
           <WorkflowListItem
             key={workflowDetail.run.id}
             workflowDetail={workflowDetail}
+            issues={issues}
             isSelected={selectedWorkflowType === workflowDetail.run.type}
             onSelect={() => onSelectWorkflowType(workflowDetail.run.type)}
           />
@@ -149,6 +170,7 @@ export function WorkflowListSidebar({
                   <div key={workflowDetail.run.id} className="opacity-70">
                     <WorkflowListItem
                       workflowDetail={workflowDetail}
+                      issues={issues}
                       isSelected={selectedWorkflowType === workflowDetail.run.type}
                       onSelect={() => onSelectWorkflowType(workflowDetail.run.type)}
                     />

--- a/frontend/components/results/tabs/workflow-results-renderer.tsx
+++ b/frontend/components/results/tabs/workflow-results-renderer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
 import { Callout } from '@/components/ui/callout';
 import { ErrorsCard } from '@/components/results/components/errors-card';
+import { GenericWorkflowResults } from '@/components/results/components/generic-workflow-results';
 import { AboutThisGerResults } from '@/components/workflows/results/about-this-ger-results';
 import { AdvocacyToneResults } from '@/components/workflows/results/advocacy-tone-results';
 import { CitationSuggesterResults } from '@/components/workflows/results/citation-suggester-results';
@@ -19,7 +19,7 @@ import { SimpleDeepAgentResults } from '@/components/workflows/results/simple-de
 import { ProjectDetailed, SimpleDeepAgentState, WorkflowRunDetail, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { getCurrentRunErrors, WorkflowRunDetailTyped } from '@/lib/workflow-state';
-import { ArrowRight, FileText, FlaskConicalIcon } from 'lucide-react';
+import { FlaskConicalIcon } from 'lucide-react';
 
 function InternalWorkflowResults({ workflowName }: { workflowName: string }) {
   return (
@@ -82,20 +82,12 @@ function renderWorkflowResults(
     case WorkflowRunType.ClaimReferenceValidationV2:
     case WorkflowRunType.AbbreviationScanV2:
       return (
-        <Callout title="View Results in Document Explorer" variant="info" icon={FileText}>
-          <div className="space-y-3">
-            <p className="text-sm">
-              Results for {getWorkflowTypeName(type)} are displayed in the <strong>Document Explorer</strong> tab.
-              Please navigate there to view each issue highlighted inline on the document.
-            </p>
-            {onNavigateToDocumentExplorer && (
-              <Button onClick={() => onNavigateToDocumentExplorer()} size="sm" variant="outline" className="mt-2">
-                Go to Document Explorer
-                <ArrowRight className="h-4 w-4" />
-              </Button>
-            )}
-          </div>
-        </Callout>
+        <GenericWorkflowResults
+          project={project}
+          workflowRun={workflowRun}
+          workflowName={getWorkflowTypeName(type)}
+          onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+        />
       );
     case WorkflowRunType.Reviewer2:
       return <Reviewer2Results workflowDetail={workflowRun} />;
@@ -121,12 +113,15 @@ function renderWorkflowResults(
         />
       );
     default:
+      // No bespoke visualisation for this type: fall back to its issues, which
+      // every assessment produces, rather than telling the user nothing.
       return (
-        <div className="p-4 bg-muted rounded-lg">
-          <p className="text-sm text-muted-foreground">
-            Results visualization for {getWorkflowTypeName(type)} is not yet implemented.
-          </p>
-        </div>
+        <GenericWorkflowResults
+          project={project}
+          workflowRun={workflowRun}
+          workflowName={getWorkflowTypeName(type)}
+          onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+        />
       );
   }
 }

--- a/frontend/components/shared/navigate-to-explorer-button.tsx
+++ b/frontend/components/shared/navigate-to-explorer-button.tsx
@@ -1,11 +1,14 @@
 import { ExternalLink } from 'lucide-react';
 import { Button } from '../ui/button';
+import { cn } from '@/lib/utils';
 
 interface NavigateToExplorerButtonProps {
   /** Callback when button is clicked */
   onClick: () => void;
   /** Optional custom label (defaults to "View in Document Explorer") */
   label?: string;
+  /** Extra classes, e.g. to drop the default top margin inside a flex row */
+  className?: string;
 }
 
 /**
@@ -15,12 +18,13 @@ interface NavigateToExplorerButtonProps {
 export function NavigateToExplorerButton({
   onClick,
   label = 'View in Document Explorer',
+  className,
 }: NavigateToExplorerButtonProps) {
   return (
     <Button
       variant="ghost"
       size="sm"
-      className="mt-2 gap-1"
+      className={cn('mt-2 gap-1', className)}
       onClick={(e) => {
         e.stopPropagation();
         onClick();

--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -2,14 +2,14 @@
 
 import { ReadonlyThread } from '@/components/assistant-ui/readonly-thread';
 import { Markdown } from '@/components/markdown';
-import { DocumentIssueCard } from '@/components/results/components/document-issue-card';
 import { HtmlReportFrame, HtmlReportFrameHandle } from '@/components/results/components/html-report-frame';
+import { WorkflowIssuesList } from '@/components/results/components/workflow-issues-list';
 import { MarkdownDownloadButton } from '@/components/results/components/markdown-download-button';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/shared/empty-state';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Issue, ProjectDetailed, SeverityEnum, SimpleDeepAgentState } from '@/lib/generated-api';
+import { ProjectDetailed, SimpleDeepAgentState } from '@/lib/generated-api';
 import {
   isWorkflowCancelled,
   isWorkflowFailed,
@@ -18,7 +18,7 @@ import {
 } from '@/lib/workflow-state';
 import { AssistantRuntimeProvider, ThreadMessageLike, useExternalStoreRuntime } from '@assistant-ui/react';
 import { convertLangChainMessages, LangChainMessage } from '@assistant-ui/react-langgraph';
-import { Ban, CheckCircle2, ClipboardList, Download, Loader2, MessageSquare, XCircle } from 'lucide-react';
+import { Ban, ClipboardList, Download, Loader2, MessageSquare, XCircle } from 'lucide-react';
 import { useMemo, useRef, useState } from 'react';
 
 interface SimpleDeepAgentResultsProps {
@@ -26,67 +26,6 @@ interface SimpleDeepAgentResultsProps {
   workflowDetail: WorkflowRunDetailTyped<SimpleDeepAgentState>;
   workflowName: string;
   onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
-}
-
-function IssuesList({
-  issues,
-  onNavigateToDocumentExplorer,
-}: {
-  issues: Issue[];
-  onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
-}) {
-  const realIssues = issues.filter((i) => i.severity !== SeverityEnum.None);
-  const informational = issues.filter((i) => i.severity === SeverityEnum.None);
-
-  const handleSelect = (issue: Issue) => {
-    if (typeof issue.start_line === 'number' && typeof issue.end_line === 'number') {
-      onNavigateToDocumentExplorer([issue.start_line, issue.end_line]);
-    } else {
-      onNavigateToDocumentExplorer();
-    }
-  };
-
-  return (
-    <>
-      {realIssues.length === 0 ? (
-        <Card className="border-green-200 bg-green-50/30 dark:bg-green-950/30 dark:border-green-900">
-          <CardContent className="flex items-center gap-3 py-6">
-            <div className="h-10 w-10 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center flex-shrink-0">
-              <CheckCircle2 className="h-5 w-5 text-green-600" />
-            </div>
-            <div>
-              <p className="text-sm font-medium">All Checks Passed</p>
-              <p className="text-xs text-muted-foreground">No issues were found in the document.</p>
-            </div>
-          </CardContent>
-        </Card>
-      ) : (
-        <section className="space-y-2">
-          <h3 className="text-sm font-medium text-muted-foreground">
-            {realIssues.length} Issue{realIssues.length !== 1 ? 's' : ''} Found
-          </h3>
-          <div className="space-y-2">
-            {realIssues.map((issue) => (
-              <DocumentIssueCard key={issue.id} issue={issue} onSelect={handleSelect} />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {informational.length > 0 && (
-        <section className="space-y-2 mt-4">
-          <h3 className="text-sm font-medium text-muted-foreground">
-            {informational.length} Informational Item{informational.length !== 1 ? 's' : ''}
-          </h3>
-          <div className="space-y-2">
-            {informational.map((issue) => (
-              <DocumentIssueCard key={issue.id} issue={issue} onSelect={handleSelect} />
-            ))}
-          </div>
-        </section>
-      )}
-    </>
-  );
 }
 
 function ReportCard({ reportMarkdown }: { reportMarkdown: string }) {
@@ -203,7 +142,7 @@ export function SimpleDeepAgentResults({
         ) : (
           <>
             {result.report_markdown && <ReportCard reportMarkdown={result.report_markdown} />}
-            <IssuesList issues={issues} onNavigateToDocumentExplorer={onNavigateToDocumentExplorer} />
+            <WorkflowIssuesList issues={issues} onNavigateToDocumentExplorer={onNavigateToDocumentExplorer} />
           </>
         )}
       </TabsContent>

--- a/frontend/lib/health-status.ts
+++ b/frontend/lib/health-status.ts
@@ -1,4 +1,6 @@
 import { Issue, SeverityEnum, WorkflowRunDetail, WorkflowRunStatus, WorkflowRunType } from './generated-api';
+import { getMaxSeverity } from './severity';
+import { isIssueResolved } from './stores/document-explorer-store';
 import { getDisplayStatus } from './workflow-state';
 
 /**
@@ -20,33 +22,55 @@ export interface WorkflowHealthData {
 }
 
 /**
- * Determines if an issue should be considered as affecting health status.
- * Only Medium and High severity issues affect the health status.
+ * The reported issues of one workflow type, for at-a-glance display.
  */
-export function isHealthAffectingIssue(issue: Issue): boolean {
-  return issue.severity === SeverityEnum.High || issue.severity === SeverityEnum.Medium;
+export interface ReportedIssuesSummary {
+  /** Every reported issue, across severities. */
+  total: number;
+  /** Per severity; `none` is always 0, since passing checks are not reported. */
+  counts: Record<SeverityEnum, number>;
+  /** Undefined when nothing was reported. Drives the badge's icon and colour. */
+  maxSeverity?: SeverityEnum;
 }
 
 /**
- * Counts issues by severity from a pre-filtered list
+ * Summarise the issues one workflow type reported.
+ *
+ * The single counting rule for the app: passing checks (severity `none`) and
+ * resolved issues are excluded, matching the document explorer's defaults, so
+ * every count the user sees agrees with the list they land on.
  */
-function countBySeverity(issues: Issue[]): { high: number; medium: number; low: number; total: number } {
-  const high = issues.filter((i) => i.severity === SeverityEnum.High).length;
-  const medium = issues.filter((i) => i.severity === SeverityEnum.Medium).length;
-  const low = issues.filter((i) => i.severity === SeverityEnum.Low).length;
-  return {
-    high,
-    medium,
-    low,
-    total: high + medium + low,
+export function summarizeReportedIssues(issues: Issue[], workflowType: WorkflowRunType): ReportedIssuesSummary {
+  const reported = issues.filter(
+    (issue) => issue.workflow_type === workflowType && issue.severity !== SeverityEnum.None && !isIssueResolved(issue),
+  );
+
+  const counts: Record<SeverityEnum, number> = {
+    [SeverityEnum.None]: 0,
+    [SeverityEnum.Low]: 0,
+    [SeverityEnum.Medium]: 0,
+    [SeverityEnum.High]: 0,
   };
+  reported.forEach((issue) => {
+    counts[issue.severity] += 1;
+  });
+
+  return { total: reported.length, counts, maxSeverity: getMaxSeverity(reported) };
 }
 
 /**
- * Determines the health status for a workflow based on its run status and issues.
- * Accepts pre-filtered issues to avoid redundant filtering in aggregateWorkflowHealth.
+ * Whether a workflow's findings warrant attention. Only Medium and High
+ * severity issues affect health status.
  */
-function determineHealthStatusFromIssues(workflowRun: WorkflowRunDetail, workflowIssues: Issue[]): HealthStatus {
+function hasHealthAffectingIssues(summary: ReportedIssuesSummary): boolean {
+  return summary.counts[SeverityEnum.High] > 0 || summary.counts[SeverityEnum.Medium] > 0;
+}
+
+/**
+ * Determines the health status for a workflow from its run status and the
+ * issues it reported.
+ */
+function determineHealthStatus(workflowRun: WorkflowRunDetail, summary: ReportedIssuesSummary): HealthStatus {
   const displayStatus = getDisplayStatus(workflowRun);
 
   if (displayStatus === 'failed') return 'error';
@@ -55,24 +79,27 @@ function determineHealthStatusFromIssues(workflowRun: WorkflowRunDetail, workflo
     return 'processing';
   }
 
-  return workflowIssues.some(isHealthAffectingIssue) ? 'issues' : 'healthy';
+  return hasHealthAffectingIssues(summary) ? 'issues' : 'healthy';
 }
 
 /**
- * Aggregates health data for all workflow runs
+ * Aggregates health data for all workflow runs.
+ *
+ * Counts come from `summarizeReportedIssues`, so the health monitor, the
+ * assessment badges and the document explorer all agree on what an issue is:
+ * a resolved finding stops counting everywhere at once.
  */
 export function aggregateWorkflowHealth(workflowRuns: WorkflowRunDetail[], issues: Issue[]): WorkflowHealthData[] {
   return workflowRuns.map((workflowRun) => {
-    const workflowIssues = issues.filter((issue) => issue.workflow_type === workflowRun.run.type);
-    const { high, medium, low, total } = countBySeverity(workflowIssues);
+    const summary = summarizeReportedIssues(issues, workflowRun.run.type);
 
     return {
       type: workflowRun.run.type,
-      status: determineHealthStatusFromIssues(workflowRun, workflowIssues),
-      issueCount: total,
-      highSeverityCount: high,
-      mediumSeverityCount: medium,
-      lowSeverityCount: low,
+      status: determineHealthStatus(workflowRun, summary),
+      issueCount: summary.total,
+      highSeverityCount: summary.counts[SeverityEnum.High],
+      mediumSeverityCount: summary.counts[SeverityEnum.Medium],
+      lowSeverityCount: summary.counts[SeverityEnum.Low],
       workflowRun,
     };
   });


### PR DESCRIPTION
## Summary

Makes an assessment's findings visible from the Assessments tab. Each card in the sidebar gains an issue-count indicator, and assessments with no bespoke results component now render their issues instead of a pointer to another tab.

## Motivation

Two gaps in the same flow. The sidebar listed assessments with a status and a timestamp but nothing about what they found, so learning whether anything was flagged meant opening each one. And for Claim Reference Validation, Abbreviation Scan, and anything hitting the "not yet implemented" default, opening one showed only "Results for X are displayed in the Document Explorer" — a completed assessment's findings were invisible from the tab that lists it.

## What's Changed

Frontend only; no backend or API changes.

### Issue counts on assessment cards

- **`lib/health-status.ts`** — adds `summarizeReportedIssues`, the single counting rule: passing checks (severity `none`) and resolved issues are excluded, matching the document explorer's defaults so every count agrees with the list the user lands on. That exclusion carries real weight: Abbreviation Scan has 717 passing checks behind its 3 reported issues.
- **`components/results/components/issue-count-badge.tsx`** (new) — compact icon + number on the card's title line, plus a hover breakdown. It shows the size of the **most severe tier**, not the total, so the colour and the number describe the same thing: a red 7 means seven high-severity issues, not thirty-four issues of which some are high. Icons and colours reuse the `SeverityBadge` vocabulary.
- **`components/results/tabs/workflow-list-sidebar.tsx`**, **`analyses-tab.tsx`** — render the badge and thread `projectDetail.issues` through.

The same commit points the health monitor at `summarizeReportedIssues` instead of its own tally. It previously counted resolved issues, so its numbers could disagree with the new badges; `countBySeverity` and the zero-importer `isHealthAffectingIssue` export are gone.

### Findings for assessments without a custom view

- **`components/results/components/workflow-issues-list.tsx`** (new) — extracted from `SimpleDeepAgentResults` rather than rewritten, so both paths stay identical. Gains a severity filter matching the document explorer's, and collapses passing checks behind a disclosure.
- **`components/results/components/generic-workflow-results.tsx`** (new) — the fallback results view: the run's issues, or an all-clear when it found none, with processing/cancelled/failed states mirroring the deep-agent component.
- **`components/results/tabs/workflow-results-renderer.tsx`** — both placeholder branches route here.
- **`components/workflows/results/simple-deep-agent-results.tsx`** — uses the shared list.

## Risks and Mitigations

- **Health monitor numbers change.** Excluding resolved issues is the point, but it also changes status: a workflow whose medium/high findings have all been resolved now reads *healthy* rather than *Review recommended*. Four workflows across three projects are affected today, all dropping to zero counted issues. Flagged here because it goes beyond the counts.
- **Rendering hundreds of cards.** Abbreviation Scan's 717 passing checks would mount 717 components. They are collapsed by default and only rendered when expanded.
- **A superseded run claiming a false all-clear.** Only the newest run of a type keeps active issues; earlier ones are archived server-side and never reach the client. Since the run-history picker can select an older run, "no issues" there would be a lie. Those report as *Superseded Run* instead.
- **A filter faking a clean result.** The green "All Checks Passed" card keys off the unfiltered set, so narrowing the severity filter to nothing shows "No issues match the selected severities", never an all-clear.
- **Not verified in a browser.** `tsc --noEmit`, eslint, prettier and `pnpm build` all pass, but the layouts were not exercised in a browser — Playwright isn't set up in this repo and adding it seemed out of scope. Worth a look at the badge in the narrow sidebar and the 717-item collapsible before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
