### PR TITLE
feat(export): default DOCX download to regular comments

### DIFF
--- a/frontend/components/share/share-warning-dialog.tsx
+++ b/frontend/components/share/share-warning-dialog.tsx
@@ -15,6 +15,10 @@ import { RadioGroup, RadioGroupItemWithDescription } from '@/components/ui/radio
 import { AlertTriangle, Download, Loader2 } from 'lucide-react';
 import { DocxType } from '../results/components/use-download-docx';
 
+// Temporarily hidden: the Draft Detective add-in export is not offered right now.
+// Flip back to `true` to restore the export type picker.
+const SHOW_ADD_IN_OPTION = false;
+
 interface ShareWarningDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -33,7 +37,7 @@ export function ShareWarningDialog({
   onDownload,
 }: ShareWarningDialogProps) {
   const isProcessing = isEnablingShare || isDownloading;
-  const [selectedExportType, setSelectedExportType] = useState<'comments' | 'add-in'>('add-in');
+  const [selectedExportType, setSelectedExportType] = useState<'comments' | 'add-in'>('comments');
   const [makePublicAndAddLinks, setMakePublicAndAddLinks] = useState(isProjectPublic);
 
   const shouldShowLinksCheckbox = selectedExportType === 'comments' && !isProjectPublic;
@@ -41,7 +45,7 @@ export function ShareWarningDialog({
 
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
-      setSelectedExportType('add-in');
+      setSelectedExportType('comments');
       setMakePublicAndAddLinks(isProjectPublic);
     }
     onOpenChange(isOpen);
@@ -52,7 +56,7 @@ export function ShareWarningDialog({
       selectedExportType === 'add-in' ? 'add-in' : makePublicAndAddLinks ? 'comments-with-links' : 'comments';
 
     onDownload(docxType);
-    setSelectedExportType('add-in');
+    setSelectedExportType('comments');
     setMakePublicAndAddLinks(isProjectPublic);
   };
 
@@ -62,36 +66,40 @@ export function ShareWarningDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-amber-500" />
-            Choose How Issues Are Shown
+            {SHOW_ADD_IN_OPTION ? 'Choose How Issues Are Shown' : 'Download DOCX'}
           </DialogTitle>
           <DialogDescription asChild>
             <div className="text-sm text-muted-foreground pt-2">
-              Choose how reviewers should see this assessment in the downloaded DOCX.
+              {SHOW_ADD_IN_OPTION
+                ? 'Choose how reviewers should see this assessment in the downloaded DOCX.'
+                : 'The assessment results are added to the document as standard Word comments.'}
             </div>
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3 pt-2">
-          <RadioGroup
-            value={selectedExportType}
-            onValueChange={(value) => setSelectedExportType(value as 'comments' | 'add-in')}
-            className="gap-2"
-          >
-            <RadioGroupItemWithDescription
-              id="add-in"
+          {SHOW_ADD_IN_OPTION && (
+            <RadioGroup
               value={selectedExportType}
-              label="Draft Detective add-in"
-              description="Reviewers can see issues directly in the add-in as they do in the app."
-              disabled={isProcessing}
-            />
-            <RadioGroupItemWithDescription
-              id="comments"
-              value={selectedExportType}
-              label="Regular comments"
-              description="Adds standard Word comments for use outside the add-in."
-              disabled={isProcessing}
-            />
-          </RadioGroup>
+              onValueChange={(value) => setSelectedExportType(value as 'comments' | 'add-in')}
+              className="gap-2"
+            >
+              <RadioGroupItemWithDescription
+                id="comments"
+                value={selectedExportType}
+                label="Regular comments"
+                description="Adds standard Word comments for use outside the add-in."
+                disabled={isProcessing}
+              />
+              <RadioGroupItemWithDescription
+                id="add-in"
+                value={selectedExportType}
+                label="Draft Detective add-in"
+                description="Reviewers can see issues directly in the add-in as they do in the app."
+                disabled={isProcessing}
+              />
+            </RadioGroup>
+          )}
 
           {shouldShowLinksCheckbox && (
             <label className="flex items-start gap-2 rounded-md border p-3 cursor-pointer">


### PR DESCRIPTION
## Summary

The DOCX download dialog now defaults to **Regular comments** and temporarily hides the Draft Detective add-in export option.

## Motivation

The add-in export was the default and the first item in the picker, which pushed most users toward an export that requires the Word add-in to be useful. Regular Word comments are the option that works everywhere, so it should be the default. The add-in option is hidden for now rather than deleted, since it is expected to come back.

## What's Changed

### Frontend

- `frontend/components/share/share-warning-dialog.tsx`
  - Added a `SHOW_ADD_IN_OPTION` module constant (currently `false`) that gates the add-in radio item. Flipping it back to `true` restores the previous picker.
  - Reordered the radio items so **Regular comments** comes first, and changed the initial/reset state of `selectedExportType` from `'add-in'` to `'comments'` (initial mount, dialog close, and post-download reset).
  - When the add-in option is hidden, the radio group is not rendered at all — with a single choice a picker is noise — and the dialog title/description switch to "Download DOCX" / "The assessment results are added to the document as standard Word comments."

No backend changes. The `add-in` DOCX type and its backend manipulator are untouched; only the UI entry point is hidden.

## Risks and Mitigations

- **Users who relied on the add-in export lose access to it from the UI.** This is the intended, temporary behavior. The code path is intact and restoring it is a one-line flag change.
- **Empty dialog body when the project is already public.** With the add-in hidden and the project public, the share-links checkbox is also hidden, so the dialog is title + description + Download button. The description was rewritten to carry the explanation, so the dialog still reads sensibly.
- The `shouldShowAddInDisclaimer` branch is now unreachable. It is kept deliberately so re-enabling the flag restores the full behavior without further edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)