### PR TITLE
fix(projects): refresh project title in place after editing it

### DIFF
--- a/frontend/app/(authenticated)/projects/[projectId]/layout.tsx
+++ b/frontend/app/(authenticated)/projects/[projectId]/layout.tsx
@@ -57,13 +57,16 @@ export default function ProjectLayout({ children }: { children: ReactNode }) {
       });
     },
     onSuccess: (updatedProject) => {
-      queryClient.setQueryData(['project', projectId], (curr: ProjectDetailed | undefined) => {
+      // The details query is keyed per revision (['project', id, revision]), so patch every
+      // cached revision instead of an exact key that would never match.
+      queryClient.setQueriesData({ queryKey: ['project', projectId] }, (curr: ProjectDetailed | undefined) => {
         if (!curr) return curr;
         return {
           ...curr,
           project: updatedProject,
         };
       });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
       toast.success('Title updated successfully');
     },
     onError: (error) => {


### PR DESCRIPTION
## Summary

Editing a project's title from the project detail page updated the backend but not the UI — the new title only appeared after a page reload. This fixes the React Query cache update so the header (and the projects list) reflect the change immediately.

## Motivation

The title mutation in the project layout wrote to the exact query key `['project', projectId]`, while `useProjectDetails` caches under `['project', projectId, revision ?? 'latest']`. `setQueryData` matches keys exactly, so the write landed on an unrelated cache entry and the rendered `projectDetail.project.title` never changed. Only a fresh fetch (page refresh) surfaced the new value.

## What's Changed

### Backend

No backend changes.

### Frontend

- `frontend/app/(authenticated)/projects/[projectId]/layout.tsx` — in the title mutation's `onSuccess`:
  - `setQueryData(['project', projectId], …)` → `setQueriesData({ queryKey: ['project', projectId] }, …)`, which matches by key prefix and therefore patches every cached revision of the project with the updated record.
  - Added `invalidateQueries({ queryKey: ['projects'] })` so the dashboard project list stops showing the stale title.

## Risks and Mitigations

- **Broader cache match:** `setQueriesData` with the `['project', projectId]` prefix now touches all revision-scoped entries for that project. The updater is a no-op for empty entries (`if (!curr) return curr`) and only replaces the `project` field, leaving files, issues, and workflow runs untouched. No other query key starts with `['project', <id>]`.
- **Extra refetch:** invalidating `['projects']` triggers one list refetch after a title save, matching what `delete-project-dialog` already does.
- `tsc --noEmit` passes clean.