### PR TITLE
docs(evals): fix the function name in start_workflow's docstring

### DIFF
--- a/evals_inspectai/common/api_client.py
+++ b/evals_inspectai/common/api_client.py
@@ -325,7 +325,7 @@ async def start_workflow(config: dict[str, Any]) -> str:
         payload carrying only `type` and `project_id` validates against the
         first union member that accepts it, not the one matching `type`. Pass a
         config with fields unique to the target workflow, or use
-        `start_workflow_by_type`, whose endpoint takes an explicit request model.
+        `start_workflow_types`, whose endpoint takes an explicit request model.
     """
     async with _build_client() as client:
         resp = await client.post("/api/workflows/start", json=config)


### PR DESCRIPTION
## Summary

One-word docstring fix in `evals_inspectai/common/api_client.py`. `start_workflow`'s `Note:` points readers at `start_workflow_by_type`, which does not exist anywhere in the codebase. The function it means is `start_workflow_types`, defined ~30 lines below in the same module.

## Motivation

The note exists to steer callers away from a real footgun: `/api/workflows/start` takes the untagged `WorkflowConfig` union, so a minimal `{type, project_id}` payload can validate against the wrong union member and fail later when the run builds its state. Someone hitting that problem and following the note would go looking for a function that isn't there.

Found while porting this module into `RANDCorporation/ai-eval-framework`, where the two copies are kept aligned — so the wrong name would have propagated.

## What's Changed

### Backend

- `evals_inspectai/common/api_client.py` — `start_workflow_by_type` → `start_workflow_types` in the `start_workflow` docstring.

### Frontend

None.

## Risks and Mitigations

None. Comment-only change with no executable code affected: no behavior, no signatures, no imports. `uv run mypy .` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)