### PR TITLE
feat(evals): add a client helper for the manual reference-file link

### DIFF
--- a/evals_inspectai/common/api_client.py
+++ b/evals_inspectai/common/api_client.py
@@ -240,6 +240,31 @@ async def tus_upload_file(
         )
 
 
+async def link_reference_file(
+    project_id: str, reference_id: str, file_id: str
+) -> None:
+    """Link an already-uploaded supporting file to an extracted reference.
+
+    Records a MANUAL_UPLOAD match, the same one the app creates when a user
+    supplies the source for a reference themselves. Use it when the correct
+    reference->file pairing is known up front and running the automatic matcher
+    would only add noise.
+    """
+    async with _build_client() as client:
+        resp = await client.post(
+            f"/api/project/{project_id}/references/{reference_id}/files",
+            json={"file_id": file_id},
+        )
+        resp.raise_for_status()
+
+    logger.info(
+        "Linked file %s to reference %s on project %s",
+        file_id,
+        reference_id,
+        project_id,
+    )
+
+
 async def approve_workflow_run(workflow_run_id: str) -> None:
     """Trigger the human-approval gate for a workflow run."""
     async with _build_client() as client:


### PR DESCRIPTION
## Summary

Adds `link_reference_file` to the eval API client, wrapping `POST /api/project/{project_id}/references/{reference_id}/files`.

## Motivation

That endpoint (added in #669) lets a caller link an already-uploaded supporting file to an extracted reference, recording a `MANUAL_UPLOAD` match. The eval client had no helper for it, so a suite that already knows the correct reference→file pairing has no way to declare it and has to let the automatic matcher guess.

That matters when a document cites exactly one source: on a lone candidate the matcher can return `NONE`, which surfaces as a spurious `unverifiable` and scores the validator for a mistake it did not make.

**Nothing in this repo calls it yet.** It is added for two reasons: so the client covers the endpoint, and because a private benchmark suite maintained in `RANDCorporation/ai-eval-framework` depends on it. That repo keeps its copy of `evals_inspectai/common/api_client.py` deliberately in sync with this one, and without this the two files drift by a function.

## What's Changed

### Backend

- `evals_inspectai/common/api_client.py` — one new function, 25 lines, placed with the other project-scoped helpers. Same shape as its neighbours: builds the shared authenticated client, posts, `raise_for_status()`, logs.

### Frontend

None. No API surface changes, so no OpenAPI regeneration is needed — this consumes an endpoint that already exists.

## Risks and Mitigations

- **Purely additive.** No existing function, signature, or call site is touched; nothing calls the new helper, so no eval changes behaviour.
- `uv run mypy .` clean (418 files); `uv run pytest tests/unit` 891 passed, 3 skipped.
- Exercised end-to-end against a local deploy while developing the benchmark suite: the linked match is recorded as `MANUAL_UPLOAD` and the automatic matcher does not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)