### PR TITLE
feat(peer-review): hide the Peer Review tab behind Alpha features

### DIFF
--- a/frontend/components/results/project-results-shell.tsx
+++ b/frontend/components/results/project-results-shell.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Callout } from '@/components/ui/callout';
 import { EditableTitle } from '@/components/ui/editable-title';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { ProjectFeedbackProvider } from '@/lib/contexts/project-feedback-context';
 import { ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
@@ -67,6 +68,8 @@ export function ProjectResultsShell({
   const documentSummarization = getWorkflowRunByType(results, WorkflowRunType.DocumentSummarization);
   const referenceExtraction = getWorkflowRunByType(results, WorkflowRunType.ReferenceExtraction);
   const { isWorkflowTypeVisible } = useWorkflowTypes();
+  // Peer Review is still alpha, so it only exists for users who opted in.
+  const { showExperimentalFeatures } = useExperimentalFeatures();
 
   const referenceApproval = useReferenceApprovalFlow(projectDetail, projectDetail.project.id);
 
@@ -175,17 +178,19 @@ export function ProjectResultsShell({
                     {results.filter((r) => isWorkflowTypeVisible(r.run.type)).length}
                   </Badge>
                 </TabsTrigger>
-                <TabsTrigger value="peer-review" className="relative">
-                  Peer Review
-                  {peerReviewFacts.memos.length > 0 && (
-                    <Badge className="rounded-full h-4.5 min-w-4.5" variant="secondary">
-                      {peerReviewFacts.memos.length}
-                    </Badge>
-                  )}
-                  {peerReviewAttention && (
-                    <span className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-amber-500 ring-2 ring-background" />
-                  )}
-                </TabsTrigger>
+                {showExperimentalFeatures && (
+                  <TabsTrigger value="peer-review" className="relative">
+                    Peer Review
+                    {peerReviewFacts.memos.length > 0 && (
+                      <Badge className="rounded-full h-4.5 min-w-4.5" variant="secondary">
+                        {peerReviewFacts.memos.length}
+                      </Badge>
+                    )}
+                    {peerReviewAttention && (
+                      <span className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-amber-500 ring-2 ring-background" />
+                    )}
+                  </TabsTrigger>
+                )}
               </TabsList>
             </Tabs>
 

--- a/frontend/components/results/project-tab-panel.tsx
+++ b/frontend/components/results/project-tab-panel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { WorkflowRunType } from '@/lib/generated-api';
 import { useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
 import { TabType } from './constants';
@@ -19,6 +20,9 @@ export function ProjectTabPanel({ tab }: { tab: TabType }) {
   const { projectDetail, readOnly, selectedRevision, onRevisionChange, onRevisionCreated, navigateToTab } =
     useProjectView();
   const setFilter = useDocumentExplorerStore((s) => s.setFilter);
+  // Peer Review is still alpha: the tab, and the route behind it, exist only
+  // for users who opted in.
+  const { showExperimentalFeatures, isLoading: isLoadingPreferences } = useExperimentalFeatures();
 
   const navigateToDocumentExplorer = (lineRange?: [number, number]) => {
     navigateToTab('document-explorer', lineRangeHash(lineRange));
@@ -61,10 +65,12 @@ export function ProjectTabPanel({ tab }: { tab: TabType }) {
           readOnly={readOnly}
           onNavigateToDocumentExplorer={navigateToDocumentExplorer}
           onNavigateToReferences={() => navigateToTab('references')}
-          onNavigateToPeerReview={() => navigateToTab('peer-review')}
+          onNavigateToPeerReview={showExperimentalFeatures ? () => navigateToTab('peer-review') : undefined}
         />
       );
     case 'peer-review':
+      if (isLoadingPreferences) return null;
+      if (!showExperimentalFeatures) return <PeerReviewUnavailable />;
       return (
         <PeerReviewTab
           projectDetail={projectDetail}
@@ -75,4 +81,16 @@ export function ProjectTabPanel({ tab }: { tab: TabType }) {
         />
       );
   }
+}
+
+/**
+ * Shown when the Peer Review route is reached without the alpha opt-in — from a
+ * bookmark or a shared link, since the tab itself is hidden in that case.
+ */
+function PeerReviewUnavailable() {
+  return (
+    <div className="py-12 text-center text-sm text-muted-foreground">
+      Peer Review is an alpha feature. Turn on <strong>Alpha features</strong> in your profile menu to use it.
+    </div>
+  );
 }

--- a/frontend/components/results/tabs/files-tab.tsx
+++ b/frontend/components/results/tabs/files-tab.tsx
@@ -23,6 +23,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { FileDownloadLink } from '@/components/ui/file-download-link';
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
 import { buildReferenceByFileIdMap, composeReferences, ComposedReference } from '@/lib/composed-references';
 import { FileListItem, FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
@@ -179,6 +180,9 @@ export function FilesTab({ projectDetail, readOnly = false, onRevisionCreated }:
   const [searchQuery, setSearchQuery] = useState('');
   const [isReplaceDialogOpen, setIsReplaceDialogOpen] = useState(false);
   const [isUploadOpen, setIsUploadOpen] = useState(false);
+  // Reviewer memos only feed the alpha Peer Review tab, so the role picker is
+  // offered to the same users who can see that tab.
+  const { showExperimentalFeatures } = useExperimentalFeatures();
 
   const referenceExtraction = getWorkflowRunByType(workflowDetails, WorkflowRunType.ReferenceExtraction);
   const referenceFileMatching = getWorkflowRunByType(workflowDetails, WorkflowRunType.ReferenceFileMatching);
@@ -314,9 +318,13 @@ export function FilesTab({ projectDetail, readOnly = false, onRevisionCreated }:
         isOpen={isUploadOpen}
         projectId={projectId}
         title="Upload files"
-        description="Add supporting documents or reviewer memos to this project."
+        description={
+          showExperimentalFeatures
+            ? 'Add supporting documents or reviewer memos to this project.'
+            : 'Add supporting documents to this project.'
+        }
         multiple
-        allowRoleSelection
+        allowRoleSelection={showExperimentalFeatures}
         allowRevisionSelection
         currentRevision={currentRevision}
         onCancel={() => setIsUploadOpen(false)}

--- a/frontend/context/experimental-features-context.tsx
+++ b/frontend/context/experimental-features-context.tsx
@@ -11,6 +11,12 @@ interface ExperimentalFeaturesContextType {
   showExperimentalFeatures: boolean;
   setShowExperimentalFeatures: (value: boolean) => void;
   isUpdating: boolean;
+  /**
+   * True while the preference is still unknown. Gate anything that would
+   * otherwise render its "feature is off" state before the user has loaded.
+   * Stays false for anonymous visitors, whose query never runs.
+   */
+  isLoading: boolean;
 }
 
 const ExperimentalFeaturesContext = React.createContext<ExperimentalFeaturesContextType | undefined>(undefined);
@@ -25,7 +31,7 @@ interface ExperimentalFeaturesProviderProps {
  */
 export function ExperimentalFeaturesProvider({ children }: ExperimentalFeaturesProviderProps) {
   const queryClient = useQueryClient();
-  const { data: user } = useUserMe();
+  const { data: user, isLoading } = useUserMe();
 
   const showExperimentalFeatures = user?.show_experimental_features ?? false;
 
@@ -61,8 +67,9 @@ export function ExperimentalFeaturesProvider({ children }: ExperimentalFeaturesP
       showExperimentalFeatures,
       setShowExperimentalFeatures,
       isUpdating: mutation.isPending,
+      isLoading,
     }),
-    [showExperimentalFeatures, setShowExperimentalFeatures, mutation.isPending],
+    [showExperimentalFeatures, setShowExperimentalFeatures, mutation.isPending, isLoading],
   );
 
   return <ExperimentalFeaturesContext.Provider value={value}>{children}</ExperimentalFeaturesContext.Provider>;


### PR DESCRIPTION
## Summary

Hides the **Peer Review** tab, its route, and the reviewer-memo upload role unless the user has **Alpha features** turned on.

## Motivation

Peer Review is still alpha. Every other alpha capability is already gated behind the Alpha features preference (the assessment picker filters `is_experimental` workflows via `useVisibleWorkflowTypes`), but the Peer Review tab was visible to everyone, so users without the opt-in could reach an unfinished feature.

## What's Changed

### Backend

None.

### Frontend

- **`frontend/context/experimental-features-context.tsx`** — exposes `isLoading` alongside the existing values. A gate that renders an "off" state needs to know when the preference is merely still loading, otherwise it flashes the wrong state before `useUserMe` resolves. Stays `false` for anonymous visitors, whose query never runs.
- **`frontend/components/results/project-results-shell.tsx`** — the `Peer Review` `TabsTrigger` renders only when `showExperimentalFeatures` is true.
- **`frontend/components/results/project-tab-panel.tsx`** — gates the route as well, so a bookmark or an old link cannot bypass the hidden tab; it renders a one-line "Peer Review is an alpha feature" message instead. Also stops passing `onNavigateToPeerReview` to the Assessments tab when alpha is off, which removes the "Manage in Peer Review" button that would otherwise point at a hidden tab (the prop was already optional and guarded).
- **`frontend/components/results/tabs/files-tab.tsx`** — the upload dialog's role picker (supporting document vs. reviewer memo) is offered only with alpha on, and the dialog description follows. Without the Peer Review tab, uploading a reviewer memo is a dead end. Uploads fall back to the supporting-document role.

## Risks and Mitigations

- **Shared views.** `/share/[token]` renders the same shell, and an anonymous viewer has no preference, so Peer Review is now hidden there for everyone. If peer-review results should stay shareable, the gate in the shell needs a `readOnly` or content-based exception. Flagging rather than assuming.
- **Existing projects.** A user with alpha off who already has reviewer memos and peer-review runs loses the entry point to them. The runs still appear in the Assessments tab (they are not marked internal), just without the "Manage in Peer Review" button. This matches how experimental assessments already behave: hidden from the picker, historical results kept. An alternative is to keep the tab visible whenever a project actually has memos.
- **Scope.** Frontend only, no API or schema changes. `tsc --noEmit` is clean and `pnpm lint` reports no new problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
