### PR TITLE
fix(ci): pin pnpm and move the frontend image to node 22

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,10 @@
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm, pinned to the version package.json declares in
+# `packageManager`. Unpinned, this picks up whatever is latest at build time:
+# pnpm 11 verifies the package-manager identity against a `@pnpm/exe.<platform>`
+# entry that a pnpm-10 lockfile does not carry, so `--frozen-lockfile` fails.
+RUN npm install -g pnpm@10.33.0
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
## Summary

Unblocks CI. The frontend Docker image installed pnpm unpinned, and a new pnpm major released today broke `pnpm install --frozen-lockfile`, failing the `Trivy Security Scan - Frontend` job on every PR regardless of content. Pins pnpm to the version `package.json` already declares, and moves the base image to the Node major the package has required all along.

## Motivation

`frontend/Dockerfile` line 4 was `RUN npm install -g pnpm`, so the image built with whatever npm considered latest — now **pnpm 11.24.0**. pnpm 11 verifies the package-manager identity, which requires a `@pnpm/exe.<platform>` entry in `pnpm-lock.yaml`. Our lockfile is lockfileVersion 9.0, written by pnpm 10, and carries no such entry, so the install refuses to run:

```
#12 [deps 4/4] RUN pnpm install --frozen-lockfile
Error: ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE
  × verify the package manager identity
  ╰─▶ Cannot verify the identity of the @pnpm/exe.linux-x64 native binary:
      it is missing from pnpm-lock.yaml.
```

The last green Security Scan was 2026-08-25 20:26; the next run, this morning, failed. Nothing in the repo changed — only the resolved pnpm version did. That is exactly what pinning is for, and `package.json` already names the intended version in `packageManager: "pnpm@10.33.0"`.

Separately, the image ran on `node:20-alpine` while `package.json` sets `"engines": { "node": ">=22" }` — the build worked but on an unsupported runtime, and Node 20 is now out of active support.

## What's Changed

### Frontend

- `frontend/Dockerfile`
  - `RUN npm install -g pnpm` → `RUN npm install -g pnpm@10.33.0`, matching `packageManager`, with a comment recording why it must stay pinned so nobody helpfully removes the version again.
  - Base image `node:20-alpine` → `node:22-alpine`, satisfying `engines.node: >=22`.

No changes to `package.json`, `pnpm-lock.yaml`, or any application code.

## Verification

Done locally with Docker, since the failing job is purely an image build:

1. Exported `origin/dev:frontend` to a clean directory and built the `deps` stage: reproduced `ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE` with none of this branch's changes present, confirming the breakage is on `dev` and not from any PR.
2. Built the **full** image from this branch: completes through `pnpm build` and exports successfully.
3. Ran the resulting image: reports `v22.23.2` and serves HTTP 200 on `/`. (An `UntrustedHost` auth warning appears when running ad hoc without `AUTH_URL`/`AUTH_TRUST_HOST` set; expected for a bare `docker run`, unrelated to this change.)

CI here will re-run the real build and Trivy scan.

## Risks and Mitigations

- **Node 20 → 22 in the runtime image.** The Node major the app declares support for, and the full image build plus a container boot both pass. Risk is a native dependency compiled against Node 20 ABI; `sharp` and `@tailwindcss/oxide` are the candidates, and both resolved and built cleanly in the verification build. Watch the first dev deploy.
- **Pinned pnpm now needs manual bumps.** Deliberate: the pin must move together with `packageManager` and the lockfile, which is a single deliberate change rather than a silent one at build time. Dependabot will not bump it, so a future pnpm upgrade means editing both places.
- **Does not touch CI's own Node setup.** `.github/workflows/release-changelog.yml` still pins `node-version: '20'`; it only runs changelog tooling, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
