### PR TITLE
refactor(reference-file-matching): stop reporting missing supporting document issues

### DIFF
--- a/lib/workflows/reference_file_matching/manifest.py
+++ b/lib/workflows/reference_file_matching/manifest.py
@@ -5,8 +5,7 @@ from typing import List, Type, cast
 from langgraph.graph import StateGraph
 
 from lib.workflows.manifest import WorkflowManifest
-from lib.workflows.models import DocumentIssue, SeverityEnum, WorkflowRunType
-from lib.workflows.reference_extraction.state import ReferenceExtractionState
+from lib.workflows.models import DocumentIssue, WorkflowRunType
 from lib.workflows.reference_file_matching.graph import (
     build_reference_file_matching_graph,
 )
@@ -87,34 +86,6 @@ class ReferenceFileMatchingManifest(
         state: ReferenceFileMatchingState,
         other_states: List[WorkflowState],
     ) -> List[DocumentIssue]:
-        """Convert reference file matching state to issues."""
+        """Reference file matching does not report issues."""
 
-        issues: List[DocumentIssue] = []
-
-        # Get reference extraction state to access extracted references
-        ref_extraction_state = get_state_by_type(
-            WorkflowRunType.REFERENCE_EXTRACTION, other_states
-        )
-        if ref_extraction_state is None:
-            return issues
-
-        ref_extraction_state = cast(ReferenceExtractionState, ref_extraction_state)
-
-        # Build set of matched reference IDs
-        matched_ref_ids = {match.reference_id for match in state.matches}
-
-        # References without matching supporting documents. Emits line ranges
-        # only; persistence derives chunk_indices from them.
-        for reference in ref_extraction_state.extracted_references:
-            if reference.id not in matched_ref_ids:
-                issue = DocumentIssue(
-                    title="Missing supporting document for reference",
-                    description=f'Reference does not have an associated supporting document: "{reference.text}"',
-                    severity=SeverityEnum.LOW,
-                    type=self.type,
-                    start_line=reference.start_line,
-                    end_line=reference.end_line,
-                )
-                issues.append(issue)
-
-        return issues
+        return []


### PR DESCRIPTION
## Summary

The reference file matching workflow no longer emits `"Missing supporting document for reference"` issues. Every extracted reference without a matched supporting document used to produce a LOW-severity issue; that signal is no longer wanted, so the workflow now reports nothing.

## Motivation

A reference having no supporting document uploaded is normal — most projects only include a handful of supporting files, so the workflow flooded the issue list with low-value LOW-severity entries for the remaining references. Removing them cleans up the review output.

## What's Changed

### Backend

- `lib/workflows/reference_file_matching/manifest.py` — `convert_state_to_issues` now returns an empty list instead of iterating over unmatched references and building a `DocumentIssue` for each. The method is kept because it's an `@abstractmethod` on `WorkflowManifest`, so it's now a documented no-op. Dropped the imports that became unused as a result (`SeverityEnum`, `ReferenceExtractionState`).

### Frontend

No changes.

## Risks and Mitigations

- **Matching itself is untouched.** The workflow still runs, still matches references to supporting files, and still persists `ReferenceFileMatchingState.matches`. Only the issue-reporting step changed, so anything consuming the matches (the references UI, downstream workflows) is unaffected.
- **Pre-existing issues are not removed.** This stops new issues from being generated but does not clean up issues already persisted from earlier runs. Existing projects will keep showing them until they are re-run or the rows are cleaned up separately.
- Verified with `uv run mypy .` (clean, 346 files) and `uv run pytest tests/unit/test_match_supporting_docs.py` (20 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)