### PR TITLE
feat(project-view): a redesigned project view under /v2

### DIFF
--- a/frontend/app/(authenticated)/v2/projects/[projectId]/analyses/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/analyses/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+
+/** Production tab content, v2 chrome. Redesigned in a later step. */
+export default function Page() {
+  return <ProjectTabPanel tab="analyses" />;
+}

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/analyses/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/analyses/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+import { AssessmentsV2Panel } from '@/components/results-v2/assessments-v2-panel';
 
-/** Production tab content, v2 chrome. Redesigned in a later step. */
 export default function Page() {
-  return <ProjectTabPanel tab="analyses" />;
+  return <AssessmentsV2Panel />;
 }

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/files/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/files/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+import { FilesV2Panel } from '@/components/results-v2/files-v2-panel';
 
-/** Production tab content, v2 chrome. Redesigned in a later step. */
 export default function Page() {
-  return <ProjectTabPanel tab="files" />;
+  return <FilesV2Panel />;
 }

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/files/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/files/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+
+/** Production tab content, v2 chrome. Redesigned in a later step. */
+export default function Page() {
+  return <ProjectTabPanel tab="files" />;
+}

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/layout.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/layout.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useTabRouting } from '@/components/results/use-tab-routing';
+import { AppBar } from '@/components/results-v2/app-bar';
+import { ProjectShellV2 } from '@/components/results-v2/project-shell';
+import { useProjectShellState } from '@/components/results-v2/use-project-shell-state';
+import { isApiError } from '@/lib/api-error';
+import { needsHumanApproval } from '@/lib/workflow-state';
+import { FileXIcon, LockIcon } from 'lucide-react';
+import { useParams } from 'next/navigation';
+import { ReactNode } from 'react';
+
+/** Centred panel for the states that exist before the project does. */
+function StatusScreen({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-1 items-center justify-center p-8">
+      <div className="max-w-sm text-center">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * The v2 tree mirrors the production project routes one level down, so
+ * `/v2/projects/<id>/files` shows the same tab as `/projects/<id>/files` with the
+ * redesigned chrome around it. Only the document explorer is redesigned so far;
+ * the other tabs render their production panels unchanged.
+ */
+export default function ProjectLayoutV2({ children }: { children: ReactNode }) {
+  const params = useParams();
+  const projectId = params.projectId as string;
+
+  const { activeTab, onTabChange } = useTabRouting(`/v2/projects/${projectId}`);
+
+  const {
+    project,
+    workflowDetails,
+    isLoading,
+    error,
+    effectiveRevision,
+    handleRevisionChange,
+    handleRevisionCreated,
+    handleTitleSave,
+    isTitleSaving,
+    readOnly,
+    isReadOnly,
+    isViewingOldRevision,
+  } = useProjectShellState(projectId);
+
+  const statusScreen = isLoading ? (
+    <StatusScreen>
+      <div className="border-primary mx-auto mb-4 size-8 animate-spin rounded-full border-b-2" />
+      <p className="text-muted-foreground">Loading project...</p>
+    </StatusScreen>
+  ) : isApiError(error, 403) ? (
+    <StatusScreen>
+      <LockIcon className="mx-auto mb-4 size-10 text-muted-foreground" />
+      <h2 className="mb-2 text-lg font-semibold">Access denied</h2>
+      <p className="text-sm text-muted-foreground">
+        You don&apos;t have permission to view this project. Contact the project owner to request access.
+      </p>
+    </StatusScreen>
+  ) : isApiError(error, 404) ? (
+    <StatusScreen>
+      <FileXIcon className="mx-auto mb-4 size-10 text-muted-foreground" />
+      <h2 className="mb-2 text-lg font-semibold">Project not found</h2>
+      <p className="text-sm text-muted-foreground">This project doesn&apos;t exist or may have been deleted.</p>
+    </StatusScreen>
+  ) : error ? (
+    <StatusScreen>
+      <p className="text-destructive">{error.message}</p>
+    </StatusScreen>
+  ) : !project ? (
+    <StatusScreen>
+      <p className="text-muted-foreground">Nothing to show.</p>
+    </StatusScreen>
+  ) : null;
+
+  // The application row renders either way, so a slow load is never a blank page.
+  if (statusScreen) {
+    return (
+      <div className="bg-background text-foreground flex h-dvh flex-col">
+        <AppBar />
+        {statusScreen}
+      </div>
+    );
+  }
+
+  return (
+    <ProjectShellV2
+      projectDetail={project!}
+      activeTab={activeTab}
+      onTabChange={onTabChange}
+      readOnly={readOnly}
+      onTitleSave={isReadOnly ? undefined : handleTitleSave}
+      isTitleSaving={isReadOnly ? undefined : isTitleSaving}
+      needsReferenceReview={!isReadOnly && !isViewingOldRevision && needsHumanApproval(workflowDetails)}
+      selectedRevision={effectiveRevision}
+      onRevisionChange={handleRevisionChange}
+      onRevisionCreated={handleRevisionCreated}
+    >
+      {children}
+    </ProjectShellV2>
+  );
+}

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { DocumentExplorerV2Panel } from '@/components/results-v2/document-explorer-v2-panel';
+
+/** The redesigned document explorer — the root tab, as in production. */
+export default function Page() {
+  return <DocumentExplorerV2Panel />;
+}

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/peer-review/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/peer-review/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+
+/** Production tab content, v2 chrome. Redesigned in a later step. */
+export default function Page() {
+  return <ProjectTabPanel tab="peer-review" />;
+}

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/peer-review/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/peer-review/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+import { PeerReviewV2Panel } from '@/components/results-v2/peer-review-v2-panel';
 
-/** Production tab content, v2 chrome. Redesigned in a later step. */
 export default function Page() {
-  return <ProjectTabPanel tab="peer-review" />;
+  return <PeerReviewV2Panel />;
 }

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/references/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/references/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+
+/** Production tab content, v2 chrome. Redesigned in a later step. */
+export default function Page() {
+  return <ProjectTabPanel tab="references" />;
+}

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/references/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/references/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+import { ReferencesV2Panel } from '@/components/results-v2/references-v2-panel';
 
-/** Production tab content, v2 chrome. Redesigned in a later step. */
 export default function Page() {
-  return <ProjectTabPanel tab="references" />;
+  return <ReferencesV2Panel />;
 }

--- a/frontend/app/(authenticated)/v2/projects/[projectId]/summary/page.tsx
+++ b/frontend/app/(authenticated)/v2/projects/[projectId]/summary/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ProjectTabPanel } from '@/components/results/project-tab-panel';
+
+/** Production tab content, v2 chrome. Redesigned in a later step. */
+export default function Page() {
+  return <ProjectTabPanel tab="summary" />;
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -120,3 +120,22 @@
     @apply bg-background text-foreground;
   }
 }
+
+/**
+ * Shrinks the type scale one step for anything inside it.
+ *
+ * The v2 project view runs a denser chrome than the pages its result
+ * components were written for, and those components are shared with v1, so
+ * their sizes cannot simply be changed. Tailwind v4 resolves every `text-*`
+ * utility through these variables, so redefining them on a wrapper carries the
+ * whole subtree down without touching a single component. Line heights are
+ * unitless ratios in the default theme, so they follow on their own.
+ */
+.text-scale-compact {
+  --text-xs: 0.6875rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-lg: 1rem;
+  --text-xl: 1.125rem;
+  --text-2xl: 1.25rem;
+}

--- a/frontend/components/analysis-wizard/step-analyses.tsx
+++ b/frontend/components/analysis-wizard/step-analyses.tsx
@@ -65,7 +65,7 @@ export function StepAnalyses() {
             <Loader2 className="w-12 h-12 animate-spin text-primary" />
             <div className="text-center space-y-2">
               <h2 className="text-xl font-semibold">Starting Assessment</h2>
-              <p className="text-sm text-muted-foreground">Starting workflows...</p>
+              <p className="text-sm text-muted-foreground">Starting assessments...</p>
             </div>
           </div>
         </CardContent>

--- a/frontend/components/analysis-wizard/use-approve-workflow.ts
+++ b/frontend/components/analysis-wizard/use-approve-workflow.ts
@@ -7,7 +7,7 @@ import { approveWorkflowRunApiWorkflowRunsWorkflowRunIdApprovePost } from '@/lib
 
 function approveRun(humanApprovalRunId: string | undefined) {
   if (!humanApprovalRunId) {
-    throw new Error('Human approval workflow not found');
+    throw new Error('There is no reference review waiting for approval.');
   }
   return approveWorkflowRunApiWorkflowRunsWorkflowRunIdApprovePost({
     path: { workflow_run_id: humanApprovalRunId },

--- a/frontend/components/help/help-center.tsx
+++ b/frontend/components/help/help-center.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 import { HELP_TOPICS, HelpTopicId } from './topics';
@@ -44,7 +45,9 @@ function HelpCenterBody({
   onReviewReferences?: () => void;
 }) {
   const [topicId, setTopicId] = useState<HelpTopicId>(initialTopic);
-  const topic = HELP_TOPICS.find((entry) => entry.id === topicId) ?? HELP_TOPICS[0];
+  const { showExperimentalFeatures } = useExperimentalFeatures();
+  const topics = HELP_TOPICS.filter((entry) => showExperimentalFeatures || !entry.experimental);
+  const topic = topics.find((entry) => entry.id === topicId) ?? topics[0];
   const { Body } = topic;
 
   return (
@@ -58,7 +61,7 @@ function HelpCenterBody({
         <p className="hidden px-2 pb-1 font-mono text-[10px] tracking-wide text-muted-foreground uppercase sm:block">
           Help
         </p>
-        {HELP_TOPICS.map((entry) => (
+        {topics.map((entry) => (
           <button
             key={entry.id}
             onClick={() => setTopicId(entry.id)}

--- a/frontend/components/help/help-center.tsx
+++ b/frontend/components/help/help-center.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
+import { RAIL_ITEM_ACTIVE } from '@/lib/rail-style';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 import { HELP_TOPICS, HelpTopicId } from './topics';
@@ -69,7 +70,7 @@ function HelpCenterBody({
             className={cn(
               'flex shrink-0 cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
               entry.id === topicId
-                ? 'bg-accent text-accent-foreground font-medium'
+                ? RAIL_ITEM_ACTIVE
                 : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',
             )}
           >

--- a/frontend/components/help/help-center.tsx
+++ b/frontend/components/help/help-center.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import { useState } from 'react';
+import { HELP_TOPICS, HelpTopicId } from './topics';
+
+interface HelpCenterProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The topic the link that opened this promised. */
+  topic: HelpTopicId;
+  /** Forwarded to the topic that has somewhere to send the reader. */
+  onReviewReferences?: () => void;
+}
+
+/**
+ * One dialog for every concept the app has to explain, with the list of them
+ * down the side. A reader who arrives asking about source files can see that
+ * revisions are also explained, which a one-off modal per question never shows
+ * them.
+ */
+export function HelpCenter({ open, onOpenChange, topic, onReviewReferences }: HelpCenterProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* Wide enough that the navigation costs the content nothing: the traces
+          in a topic are three columns of prose that stack the moment they are
+          squeezed. */}
+      <DialogContent className="gap-0 p-0 sm:max-w-5xl">
+        {/* Keyed on the topic, and unmounted between openings: either way the
+            dialog starts on the topic of the link that was clicked, rather than
+            wherever the last reader wandered off to. */}
+        <HelpCenterBody key={topic} initialTopic={topic} onReviewReferences={onReviewReferences} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function HelpCenterBody({
+  initialTopic,
+  onReviewReferences,
+}: {
+  initialTopic: HelpTopicId;
+  onReviewReferences?: () => void;
+}) {
+  const [topicId, setTopicId] = useState<HelpTopicId>(initialTopic);
+  const topic = HELP_TOPICS.find((entry) => entry.id === topicId) ?? HELP_TOPICS[0];
+  const { Body } = topic;
+
+  return (
+    <div className="flex max-h-[80vh] min-h-0 flex-col sm:flex-row">
+      {/* A column beside the content, and a strip above it where there is no
+          room for one. */}
+      <nav
+        aria-label="Help topics"
+        className="flex shrink-0 gap-1 overflow-x-auto border-b p-2 sm:w-52 sm:flex-col sm:overflow-visible sm:border-r sm:border-b-0 sm:p-3"
+      >
+        <p className="hidden px-2 pb-1 font-mono text-[10px] tracking-wide text-muted-foreground uppercase sm:block">
+          Help
+        </p>
+        {HELP_TOPICS.map((entry) => (
+          <button
+            key={entry.id}
+            onClick={() => setTopicId(entry.id)}
+            aria-current={entry.id === topicId ? 'page' : undefined}
+            className={cn(
+              'flex shrink-0 cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+              entry.id === topicId
+                ? 'bg-accent text-accent-foreground font-medium'
+                : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',
+            )}
+          >
+            <entry.icon className="size-3.5 shrink-0" aria-hidden />
+            {entry.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {/* pr-12 keeps the heading clear of the dialog's own close button. */}
+        <DialogHeader className="shrink-0 border-b p-4 pr-12 text-left">
+          <DialogTitle className="text-base">{topic.title}</DialogTitle>
+          <DialogDescription>{topic.description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-4 text-sm">
+          <Body onReviewReferences={onReviewReferences} onOpenTopic={setTopicId} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/help/help-link.tsx
+++ b/frontend/components/help/help-link.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { ReactNode, useState } from 'react';
+import { HelpCenter } from './help-center';
+import { HelpTopicId } from './topics';
+
+interface HelpLinkProps {
+  topic: HelpTopicId;
+  /** The link's words. Default asks the question the reader is already asking. */
+  children?: ReactNode;
+  className?: string;
+  /** Forwarded to the source-files topic, where it has somewhere to send them. */
+  onReviewReferences?: () => void;
+}
+
+/**
+ * A quiet link that opens the help centre on one topic, with the dialog it
+ * needs. One component so that adding an explanation somewhere is a single
+ * line, and so every one of them looks and behaves the same.
+ */
+export function HelpLink({ topic, children = 'What is this?', className, onReviewReferences }: HelpLinkProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(event) => {
+          // These sit inside labels, rows and cards that act on a click of
+          // their own; asking what something is must not also choose it.
+          event.preventDefault();
+          event.stopPropagation();
+          setOpen(true);
+        }}
+        className={cn(
+          'cursor-pointer underline underline-offset-2 text-muted-foreground hover:text-foreground',
+          className,
+        )}
+      >
+        {children}
+      </button>
+
+      <HelpCenter
+        open={open}
+        onOpenChange={setOpen}
+        topic={topic}
+        onReviewReferences={
+          onReviewReferences &&
+          (() => {
+            setOpen(false);
+            onReviewReferences();
+          })
+        }
+      />
+    </>
+  );
+}

--- a/frontend/components/help/help-primitives.tsx
+++ b/frontend/components/help/help-primitives.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+
+/** The label that opens each block of a help topic. */
+export function SectionTitle({ children }: { children: ReactNode }) {
+  return <h3 className="mb-1.5 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">{children}</h3>;
+}

--- a/frontend/components/help/help-primitives.tsx
+++ b/frontend/components/help/help-primitives.tsx
@@ -1,6 +1,34 @@
 import { ReactNode } from 'react';
+import type { HelpTopicId } from './topics';
 
 /** The label that opens each block of a help topic. */
 export function SectionTitle({ children }: { children: ReactNode }) {
   return <h3 className="mb-1.5 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">{children}</h3>;
+}
+
+/**
+ * A word in one topic that is explained in another. Falls back to plain text
+ * when the dialog has not passed a navigator, so a body stays readable wherever
+ * it is rendered.
+ */
+export function TopicLink({
+  to,
+  onOpenTopic,
+  children,
+}: {
+  to: HelpTopicId;
+  onOpenTopic?: (topic: HelpTopicId) => void;
+  children: ReactNode;
+}) {
+  if (!onOpenTopic) return <>{children}</>;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenTopic(to)}
+      className="cursor-pointer underline underline-offset-2 hover:text-foreground"
+    >
+      {children}
+    </button>
+  );
 }

--- a/frontend/components/help/topics.ts
+++ b/frontend/components/help/topics.ts
@@ -1,0 +1,84 @@
+import { BookOpen, CircleAlert, FileText, History, ListChecks, LucideIcon } from 'lucide-react';
+import { ComponentType } from 'react';
+import { AssessmentsTopic } from './topics/assessments';
+import { IssuesTopic } from './topics/issues';
+import { ReferencesTopic } from './topics/references';
+import { RevisionsTopic } from './topics/revisions';
+import { SourceFilesTopic } from './topics/source-files';
+
+export type HelpTopicId = 'assessments' | 'issues' | 'references' | 'source-files' | 'revisions';
+
+export interface HelpTopicBodyProps {
+  /**
+   * Sends the reader to the References tab. Passed only where that is somewhere
+   * else to go — the References tab itself omits it.
+   */
+  onReviewReferences?: () => void;
+  /**
+   * Moves the dialog to another topic, for the places where one concept hands
+   * over to the next rather than repeating it.
+   */
+  onOpenTopic?: (topic: HelpTopicId) => void;
+}
+
+export interface HelpTopic {
+  id: HelpTopicId;
+  /** In the navigation, where it sits beside the other topics. */
+  label: string;
+  /** The dialog's heading once this topic is open. */
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  Body: ComponentType<HelpTopicBodyProps>;
+}
+
+/**
+ * The concepts the app explains in one place, ordered as the work runs:
+ * assessments produce issues, references name sources, one assessment needs
+ * those sources, and revisions are what all of it hangs from. Every "what is this" link in the product opens
+ * this list at one of them, so a question asked in one corner is answered next
+ * to all the others.
+ */
+export const HELP_TOPICS: HelpTopic[] = [
+  {
+    id: 'assessments',
+    label: 'Assessments',
+    title: 'Assessments, and what they check',
+    description: 'Each one reads your draft looking for a different kind of problem, and reports what it finds.',
+    icon: ListChecks,
+    Body: AssessmentsTopic,
+  },
+  {
+    id: 'issues',
+    label: 'Issues',
+    title: 'Issues in your document',
+    description: 'One finding from one assessment, anchored to the lines it is about.',
+    icon: CircleAlert,
+    Body: IssuesTopic,
+  },
+  {
+    id: 'references',
+    label: 'References',
+    title: 'References in your bibliography',
+    description: 'Every entry, pulled out of your document automatically.',
+    icon: BookOpen,
+    Body: ReferencesTopic,
+  },
+  {
+    id: 'source-files',
+    label: 'Source files',
+    title: 'Source files, and the assessment that needs them',
+    description:
+      'The document a reference points at. It does not arrive with your draft, so someone has to provide it.',
+    icon: FileText,
+    Body: SourceFilesTopic,
+  },
+  {
+    id: 'revisions',
+    label: 'Revisions',
+    title: 'Revisions of the main document',
+    description: 'Each draft you upload becomes a revision. The ones before it stay, with everything they found.',
+    icon: History,
+    Body: RevisionsTopic,
+  },
+];

--- a/frontend/components/help/topics.ts
+++ b/frontend/components/help/topics.ts
@@ -1,12 +1,13 @@
-import { BookOpen, CircleAlert, FileText, History, ListChecks, LucideIcon } from 'lucide-react';
+import { BookOpen, CircleAlert, FileText, History, ListChecks, LucideIcon, MessagesSquare } from 'lucide-react';
 import { ComponentType } from 'react';
 import { AssessmentsTopic } from './topics/assessments';
 import { IssuesTopic } from './topics/issues';
+import { PeerReviewTopic } from './topics/peer-review';
 import { ReferencesTopic } from './topics/references';
 import { RevisionsTopic } from './topics/revisions';
 import { SourceFilesTopic } from './topics/source-files';
 
-export type HelpTopicId = 'assessments' | 'issues' | 'references' | 'source-files' | 'revisions';
+export type HelpTopicId = 'assessments' | 'issues' | 'references' | 'source-files' | 'revisions' | 'peer-review';
 
 export interface HelpTopicBodyProps {
   /**
@@ -30,14 +31,21 @@ export interface HelpTopic {
   description: string;
   icon: LucideIcon;
   Body: ComponentType<HelpTopicBodyProps>;
+  /**
+   * Listed only for readers who have opted into experimental features, matching
+   * the tab it explains. Explaining a part of the app someone cannot see would
+   * be worse than saying nothing.
+   */
+  experimental?: boolean;
 }
 
 /**
  * The concepts the app explains in one place, ordered as the work runs:
  * assessments produce issues, references name sources, one assessment needs
- * those sources, and revisions are what all of it hangs from. Every "what is this" link in the product opens
- * this list at one of them, so a question asked in one corner is answered next
- * to all the others.
+ * those sources, revisions are what all of it hangs from, and peer review is
+ * what happens once someone else has read the draft. Every "what is this" link
+ * in the product opens this list at one of them, so a question asked in one
+ * corner is answered next to all the others.
  */
 export const HELP_TOPICS: HelpTopic[] = [
   {
@@ -80,5 +88,14 @@ export const HELP_TOPICS: HelpTopic[] = [
     description: 'Each draft you upload becomes a revision. The ones before it stay, with everything they found.',
     icon: History,
     Body: RevisionsTopic,
+  },
+  {
+    id: 'peer-review',
+    label: 'Peer Review',
+    title: 'Peer review, from memos to sign-off',
+    description: 'The round trip after other people have read your draft: plan, revise, respond, and check coverage.',
+    icon: MessagesSquare,
+    Body: PeerReviewTopic,
+    experimental: true,
   },
 ];

--- a/frontend/components/help/topics/assessments.tsx
+++ b/frontend/components/help/topics/assessments.tsx
@@ -2,7 +2,8 @@
 
 import { Clock, History, LucideIcon, PlayIcon } from 'lucide-react';
 import { ReactNode } from 'react';
-import { SectionTitle } from '../help-primitives';
+import { SectionTitle, TopicLink } from '../help-primitives';
+import { HelpTopicBodyProps } from '../topics';
 
 /** What running one sets in motion, once you have picked from the list. */
 const MECHANICS: { icon: LucideIcon; title: string; body: string }[] = [
@@ -29,15 +30,20 @@ const MECHANICS: { icon: LucideIcon; title: string; body: string }[] = [
  * away in the dialog that starts them, and repeating it here would be a second
  * copy to keep true.
  */
-export function AssessmentsTopic() {
+export function AssessmentsTopic({ onOpenTopic }: HelpTopicBodyProps) {
   return (
     <div className="space-y-5">
       <section>
         <SectionTitle>One question each</SectionTitle>
         <p className="text-foreground/80 leading-relaxed">
           An assessment reads your draft looking for one kind of problem, and reports what it finds as{' '}
-          <strong className="text-foreground font-medium">issues in the document explorer</strong>, anchored to the
-          lines they are about. Nothing is changed in your document — an assessment only reads.
+          <strong className="text-foreground font-medium">
+            <TopicLink to="issues" onOpenTopic={onOpenTopic}>
+              issues
+            </TopicLink>{' '}
+            in the document explorer
+          </strong>
+          , anchored to the lines they are about. Nothing is changed in your document — an assessment only reads.
         </p>
       </section>
 
@@ -45,7 +51,11 @@ export function AssessmentsTopic() {
         <SectionTitle>Running them</SectionTitle>
         <p className="text-foreground/80 mb-2 leading-relaxed">
           <strong className="text-foreground font-medium">Run assessments</strong> in the header opens the list at any
-          time, from any tab. The Assessments tab is where their results are read.
+          time, from any tab. The Assessments tab is where their results are read, and every run is filed under the{' '}
+          <TopicLink to="revisions" onOpenTopic={onOpenTopic}>
+            revision
+          </TopicLink>{' '}
+          it read.
         </p>
         <div className="space-y-2">
           {MECHANICS.map((item) => (
@@ -55,8 +65,11 @@ export function AssessmentsTopic() {
           ))}
         </div>
         <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-          One assessment waits for you rather than for another assessment: Claim Reference Validation needs the source
-          documents behind your citations, and holds until you say they are ready.
+          One assessment waits for you rather than for another assessment: Claim Reference Validation needs the{' '}
+          <TopicLink to="source-files" onOpenTopic={onOpenTopic}>
+            source documents
+          </TopicLink>{' '}
+          behind your citations, and holds until you say they are ready.
         </p>
       </section>
     </div>

--- a/frontend/components/help/topics/assessments.tsx
+++ b/frontend/components/help/topics/assessments.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Clock, History, LucideIcon, PlayIcon } from 'lucide-react';
+import { ReactNode } from 'react';
+import { SectionTitle } from '../help-primitives';
+
+/** What running one sets in motion, once you have picked from the list. */
+const MECHANICS: { icon: LucideIcon; title: string; body: string }[] = [
+  {
+    icon: PlayIcon,
+    title: 'They run in the background, and in order',
+    body: 'Pick as many as you like and carry on reading. Some need another to finish first — the document has to be converted before anything can be read — so they queue themselves rather than asking you to sequence them.',
+  },
+  {
+    icon: History,
+    title: 'Re-running one replaces what the explorer shows',
+    body: 'The findings from the previous run are archived rather than deleted: the run stays in that assessment’s history, and you can open it to read what it said.',
+  },
+  {
+    icon: Clock,
+    title: 'Every run records what it cost',
+    body: 'How long it took and what it spent are kept beside the result, so an expensive assessment is an informed choice rather than a surprise.',
+  },
+];
+
+/**
+ * What an assessment is and what running one costs you. Deliberately not a
+ * catalogue: the list of assessments, with each one's description, is a click
+ * away in the dialog that starts them, and repeating it here would be a second
+ * copy to keep true.
+ */
+export function AssessmentsTopic() {
+  return (
+    <div className="space-y-5">
+      <section>
+        <SectionTitle>One question each</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          An assessment reads your draft looking for one kind of problem, and reports what it finds as{' '}
+          <strong className="text-foreground font-medium">issues in the document explorer</strong>, anchored to the
+          lines they are about. Nothing is changed in your document — an assessment only reads.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Running them</SectionTitle>
+        <p className="text-foreground/80 mb-2 leading-relaxed">
+          <strong className="text-foreground font-medium">Run assessments</strong> in the header opens the list at any
+          time, from any tab. The Assessments tab is where their results are read.
+        </p>
+        <div className="space-y-2">
+          {MECHANICS.map((item) => (
+            <Mechanic key={item.title} icon={item.icon} title={item.title}>
+              {item.body}
+            </Mechanic>
+          ))}
+        </div>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          One assessment waits for you rather than for another assessment: Claim Reference Validation needs the source
+          documents behind your citations, and holds until you say they are ready.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function Mechanic({ icon: Icon, title, children }: { icon: LucideIcon; title: string; children: ReactNode }) {
+  return (
+    <div className="flex gap-2.5 rounded-md border p-2.5">
+      <Icon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <div className="min-w-0">
+        <p className="text-xs font-medium">{title}</p>
+        <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{children}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/help/topics/issues.tsx
+++ b/frontend/components/help/topics/issues.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { SeverityEnum } from '@/lib/generated-api';
+import { SEVERITY } from '@/lib/severity-style';
+import { cn } from '@/lib/utils';
+import { CheckIcon, LightbulbIcon, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { ReactNode } from 'react';
+import { SectionTitle } from '../help-primitives';
+
+/** What each level means, in the colours the document and the list use. */
+const LEVELS: { severity: SeverityEnum; gloss: string }[] = [
+  { severity: SeverityEnum.High, gloss: 'Worth fixing before this goes out.' },
+  { severity: SeverityEnum.Medium, gloss: 'Worth a look; the assessment is not certain, or the stakes are lower.' },
+  { severity: SeverityEnum.Low, gloss: 'A small thing, offered in case you want it.' },
+  { severity: SeverityEnum.None, gloss: 'The check ran here and found nothing wrong. Hidden until you ask for it.' },
+];
+
+/**
+ * What an issue is, shown rather than described: the anatomy below is the same
+ * note the margin and the issue list render, so a reader meets the thing itself
+ * before being told how to act on it.
+ */
+export function IssuesTopic() {
+  return (
+    <div className="space-y-5">
+      <section>
+        <SectionTitle>One finding, in one place</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          An issue is a single thing an assessment found, tied to{' '}
+          <strong className="text-foreground font-medium">the lines it is about</strong>. That anchor is what the
+          document explorer is built on: issues sit in the margin beside their paragraph, and selecting one moves the
+          document to it.
+        </p>
+
+        <div className="mt-2 overflow-hidden rounded-md border">
+          <div className={cn('flex items-start gap-2 border-b px-3 py-2', SEVERITY[SeverityEnum.Medium].wash)}>
+            <span className={cn('mt-1.5 block size-1.5 shrink-0 rounded-full', SEVERITY[SeverityEnum.Medium].dot)} />
+            <div className="min-w-0">
+              <p className="text-xs font-medium">Abbreviation “GER” is used before it is defined</p>
+              <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                It first appears on line 21, and is spelled out on line 96.
+              </p>
+            </div>
+            <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">L21</span>
+          </div>
+
+          <div className="space-y-2 px-3 py-2">
+            <div className="bg-background/60 rounded border border-dashed px-2 py-1.5">
+              <p className="mb-1 flex items-center gap-1 font-mono text-[9.5px] tracking-wide text-muted-foreground uppercase">
+                <LightbulbIcon className="size-3" aria-hidden />
+                Suggested action
+              </p>
+              <p className="text-xs leading-relaxed">
+                Spell the term out at its first use, then use the abbreviation from there on.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-1.5">
+              <span className="bg-primary text-primary-foreground inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium">
+                <CheckIcon className="size-3" aria-hidden />
+                Mark resolved
+              </span>
+              <span className="ml-auto flex items-center gap-1 text-muted-foreground">
+                <ThumbsUp className="size-3" aria-hidden />
+                <ThumbsDown className="size-3" aria-hidden />
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          The example is invented; a real one names the assessment that raised it and often carries further detail
+          behind <span className="font-medium">Show details</span>.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>How bad it thinks it is</SectionTitle>
+        <ul className="space-y-1.5">
+          {LEVELS.map((level) => (
+            <li key={level.severity} className="flex items-baseline gap-2">
+              <span className={cn('mt-1.5 block size-1.5 shrink-0 rounded-full', SEVERITY[level.severity].dot)} />
+              <span className="min-w-0 text-xs leading-snug">
+                <strong className={cn('font-medium', SEVERITY[level.severity].text)}>
+                  {SEVERITY[level.severity].label}
+                </strong>{' '}
+                <span className="text-muted-foreground">{level.gloss}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          Severity is the assessment&apos;s judgement, not a verdict on your draft. Read the ones that matter to you and
+          ignore the rest.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>What you can do with one</SectionTitle>
+        <ul className="space-y-1.5">
+          <Fact term="Mark it resolved">
+            Once you have dealt with it, or decided not to. Resolved issues drop out of the view and out of the counts,
+            and the filter panel brings them back.
+          </Fact>
+          <Fact term="Say whether it was any good">
+            The thumbs on an issue tell us where an assessment is earning its place and where it is wasting your time.
+          </Fact>
+          <Fact term="Narrow the list">
+            The filters take the explorer down to one severity or one assessment, which is how a few hundred issues
+            become a session&apos;s worth of work.
+          </Fact>
+        </ul>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          Issues belong to the revision they were found in. Re-running an assessment, or uploading a new draft, files
+          the old ones away rather than deleting them.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function Fact({ term, children }: { term: string; children: ReactNode }) {
+  return (
+    <li className="text-xs leading-relaxed">
+      <strong className="font-medium">{term}.</strong> <span className="text-muted-foreground">{children}</span>
+    </li>
+  );
+}

--- a/frontend/components/help/topics/issues.tsx
+++ b/frontend/components/help/topics/issues.tsx
@@ -5,7 +5,8 @@ import { SEVERITY } from '@/lib/severity-style';
 import { cn } from '@/lib/utils';
 import { CheckIcon, LightbulbIcon, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { ReactNode } from 'react';
-import { SectionTitle } from '../help-primitives';
+import { SectionTitle, TopicLink } from '../help-primitives';
+import { HelpTopicBodyProps } from '../topics';
 
 /** What each level means, in the colours the document and the list use. */
 const LEVELS: { severity: SeverityEnum; gloss: string }[] = [
@@ -20,16 +21,19 @@ const LEVELS: { severity: SeverityEnum; gloss: string }[] = [
  * note the margin and the issue list render, so a reader meets the thing itself
  * before being told how to act on it.
  */
-export function IssuesTopic() {
+export function IssuesTopic({ onOpenTopic }: HelpTopicBodyProps) {
   return (
     <div className="space-y-5">
       <section>
         <SectionTitle>One finding, in one place</SectionTitle>
         <p className="text-foreground/80 leading-relaxed">
-          An issue is a single thing an assessment found, tied to{' '}
-          <strong className="text-foreground font-medium">the lines it is about</strong>. That anchor is what the
-          document explorer is built on: issues sit in the margin beside their paragraph, and selecting one moves the
-          document to it.
+          An issue is a single thing an{' '}
+          <TopicLink to="assessments" onOpenTopic={onOpenTopic}>
+            assessment
+          </TopicLink>{' '}
+          found, tied to <strong className="text-foreground font-medium">the lines it is about</strong>. That anchor is
+          what the document explorer is built on: issues sit in the margin beside their paragraph, and selecting one
+          moves the document to it.
         </p>
 
         <div className="mt-2 overflow-hidden rounded-md border">
@@ -111,8 +115,12 @@ export function IssuesTopic() {
           </Fact>
         </ul>
         <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-          Issues belong to the revision they were found in. Re-running an assessment, or uploading a new draft, files
-          the old ones away rather than deleting them.
+          Issues belong to the{' '}
+          <TopicLink to="revisions" onOpenTopic={onOpenTopic}>
+            revision
+          </TopicLink>{' '}
+          they were found in. Re-running an assessment, or uploading a new draft, files the old ones away rather than
+          deleting them.
         </p>
       </section>
     </div>

--- a/frontend/components/help/topics/peer-review.tsx
+++ b/frontend/components/help/topics/peer-review.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { ReactNode } from 'react';
+import { SectionTitle, TopicLink } from '../help-primitives';
+import { HelpTopicBodyProps } from '../topics';
+
+interface Step {
+  title: string;
+  body: string;
+  /** The step the author does by hand; every other one is a run. */
+  byHand?: boolean;
+}
+
+/**
+ * The sequence, in the order it has to happen. Numbered because it genuinely is
+ * an order — two of these steps compare the revised draft against the reviewed
+ * one, so they cannot run until the draft in the middle exists.
+ */
+const STEPS: Step[] = [
+  {
+    title: 'Plan the revision',
+    body: 'Reads the memos and breaks every reviewer’s points into discrete, actionable suggestions, each mapped to the part of your draft it lands on.',
+  },
+  {
+    title: 'Upload your revised draft',
+    body: 'You write the revision; this step files it as a new one, which is what gives the next two steps a before and an after to compare.',
+    byHand: true,
+  },
+  {
+    title: 'Respond to the reviewers',
+    body: 'Drafts one response memo per reviewer. Each of their points is echoed back word for word, with a reply on what changed and where — or why it did not.',
+  },
+  {
+    title: 'QA coverage report',
+    body: 'Gives every point a verdict — addressed, partly addressed, declined with a rationale, or not addressed — plus a count table and an overall read for sign-off.',
+  },
+];
+
+/**
+ * The one part of the app that is not about reading your draft: it is about the
+ * round trip after other people have read it. The steps carry the explanation,
+ * because the order is the thing that surprises people.
+ */
+export function PeerReviewTopic({ onOpenTopic }: HelpTopicBodyProps) {
+  return (
+    <div className="space-y-5">
+      <section>
+        <SectionTitle>After the reviewers reply</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          Every other{' '}
+          <TopicLink to="assessments" onOpenTopic={onOpenTopic}>
+            assessment
+          </TopicLink>{' '}
+          reads your draft on its own. Peer Review starts from{' '}
+          <strong className="text-foreground font-medium">what your reviewers wrote about it</strong> — their memos —
+          and walks the round trip from those comments to a revised draft, a reply to each reviewer, and a report on how
+          much of it you actually addressed.
+        </p>
+        <p className="text-foreground/80 mt-2 leading-relaxed">
+          A <strong className="text-foreground font-medium">reviewer memo</strong> is one reviewer&apos;s document about
+          your draft. Add them like any other file, tagged as reviewer memos. They belong to the{' '}
+          <TopicLink to="revisions" onOpenTopic={onOpenTopic}>
+            revision
+          </TopicLink>{' '}
+          they were written about, so if you upload a newer draft first, memos left on the older one are the ones these
+          steps read.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>The four steps</SectionTitle>
+        <ol className="space-y-2">
+          {STEPS.map((step, index) => (
+            <li key={step.title} className="flex gap-2.5 rounded-md border p-2.5">
+              <span
+                className={cn(
+                  'mt-px flex size-4 shrink-0 items-center justify-center rounded-full font-mono text-[10px] font-medium',
+                  step.byHand ? 'bg-muted text-muted-foreground' : 'bg-primary/10 text-primary',
+                )}
+              >
+                {index + 1}
+              </span>
+              <div className="min-w-0">
+                <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-medium">
+                  {step.title}
+                  {step.byHand && (
+                    <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      Your turn
+                    </span>
+                  )}
+                </p>
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{step.body}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          A step stays locked until what it reads exists, and says what it is waiting for. Nothing here starts on its
+          own either — not even when you create a revision — because these steps read one draft against another, and
+          only you know when the revision is the one you meant.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Where it lives</SectionTitle>
+        <ul className="space-y-1.5">
+          <Fact term="The Peer Review tab">
+            The steps, the memos they read, and each step&apos;s report. Results also appear on the Assessments tab
+            alongside{' '}
+            <TopicLink to="assessments" onOpenTopic={onOpenTopic}>
+              everything else
+            </TopicLink>
+            , but this is where they are sequenced and started.
+          </Fact>
+          <Fact term="Still in alpha">
+            It is behind an opt-in while the sequence settles, which is why it is not in every project.
+          </Fact>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function Fact({ term, children }: { term: string; children: ReactNode }) {
+  return (
+    <li className="text-xs leading-relaxed">
+      <strong className="font-medium">{term}.</strong> <span className="text-muted-foreground">{children}</span>
+    </li>
+  );
+}

--- a/frontend/components/help/topics/references.tsx
+++ b/frontend/components/help/topics/references.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ScanSearch } from 'lucide-react';
-import { SectionTitle } from '../help-primitives';
+import { SectionTitle, TopicLink } from '../help-primitives';
 import { HelpTopicBodyProps } from '../topics';
 
 /**
@@ -34,8 +34,11 @@ export function ReferencesTopic({ onOpenTopic }: HelpTopicBodyProps) {
           appear in the document.
         </p>
         <p className="text-foreground/80 mt-2 leading-relaxed">
-          Extraction runs on its own as soon as the document is processed, and again on each new revision, so the list
-          always describes the draft you are reading.
+          Extraction runs on its own as soon as the document is processed, and again on each new{' '}
+          <TopicLink to="revisions" onOpenTopic={onOpenTopic}>
+            revision
+          </TopicLink>
+          , so the list always describes the draft you are reading.
         </p>
       </section>
 
@@ -71,7 +74,15 @@ export function ReferencesTopic({ onOpenTopic }: HelpTopicBodyProps) {
           </div>
         </div>
         <p className="text-foreground/80 mt-2 leading-relaxed">
-          This one needs nothing from you: the reference is all it reads.
+          This one needs nothing from you: the reference is all it reads. It is one of the{' '}
+          <TopicLink to="assessments" onOpenTopic={onOpenTopic}>
+            assessments
+          </TopicLink>
+          , and what it finds arrives as{' '}
+          <TopicLink to="issues" onOpenTopic={onOpenTopic}>
+            issues
+          </TopicLink>{' '}
+          like everything else.
         </p>
       </section>
 
@@ -83,16 +94,9 @@ export function ReferencesTopic({ onOpenTopic }: HelpTopicBodyProps) {
             A bibliography entry names a source, it does not contain one
           </strong>
           , so checking whether the work you cite actually says what you say it says takes the document itself —{' '}
-          {onOpenTopic ? (
-            <button
-              onClick={() => onOpenTopic('source-files')}
-              className="cursor-pointer underline underline-offset-2 hover:text-foreground"
-            >
-              a source file
-            </button>
-          ) : (
-            'a source file'
-          )}
+          <TopicLink to="source-files" onOpenTopic={onOpenTopic}>
+            a source file
+          </TopicLink>
           .
         </p>
       </section>

--- a/frontend/components/help/topics/references.tsx
+++ b/frontend/components/help/topics/references.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { ScanSearch } from 'lucide-react';
+import { SectionTitle } from '../help-primitives';
+import { HelpTopicBodyProps } from '../topics';
+
+/**
+ * An invented entry, broken into the parts a citation check compares against
+ * the published record. A real reference from the reader's own bibliography
+ * would make the point better, but this topic is read from anywhere — including
+ * before extraction has run.
+ */
+const PARTS: { label: string; value: string }[] = [
+  { label: 'Author', value: 'Sandoval, R., & Okoye, T.' },
+  { label: 'Year', value: '(2023).' },
+  { label: 'Title', value: 'Compute trends in large-scale training.' },
+  { label: 'Publisher', value: 'Journal of Applied Computing, 14(2), 88–104.' },
+];
+
+/**
+ * What a reference is and where it comes from. Deliberately stops at the edge
+ * of the bibliography: what happens once you have the document a reference
+ * names is the source-files topic, one entry down.
+ */
+export function ReferencesTopic({ onOpenTopic }: HelpTopicBodyProps) {
+  return (
+    <div className="space-y-5">
+      <section>
+        <SectionTitle>Where they come from</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          A reference is one entry in your bibliography. Draft Detective{' '}
+          <strong className="text-foreground font-medium">pulls every one of them out of your draft by itself</strong> —
+          you do not type them in or upload a list — and the References tab is where they are listed, in the order they
+          appear in the document.
+        </p>
+        <p className="text-foreground/80 mt-2 leading-relaxed">
+          Extraction runs on its own as soon as the document is processed, and again on each new revision, so the list
+          always describes the draft you are reading.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>What an entry is made of</SectionTitle>
+        <div className="overflow-hidden rounded-md border">
+          {PARTS.map((part) => (
+            <div key={part.label} className="flex flex-wrap gap-x-3 gap-y-0.5 border-b px-3 py-1.5 last:border-b-0">
+              <span className="w-16 shrink-0 font-mono text-[9.5px] tracking-wide text-muted-foreground uppercase">
+                {part.label}
+              </span>
+              <span className="min-w-0 text-xs">{part.value}</span>
+            </div>
+          ))}
+        </div>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          The example is invented. Read together, those parts are a claim about something that exists in the world —
+          which is a claim that can be checked.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Checking the citation itself</SectionTitle>
+        <div className="flex gap-2.5 rounded-md border p-2.5">
+          <ScanSearch className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <div className="min-w-0">
+            <p className="text-xs font-medium">Reference Error Checker</p>
+            <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+              Searches the web for each reference and compares the author, title, publisher and year against what it
+              finds. It is what catches a mistyped year, an author who has drifted between drafts, or a citation of
+              something that was never published.
+            </p>
+          </div>
+        </div>
+        <p className="text-foreground/80 mt-2 leading-relaxed">
+          This one needs nothing from you: the reference is all it reads.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Where a reference stops</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          A correct citation is not the same as a true claim.{' '}
+          <strong className="text-foreground font-medium">
+            A bibliography entry names a source, it does not contain one
+          </strong>
+          , so checking whether the work you cite actually says what you say it says takes the document itself —{' '}
+          {onOpenTopic ? (
+            <button
+              onClick={() => onOpenTopic('source-files')}
+              className="cursor-pointer underline underline-offset-2 hover:text-foreground"
+            >
+              a source file
+            </button>
+          ) : (
+            'a source file'
+          )}
+          .
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/help/topics/revisions.tsx
+++ b/frontend/components/help/topics/revisions.tsx
@@ -3,7 +3,8 @@
 import { cn } from '@/lib/utils';
 import { CircleStop, FileText, LucideIcon, PlayCircle, Upload } from 'lucide-react';
 import { ReactNode } from 'react';
-import { SectionTitle } from '../help-primitives';
+import { SectionTitle, TopicLink } from '../help-primitives';
+import { HelpTopicBodyProps } from '../topics';
 
 interface Version {
   label: string;
@@ -53,15 +54,18 @@ const STEPS: { icon: LucideIcon; title: string; body: string }[] = [
  * always the same — what happens to everything I have already done — so the
  * answer leads: the earlier draft and its results stay exactly where they were.
  */
-export function RevisionsTopic() {
+export function RevisionsTopic({ onOpenTopic }: HelpTopicBodyProps) {
   return (
     <div className="space-y-5">
       <section>
         <SectionTitle>One project, several drafts</SectionTitle>
         <p className="text-foreground/80 leading-relaxed">
           A revision is a version of the main document. Uploading a new one does not replace what came before it —{' '}
-          <strong className="text-foreground font-medium">every earlier revision stays readable</strong>, alongside the
-          issues and results it collected. The revision menu in the header is how you move between them.
+          <strong className="text-foreground font-medium">every earlier revision stays readable</strong>, alongside the{' '}
+          <TopicLink to="issues" onOpenTopic={onOpenTopic}>
+            issues
+          </TopicLink>{' '}
+          and results it collected. The revision menu in the header is how you move between them.
         </p>
 
         <div className="mt-2 overflow-hidden rounded-md border">
@@ -111,11 +115,23 @@ export function RevisionsTopic() {
       <section>
         <SectionTitle>What the other files do</SectionTitle>
         <ul className="space-y-1.5">
-          <Fact term="Source files">
+          <Fact
+            term={
+              <TopicLink to="source-files" onOpenTopic={onOpenTopic}>
+                Source files
+              </TopicLink>
+            }
+          >
             Shared by every revision. Provide a reference&apos;s source once and later drafts inherit it, so a new
             revision does not send you back to the References tab.
           </Fact>
-          <Fact term="Reviewer memos">
+          <Fact
+            term={
+              <TopicLink to="peer-review" onOpenTopic={onOpenTopic}>
+                Reviewer memos
+              </TopicLink>
+            }
+          >
             Belong to the revision they were written about, because that is the draft their author read.
           </Fact>
         </ul>
@@ -136,7 +152,7 @@ function Step({ icon: Icon, title, children }: { icon: LucideIcon; title: string
   );
 }
 
-function Fact({ term, children }: { term: string; children: ReactNode }) {
+function Fact({ term, children }: { term: ReactNode; children: ReactNode }) {
   return (
     <li className="text-xs leading-relaxed">
       <strong className="font-medium">{term}.</strong> <span className="text-muted-foreground">{children}</span>

--- a/frontend/components/help/topics/revisions.tsx
+++ b/frontend/components/help/topics/revisions.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { CircleStop, FileText, LucideIcon, PlayCircle, Upload } from 'lucide-react';
+import { ReactNode } from 'react';
+import { SectionTitle } from '../help-primitives';
+
+interface Version {
+  label: string;
+  tag?: string;
+  file: string;
+  note: string;
+  current?: boolean;
+}
+
+/** Newest first, the way the revision menu lists them. */
+const STACK: Version[] = [
+  {
+    label: 'Revision 2',
+    tag: 'Current',
+    file: 'manuscript-v2.docx',
+    note: 'What the explorer shows and what assessments read.',
+    current: true,
+  },
+  {
+    label: 'Revision 1',
+    file: 'manuscript-v1.docx',
+    note: 'Kept as it was, with the issues and results it had.',
+  },
+];
+
+/** What creating a revision sets in motion, in the order it happens. */
+const STEPS: { icon: LucideIcon; title: string; body: string }[] = [
+  {
+    icon: Upload,
+    title: 'Your new file becomes the current revision',
+    body: 'The draft you upload is numbered next and takes over the project view. The one it replaces is not overwritten.',
+  },
+  {
+    icon: CircleStop,
+    title: 'Work still running on the old draft stops',
+    body: 'Anything mid-run would be reporting on a document nobody is reading any more, so it is cancelled rather than finished.',
+  },
+  {
+    icon: PlayCircle,
+    title: 'The assessments that ran before run again',
+    body: 'On the new draft, unless you clear that option while uploading. Peer Review is the exception: you start it yourself, once the memos for the draft are in.',
+  },
+];
+
+/**
+ * What a revision is and what one costs to make. The question underneath is
+ * always the same — what happens to everything I have already done — so the
+ * answer leads: the earlier draft and its results stay exactly where they were.
+ */
+export function RevisionsTopic() {
+  return (
+    <div className="space-y-5">
+      <section>
+        <SectionTitle>One project, several drafts</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          A revision is a version of the main document. Uploading a new one does not replace what came before it —{' '}
+          <strong className="text-foreground font-medium">every earlier revision stays readable</strong>, alongside the
+          issues and results it collected. The revision menu in the header is how you move between them.
+        </p>
+
+        <div className="mt-2 overflow-hidden rounded-md border">
+          {STACK.map((version) => (
+            <div
+              key={version.label}
+              className={cn(
+                'flex flex-wrap items-baseline gap-x-2.5 gap-y-1 border-b px-3 py-2 last:border-b-0',
+                version.current && 'bg-primary/5',
+              )}
+            >
+              <span className="text-xs font-medium">{version.label}</span>
+              {version.tag && (
+                <span className="bg-primary/10 text-primary rounded-sm px-1.5 py-0.5 text-[10px] font-semibold">
+                  {version.tag}
+                </span>
+              )}
+              {/* Inline rather than a nested flex: a flex box takes its baseline
+                  from its first item, and an icon has none, which drops the name
+                  below the line the rest of the row sits on. */}
+              <span className="min-w-0 font-mono text-[11px] text-muted-foreground">
+                <FileText className="mr-1.5 inline size-3 align-[-0.15em]" aria-hidden />
+                {version.file}
+              </span>
+              <span className="text-foreground/80 basis-full text-xs sm:basis-auto">{version.note}</span>
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          Reading an earlier revision is read-only. Nothing there can be edited, resolved, or re-run — it is a record of
+          where the draft stood.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Creating one</SectionTitle>
+        <div className="space-y-2">
+          {STEPS.map((step) => (
+            <Step key={step.title} icon={step.icon} title={step.title}>
+              {step.body}
+            </Step>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <SectionTitle>What the other files do</SectionTitle>
+        <ul className="space-y-1.5">
+          <Fact term="Source files">
+            Shared by every revision. Provide a reference&apos;s source once and later drafts inherit it, so a new
+            revision does not send you back to the References tab.
+          </Fact>
+          <Fact term="Reviewer memos">
+            Belong to the revision they were written about, because that is the draft their author read.
+          </Fact>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function Step({ icon: Icon, title, children }: { icon: LucideIcon; title: string; children: ReactNode }) {
+  return (
+    <div className="flex gap-2.5 rounded-md border p-2.5">
+      <Icon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <div className="min-w-0">
+        <p className="text-xs font-medium">{title}</p>
+        <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function Fact({ term, children }: { term: string; children: ReactNode }) {
+  return (
+    <li className="text-xs leading-relaxed">
+      <strong className="font-medium">{term}.</strong> <span className="text-muted-foreground">{children}</span>
+    </li>
+  );
+}

--- a/frontend/components/help/topics/source-files.tsx
+++ b/frontend/components/help/topics/source-files.tsx
@@ -6,7 +6,7 @@ import { SEVERITY } from '@/lib/severity-style';
 import { cn } from '@/lib/utils';
 import { ArrowRight, FileText, FileX2, Globe, LucideIcon, Upload } from 'lucide-react';
 import { ReactNode } from 'react';
-import { SectionTitle } from '../help-primitives';
+import { SectionTitle, TopicLink } from '../help-primitives';
 import { HelpTopicBodyProps } from '../topics';
 
 interface Verdict {
@@ -79,16 +79,9 @@ export function SourceFilesTopic({ onReviewReferences, onOpenTopic }: HelpTopicB
         <SectionTitle>The document behind a reference</SectionTitle>
         <p className="text-foreground/80 leading-relaxed">
           A source file is the actual paper, report or page that one of your{' '}
-          {onOpenTopic ? (
-            <button
-              onClick={() => onOpenTopic('references')}
-              className="cursor-pointer underline underline-offset-2 hover:text-foreground"
-            >
-              references
-            </button>
-          ) : (
-            'references'
-          )}{' '}
+          <TopicLink to="references" onOpenTopic={onOpenTopic}>
+            references
+          </TopicLink>{' '}
           points at. It does not arrive with your draft, because{' '}
           <strong className="text-foreground font-medium">
             a bibliography entry names a source, it does not contain one
@@ -96,9 +89,12 @@ export function SourceFilesTopic({ onReviewReferences, onOpenTopic }: HelpTopicB
           . The References tab says, for each reference, whether one has been provided.
         </p>
         <p className="text-foreground/80 mt-2 leading-relaxed">
-          <strong className="text-foreground font-medium">Claim Reference Validation</strong> is the assessment that
-          needs them. It reads the document behind each citation and compares it to the claim you hung on it, which is
-          not something a bibliography entry can answer.
+          <strong className="text-foreground font-medium">Claim Reference Validation</strong> is the{' '}
+          <TopicLink to="assessments" onOpenTopic={onOpenTopic}>
+            assessment
+          </TopicLink>{' '}
+          that needs them. It reads the document behind each citation and compares it to the claim you hung on it, which
+          is not something a bibliography entry can answer.
         </p>
       </section>
 
@@ -117,6 +113,13 @@ export function SourceFilesTopic({ onReviewReferences, onOpenTopic }: HelpTopicB
 
       <section>
         <SectionTitle>What comes back</SectionTitle>
+        <p className="text-foreground/80 mb-2 leading-relaxed">
+          One verdict per citation, each arriving as an{' '}
+          <TopicLink to="issues" onOpenTopic={onOpenTopic}>
+            issue
+          </TopicLink>{' '}
+          on the line that carries the claim.
+        </p>
         <ul className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
           {OUTCOMES.map((outcome) => (
             <li key={outcome.label} className="flex items-baseline gap-2">
@@ -153,7 +156,11 @@ export function SourceFilesTopic({ onReviewReferences, onOpenTopic }: HelpTopicB
           runs normally.
         </p>
         <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-          Source files are shared across revisions, so this is not work you repeat on the next draft.
+          Source files are shared across{' '}
+          <TopicLink to="revisions" onOpenTopic={onOpenTopic}>
+            revisions
+          </TopicLink>
+          , so this is not work you repeat on the next draft.
         </p>
 
         {onReviewReferences && (

--- a/frontend/components/help/topics/source-files.tsx
+++ b/frontend/components/help/topics/source-files.tsx
@@ -1,20 +1,13 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { SeverityEnum } from '@/lib/generated-api';
 import { SEVERITY } from '@/lib/severity-style';
 import { cn } from '@/lib/utils';
 import { ArrowRight, FileText, FileX2, Globe, LucideIcon, Upload } from 'lucide-react';
 import { ReactNode } from 'react';
+import { SectionTitle } from '../help-primitives';
+import { HelpTopicBodyProps } from '../topics';
 
 interface Verdict {
   severity: SeverityEnum;
@@ -74,94 +67,102 @@ const OUTCOMES: Verdict[] = [
   { severity: SeverityEnum.Medium, label: 'Unverifiable', gloss: 'There was nothing to check against.' },
 ];
 
-interface ReferenceReviewExplainerProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  /** Omitted when the reader is already on the References tab. */
-  onReviewReferences?: () => void;
-}
-
-export function ReferenceReviewExplainer({ open, onOpenChange, onReviewReferences }: ReferenceReviewExplainerProps) {
+/**
+ * The document behind a reference, and why one assessment cannot work without
+ * it. The examples carry the argument: side by side, the only thing separating
+ * a real verdict from an unverifiable one is whether we hold the source.
+ */
+export function SourceFilesTopic({ onReviewReferences, onOpenTopic }: HelpTopicBodyProps) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl">
-        <DialogHeader>
-          <DialogTitle>Why Claim Reference Validation needs your sources</DialogTitle>
-          <DialogDescription>
-            This assessment reads your citations against the documents they cite. It waits here until you tell it the
-            sources are ready.
-          </DialogDescription>
-        </DialogHeader>
+    <div className="space-y-5">
+      <section>
+        <SectionTitle>The document behind a reference</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          A source file is the actual paper, report or page that one of your{' '}
+          {onOpenTopic ? (
+            <button
+              onClick={() => onOpenTopic('references')}
+              className="cursor-pointer underline underline-offset-2 hover:text-foreground"
+            >
+              references
+            </button>
+          ) : (
+            'references'
+          )}{' '}
+          points at. It does not arrive with your draft, because{' '}
+          <strong className="text-foreground font-medium">
+            a bibliography entry names a source, it does not contain one
+          </strong>
+          . The References tab says, for each reference, whether one has been provided.
+        </p>
+        <p className="text-foreground/80 mt-2 leading-relaxed">
+          <strong className="text-foreground font-medium">Claim Reference Validation</strong> is the assessment that
+          needs them. It reads the document behind each citation and compares it to the claim you hung on it, which is
+          not something a bibliography entry can answer.
+        </p>
+      </section>
 
-        <div className="max-h-[65vh] space-y-5 overflow-y-auto text-sm">
-          <section>
-            <SectionTitle>The chain it follows</SectionTitle>
-            <div className="space-y-2">
-              {TRACES.map((trace) => (
-                <TraceCard key={trace.citation} trace={trace} />
-              ))}
-            </div>
-            <p className="text-foreground/80 mt-2 leading-relaxed">
-              Both citations are perfectly good. Only one can be checked, because{' '}
-              <strong className="text-foreground font-medium">
-                a bibliography entry names a source, it does not contain one
-              </strong>
-              .
-            </p>
-          </section>
-
-          <section>
-            <SectionTitle>What comes back</SectionTitle>
-            <ul className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
-              {OUTCOMES.map((outcome) => (
-                <li key={outcome.label} className="flex items-baseline gap-2">
-                  <span className={cn('mt-1.5 block size-1.5 shrink-0 rounded-full', SEVERITY[outcome.severity].dot)} />
-                  <span className="min-w-0 text-xs leading-snug">
-                    <strong className="font-medium">{outcome.label}</strong>{' '}
-                    <span className="text-muted-foreground">{outcome.gloss}</span>
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <section>
-            <SectionTitle>What to do</SectionTitle>
-            <p className="text-foreground/80 leading-relaxed">
-              On the References tab, every reference we extracted is listed with the source matched to it. There are two
-              ways to close a gap.
-            </p>
-            <div className="mt-2 grid gap-2 sm:grid-cols-2">
-              <Route icon={Globe} title="Fetch from the web">
-                Draft Detective searches the web for the reference and downloads the full text when it finds one it can
-                read.
-              </Route>
-              <Route icon={Upload} title="Upload it yourself">
-                Plenty of sources are private, paywalled, or closed to automated downloads. Add the file and we match it
-                to the reference.
-              </Route>
-            </div>
-            <p className="text-foreground/80 mt-2 leading-relaxed">
-              Then choose <strong className="text-foreground font-medium">Approve and Start Analysis</strong>. Approving
-              with gaps is fine: those claims come back{' '}
-              <strong className="text-foreground font-medium">unverifiable instead of checked</strong>, and everything
-              else runs normally.
-            </p>
-            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-              Nothing else is waiting on this. Your other assessments work from the document alone, and their results
-              are already coming in.
-            </p>
-          </section>
+      <section>
+        <SectionTitle>Why the file matters</SectionTitle>
+        <div className="space-y-2">
+          {TRACES.map((trace) => (
+            <TraceCard key={trace.citation} trace={trace} />
+          ))}
         </div>
+        <p className="text-foreground/80 mt-2 leading-relaxed">
+          Both citations are perfectly good, and both would pass a check of the reference itself. Only one can be read
+          against its source.
+        </p>
+      </section>
 
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button variant="outline">Close</Button>
-          </DialogClose>
-          {onReviewReferences && <Button onClick={onReviewReferences}>Review references</Button>}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <section>
+        <SectionTitle>What comes back</SectionTitle>
+        <ul className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
+          {OUTCOMES.map((outcome) => (
+            <li key={outcome.label} className="flex items-baseline gap-2">
+              <span className={cn('mt-1.5 block size-1.5 shrink-0 rounded-full', SEVERITY[outcome.severity].dot)} />
+              <span className="min-w-0 text-xs leading-snug">
+                <strong className="font-medium">{outcome.label}</strong>{' '}
+                <span className="text-muted-foreground">{outcome.gloss}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <SectionTitle>Giving a reference its source</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          On the References tab, every reference is listed with the source matched to it. There are two ways to close a
+          gap.
+        </p>
+        <div className="mt-2 grid gap-2 sm:grid-cols-2">
+          <Route icon={Globe} title="Fetch from the web">
+            Draft Detective searches the web for the reference and downloads the full text when it finds one it can
+            read.
+          </Route>
+          <Route icon={Upload} title="Upload it yourself">
+            Plenty of sources are private, paywalled, or closed to automated downloads. Add the file and we match it to
+            the reference.
+          </Route>
+        </div>
+        <p className="text-foreground/80 mt-2 leading-relaxed">
+          Then choose <strong className="text-foreground font-medium">Approve and Start Analysis</strong>. Approving
+          with gaps is fine: those claims come back{' '}
+          <strong className="text-foreground font-medium">unverifiable instead of checked</strong>, and everything else
+          runs normally.
+        </p>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          Source files are shared across revisions, so this is not work you repeat on the next draft.
+        </p>
+
+        {onReviewReferences && (
+          <Button size="sm" className="mt-3" onClick={onReviewReferences}>
+            Review references
+          </Button>
+        )}
+      </section>
+    </div>
   );
 }
 
@@ -234,8 +235,4 @@ function Route({ icon: Icon, title, children }: { icon: LucideIcon; title: strin
       <p className="text-xs leading-relaxed text-muted-foreground">{children}</p>
     </div>
   );
-}
-
-function SectionTitle({ children }: { children: ReactNode }) {
-  return <h3 className="mb-1.5 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">{children}</h3>;
 }

--- a/frontend/components/layout/application-shell.tsx
+++ b/frontend/components/layout/application-shell.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { HelpCenter } from '@/components/help/help-center';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
-import { LogInIcon, MenuIcon, XIcon } from 'lucide-react';
+import { CircleHelp, LogInIcon, MenuIcon, XIcon } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useState } from 'react';
 import { Button } from '../ui/button';
 import { MobileProfileMenu, ProfileDropdown } from './profile-dropdown';
 
@@ -24,6 +27,7 @@ export function ApplicationShell({ children }: ApplicationShellProps) {
   const isLoadingUser = session.status === 'loading';
   const user = session.data?.user;
   const pathname = usePathname();
+  const [helpOpen, setHelpOpen] = useState(false);
 
   const navigationWithCurrent = navigation.map((item) => ({
     ...item,
@@ -74,6 +78,17 @@ export function ApplicationShell({ children }: ApplicationShellProps) {
               </div>
             </div>
             <div className="hidden sm:ml-6 sm:flex sm:items-center sm:gap-3">
+              {/* Beside the account menu, where the application's own controls
+                  live rather than the current page's. */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon" onClick={() => setHelpOpen(true)} aria-label="Help">
+                    <CircleHelp />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Help</TooltipContent>
+              </Tooltip>
+
               {user ? (
                 <ProfileDropdown user={user} />
               ) : !isLoadingUser ? (
@@ -126,6 +141,18 @@ export function ApplicationShell({ children }: ApplicationShellProps) {
                 Start new project
               </DisclosureButton>
             </div>
+            <div className="px-4 pb-3">
+              {/* The desktop cluster is hidden at this width, so the panel
+                  carries the same door. */}
+              <DisclosureButton
+                as="button"
+                onClick={() => setHelpOpen(true)}
+                className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-base font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <CircleHelp className="size-5" />
+                Help
+              </DisclosureButton>
+            </div>
             {user ? (
               <MobileProfileMenu user={user} />
             ) : !isLoadingUser ? (
@@ -144,6 +171,10 @@ export function ApplicationShell({ children }: ApplicationShellProps) {
       </Disclosure>
 
       <main>{isFullBleed ? children : <div className="mx-auto max-w-7xl p-4 sm:px-6 lg:px-8">{children}</div>}</main>
+
+      {/* Outside the Disclosure: its panel unmounts when the menu closes, which
+          on mobile is the same click that asks for this dialog. */}
+      <HelpCenter open={helpOpen} onOpenChange={setHelpOpen} topic="assessments" />
     </div>
   );
 }

--- a/frontend/components/layout/application-shell.tsx
+++ b/frontend/components/layout/application-shell.tsx
@@ -30,7 +30,9 @@ export function ApplicationShell({ children }: ApplicationShellProps) {
     current: pathname.startsWith(item.href),
   }));
 
-  if (pathname.startsWith('/addin')) {
+  // The add-in and the v2 project view render their own chrome edge to edge,
+  // navigation included.
+  if (pathname.startsWith('/addin') || pathname.startsWith('/v2/')) {
     return <>{children}</>;
   }
 

--- a/frontend/components/layout/profile-dropdown.tsx
+++ b/frontend/components/layout/profile-dropdown.tsx
@@ -4,6 +4,7 @@ import { useExperimentalFeatures } from '@/context/experimental-features-context
 import { UserRole } from '@/lib/generated-api';
 import { useUserMe } from '@/lib/hooks/use-user-me';
 import { DisclosureButton, Menu, MenuButton, MenuItem, MenuItems, MenuSection, MenuSeparator } from '@headlessui/react';
+import { ChevronDown } from 'lucide-react';
 import Image from 'next/image';
 import { ThemeToggle } from '../theme-toggle';
 import { Switch } from '../ui/switch';
@@ -31,24 +32,55 @@ interface User {
 
 interface ProfileDropdownProps {
   user: User;
+  /** Avatar diameter in px. */
+  size?: number;
+  /** Shows a chevron beside the avatar, for bars where the trigger needs to read as a menu. */
+  showChevron?: boolean;
+  /** Set false where dark mode is offered outside the menu. */
+  includeThemeToggle?: boolean;
 }
 
-export function ProfileDropdown({ user }: ProfileDropdownProps) {
+/** Initials from a name or email, for accounts with no picture. */
+function initialsOf(name?: string | null, email?: string | null): string {
+  const source = name?.trim() || email?.split('@')[0] || '';
+  const parts = source.split(/[\s._-]+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  return (parts[0][0] + (parts[1]?.[0] ?? '')).toUpperCase();
+}
+
+export function ProfileDropdown({
+  user,
+  size = 32,
+  showChevron = false,
+  includeThemeToggle = true,
+}: ProfileDropdownProps) {
   const { showExperimentalFeatures, setShowExperimentalFeatures, isUpdating } = useExperimentalFeatures();
   const { data: userMe } = useUserMe();
 
   return (
     <Menu as="div" className="relative ml-3">
-      <MenuButton className="relative flex max-w-xs items-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
+      <MenuButton className="relative flex max-w-xs items-center gap-1 rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
         <span className="absolute -inset-1.5" />
         <span className="sr-only">Open user menu</span>
-        <Image
-          alt={user.name ?? 'User'}
-          src={user.image ?? 'https://ui-avatars.com/api/?name=' + user.name}
-          className="size-8 rounded-full outline -outline-offset-1 outline-black/5"
-          width={32}
-          height={32}
-        />
+        {user.image ? (
+          <Image
+            alt={user.name ?? 'User'}
+            src={user.image}
+            className="rounded-full outline -outline-offset-1 outline-black/5"
+            width={size}
+            height={size}
+            style={{ width: size, height: size }}
+          />
+        ) : (
+          <span
+            aria-hidden
+            className="flex items-center justify-center rounded-full bg-primary font-semibold text-primary-foreground"
+            style={{ width: size, height: size, fontSize: Math.round(size * 0.4) }}
+          >
+            {initialsOf(user.name, user.email)}
+          </span>
+        )}
+        {showChevron && <ChevronDown className="size-3.5 text-muted-foreground" />}
       </MenuButton>
 
       <MenuItems
@@ -75,12 +107,14 @@ export function ProfileDropdown({ user }: ProfileDropdownProps) {
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
-        <MenuItem>
-          <label className="flex items-center justify-between px-4 py-2 text-sm text-popover-foreground cursor-pointer data-focus:bg-accent data-focus:outline-hidden">
-            <span>Dark mode</span>
-            <ThemeToggle />
-          </label>
-        </MenuItem>
+        {includeThemeToggle && (
+          <MenuItem>
+            <label className="flex items-center justify-between px-4 py-2 text-sm text-popover-foreground cursor-pointer data-focus:bg-accent data-focus:outline-hidden">
+              <span>Dark mode</span>
+              <ThemeToggle />
+            </label>
+          </MenuItem>
+        )}
         <MenuSeparator className="my-1 h-px bg-border" />
         {userNavigation.map((item) => (
           <MenuItem key={item.name}>

--- a/frontend/components/mcp/mcp-instructions.tsx
+++ b/frontend/components/mcp/mcp-instructions.tsx
@@ -14,7 +14,7 @@ const claudeCodeCommand = `claude mcp add-json "draft-detective" '{"type":"http"
 const codexCommand = `codex mcp add draft-detective --url ${mcpUrl}`;
 
 const sampleTriggers = [
-  'List the available Draft Detective workflows and recommend which ones to run on this draft.',
+  'List the available Draft Detective assessments and recommend which ones to run on this draft.',
   'Check figures and tables in this document using Draft Detective and summarize the findings.',
   'Run a reference validation review on this manuscript with Draft Detective.',
   'Validate the inferences in this manuscript with Draft Detective and flag any unsupported claims.',

--- a/frontend/components/results-v2/app-bar.tsx
+++ b/frontend/components/results-v2/app-bar.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { ProfileDropdown } from '@/components/layout/profile-dropdown';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { LogInIcon, Moon, Plus, Sun } from 'lucide-react';
+import { useSession } from 'next-auth/react';
+import { useTheme } from 'next-themes';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const navigation = [
+  { name: 'Projects', href: '/projects' },
+  { name: 'About', href: '/about' },
+];
+
+/**
+ * The application row for the v2 project view: where you are, how to start
+ * something new, and who you are, in 44px. Replaces ApplicationShell's nav on
+ * this route, which is why it carries the same links and account menu.
+ */
+export function AppBar() {
+  const session = useSession();
+  const pathname = usePathname();
+  const { resolvedTheme, setTheme } = useTheme();
+  const user = session.data?.user;
+  const isLoadingUser = session.status === 'loading';
+
+  return (
+    <div className="flex h-11 shrink-0 items-center gap-1 border-b px-3">
+      <Link href="/" className="text-primary mr-3 text-[15px] font-bold tracking-tight">
+        Draft Detective
+      </Link>
+
+      <nav className="flex h-full items-center gap-1" aria-label="Main">
+        {navigation.map((item) => {
+          // The v2 tree mirrors the production routes one level down, so
+          // /v2/projects/... still counts as being under Projects.
+          const current = pathname.startsWith(item.href) || pathname.startsWith(`/v2${item.href}`);
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              aria-current={current ? 'page' : undefined}
+              className={cn(
+                'flex h-full items-center border-b-2 px-2 pt-0.5 text-[13px] font-medium transition-colors',
+                current
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {item.name}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <Button asChild variant="outline" size="sm" className="ml-2 h-7 px-2.5 text-[12.5px]">
+        <Link href="/new">
+          <Plus className="size-3.5" />
+          New project
+        </Link>
+      </Button>
+
+      <div className="ml-auto flex items-center gap-1.5">
+        {/* Dark mode sits in the bar rather than the account menu: it is a
+            preference, not an account setting, and signed-out visitors want it too. */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+          aria-label="Toggle dark mode"
+        >
+          <Moon className="size-4 dark:hidden" />
+          <Sun className="hidden size-4 dark:block" />
+        </Button>
+
+        {user ? (
+          <ProfileDropdown user={user} size={26} showChevron includeThemeToggle={false} />
+        ) : !isLoadingUser ? (
+          <Button asChild variant="outline" size="sm" className="h-7 px-2.5 text-[12.5px]">
+            <Link href="/api/auth/signin">
+              <LogInIcon className="size-3.5" />
+              Sign in
+            </Link>
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/app-bar.tsx
+++ b/frontend/components/results-v2/app-bar.tsx
@@ -8,18 +8,27 @@ import { useSession } from 'next-auth/react';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { ReactNode } from 'react';
 
 const navigation = [
   { name: 'Projects', href: '/projects' },
   { name: 'About', href: '/about' },
 ];
 
+interface AppBarProps {
+  /**
+   * Centred in the bar in place of the site nav. Views that are about one
+   * project name it here, so the row below is free for that project's tabs.
+   */
+  title?: ReactNode;
+}
+
 /**
  * The application row for the v2 project view: where you are, how to start
  * something new, and who you are, in 44px. Replaces ApplicationShell's nav on
  * this route, which is why it carries the same links and account menu.
  */
-export function AppBar() {
+export function AppBar({ title }: AppBarProps) {
   const session = useSession();
   const pathname = usePathname();
   const { resolvedTheme, setTheme } = useTheme();
@@ -27,40 +36,54 @@ export function AppBar() {
   const isLoadingUser = session.status === 'loading';
 
   return (
-    <div className="flex h-11 shrink-0 items-center gap-1 border-b px-3">
-      <Link href="/" className="text-primary mr-3 text-[15px] font-bold tracking-tight">
+    <div className="relative flex h-11 shrink-0 items-center gap-1 border-b px-3">
+      {/* px-3 mirrors a tab's own padding, so the wordmark sits on the same
+          text axis as the tab labels in the row below. */}
+      <Link href="/" className="text-primary px-3 text-[15px] font-bold tracking-tight">
         Draft Detective
       </Link>
 
-      <nav className="flex h-full items-center gap-1" aria-label="Main">
-        {navigation.map((item) => {
-          // The v2 tree mirrors the production routes one level down, so
-          // /v2/projects/... still counts as being under Projects.
-          const current = pathname.startsWith(item.href) || pathname.startsWith(`/v2${item.href}`);
-          return (
-            <Link
-              key={item.name}
-              href={item.href}
-              aria-current={current ? 'page' : undefined}
-              className={cn(
-                'flex h-full items-center border-b-2 px-2 pt-0.5 text-[13px] font-medium transition-colors',
-                current
-                  ? 'border-primary text-foreground'
-                  : 'border-transparent text-muted-foreground hover:text-foreground',
-              )}
-            >
-              {item.name}
-            </Link>
-          );
-        })}
-      </nav>
+      {title ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          {/* A definite width, so the rename input has room to be typed in
+              rather than shrinking to fit the finished title. */}
+          <div className="pointer-events-auto flex w-full max-w-md min-w-0 items-center justify-center px-2">
+            {title}
+          </div>
+        </div>
+      ) : (
+        <>
+          <nav className="flex h-full items-center gap-1" aria-label="Main">
+            {navigation.map((item) => {
+              // The v2 tree mirrors the production routes one level down, so
+              // /v2/projects/... still counts as being under Projects.
+              const current = pathname.startsWith(item.href) || pathname.startsWith(`/v2${item.href}`);
+              return (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  aria-current={current ? 'page' : undefined}
+                  className={cn(
+                    'flex h-full items-center border-b-2 px-2 pt-0.5 text-[13px] font-medium transition-colors',
+                    current
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {item.name}
+                </Link>
+              );
+            })}
+          </nav>
 
-      <Button asChild variant="outline" size="sm" className="ml-2 h-7 px-2.5 text-[12.5px]">
-        <Link href="/new">
-          <Plus className="size-3.5" />
-          New project
-        </Link>
-      </Button>
+          <Button asChild variant="outline" size="sm" className="ml-2 h-7 px-2.5 text-[12.5px]">
+            <Link href="/new">
+              <Plus className="size-3.5" />
+              New project
+            </Link>
+          </Button>
+        </>
+      )}
 
       <div className="ml-auto flex items-center gap-1.5">
         {/* Dark mode sits in the bar rather than the account menu: it is a

--- a/frontend/components/results-v2/app-bar.tsx
+++ b/frontend/components/results-v2/app-bar.tsx
@@ -2,6 +2,7 @@
 
 import { ProfileDropdown } from '@/components/layout/profile-dropdown';
 import { Button } from '@/components/ui/button';
+import { useMediaQuery } from '@/lib/use-media-query';
 import { cn } from '@/lib/utils';
 import { LogInIcon, Moon, Plus, Sun } from 'lucide-react';
 import { useSession } from 'next-auth/react';
@@ -9,6 +10,12 @@ import { useTheme } from 'next-themes';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ReactNode } from 'react';
+
+/**
+ * Below this the bar is too narrow to float a centred title clear of the
+ * wordmark on one side and the account controls on the other.
+ */
+const WIDE_ENOUGH_TO_CENTRE_TITLE = '(min-width: 52rem)';
 
 const navigation = [
   { name: 'Projects', href: '/projects' },
@@ -32,6 +39,7 @@ export function AppBar({ title }: AppBarProps) {
   const session = useSession();
   const pathname = usePathname();
   const { resolvedTheme, setTheme } = useTheme();
+  const canCentreTitle = useMediaQuery(WIDE_ENOUGH_TO_CENTRE_TITLE);
   const user = session.data?.user;
   const isLoadingUser = session.status === 'loading';
 
@@ -44,13 +52,20 @@ export function AppBar({ title }: AppBarProps) {
       </Link>
 
       {title ? (
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          {/* A definite width, so the rename input has room to be typed in
-              rather than shrinking to fit the finished title. */}
-          <div className="pointer-events-auto flex w-full max-w-md min-w-0 items-center justify-center px-2">
-            {title}
+        canCentreTitle ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            {/* A definite width, so the rename input has room to be typed in
+                rather than shrinking to fit the finished title. */}
+            <div className="pointer-events-auto flex w-full max-w-md min-w-0 items-center justify-center px-2">
+              {title}
+            </div>
           </div>
-        </div>
+        ) : (
+          // Too narrow to centre over the bar: the layer would cover the
+          // wordmark and the account controls, and swallow their clicks. The
+          // title takes its own space in the row instead.
+          <div className="ml-1 flex min-w-0 flex-1 items-center">{title}</div>
+        )
       ) : (
         <>
           <nav className="flex h-full items-center gap-1" aria-label="Main">

--- a/frontend/components/results-v2/app-bar.tsx
+++ b/frontend/components/results-v2/app-bar.tsx
@@ -1,15 +1,17 @@
 'use client';
 
+import { HelpCenter } from '@/components/help/help-center';
 import { ProfileDropdown } from '@/components/layout/profile-dropdown';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useMediaQuery } from '@/lib/use-media-query';
 import { cn } from '@/lib/utils';
-import { LogInIcon, Moon, Plus, Sun } from 'lucide-react';
+import { CircleHelp, LogInIcon, Moon, Plus, Sun } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 /**
  * Below this the bar is too narrow to float a centred title clear of the
@@ -40,6 +42,7 @@ export function AppBar({ title }: AppBarProps) {
   const pathname = usePathname();
   const { resolvedTheme, setTheme } = useTheme();
   const canCentreTitle = useMediaQuery(WIDE_ENOUGH_TO_CENTRE_TITLE);
+  const [helpOpen, setHelpOpen] = useState(false);
   const user = session.data?.user;
   const isLoadingUser = session.status === 'loading';
 
@@ -101,6 +104,20 @@ export function AppBar({ title }: AppBarProps) {
       )}
 
       <div className="ml-auto flex items-center gap-1.5">
+        {/* Help belongs to the application, not to this project, so it sits in
+            this row rather than among the project's own actions — and stays
+            reachable from every tab. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" className="size-7" onClick={() => setHelpOpen(true)} aria-label="Help">
+              <CircleHelp className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Help</TooltipContent>
+        </Tooltip>
+
+        <HelpCenter open={helpOpen} onOpenChange={setHelpOpen} topic="assessments" />
+
         {/* Dark mode sits in the bar rather than the account menu: it is a
             preference, not an account setting, and signed-out visitors want it too. */}
         <Button

--- a/frontend/components/results-v2/assessments-v2-panel.tsx
+++ b/frontend/components/results-v2/assessments-v2-panel.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useProjectView } from '@/components/results/project-view-context';
+import { useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
+import { AssessmentsTabV2 } from './assessments/assessments-tab';
+
+/** Hash format the document explorer understands: `#L5` or `#L5-12`. */
+function lineRangeHash(lineRange?: [number, number]): string | undefined {
+  if (!lineRange) return undefined;
+  const [start, end] = lineRange;
+  return start === end ? `#L${start}` : `#L${start}-${end}`;
+}
+
+/** The v2 assessments tab as a tab panel, taking its project from the shell. */
+export function AssessmentsV2Panel() {
+  const { projectDetail, readOnly, navigateToTab } = useProjectView();
+  const setFilter = useDocumentExplorerStore((s) => s.setFilter);
+
+  return (
+    <AssessmentsTabV2
+      projectDetail={projectDetail}
+      readOnly={readOnly}
+      onNavigateToDocumentExplorer={(lineRange) => {
+        setFilter({ workflowType: [] });
+        navigateToTab('document-explorer', lineRangeHash(lineRange));
+      }}
+      onNavigateToReferences={() => navigateToTab('references')}
+      onNavigateToPeerReview={() => navigateToTab('peer-review')}
+    />
+  );
+}

--- a/frontend/components/results-v2/assessments-v2-panel.tsx
+++ b/frontend/components/results-v2/assessments-v2-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useProjectView } from '@/components/results/project-view-context';
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
 import { AssessmentsTabV2 } from './assessments/assessments-tab';
 
@@ -15,6 +16,8 @@ function lineRangeHash(lineRange?: [number, number]): string | undefined {
 export function AssessmentsV2Panel() {
   const { projectDetail, readOnly, navigateToTab } = useProjectView();
   const setFilter = useDocumentExplorerStore((s) => s.setFilter);
+  // Nothing should point at Peer Review while it is hidden.
+  const { showExperimentalFeatures } = useExperimentalFeatures();
 
   return (
     <AssessmentsTabV2
@@ -25,7 +28,7 @@ export function AssessmentsV2Panel() {
         navigateToTab('document-explorer', lineRangeHash(lineRange));
       }}
       onNavigateToReferences={() => navigateToTab('references')}
-      onNavigateToPeerReview={() => navigateToTab('peer-review')}
+      onNavigateToPeerReview={showExperimentalFeatures ? () => navigateToTab('peer-review') : undefined}
     />
   );
 }

--- a/frontend/components/results-v2/assessments/assessment-rail.tsx
+++ b/frontend/components/results-v2/assessments/assessment-rail.tsx
@@ -187,9 +187,12 @@ function FlagIcon({ tone, message }: { tone: 'error' | 'warning'; message: strin
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Icon
-          className={cn('size-3.5 shrink-0 cursor-help', tone === 'error' ? 'text-destructive' : 'text-amber-600')}
-        />
+        {/* A button rather than the icon itself: `asChild` would make the SVG
+            the trigger, and an SVG takes no focus, so the explanation would be
+            hover-only. */}
+        <button type="button" aria-label={message} className="inline-flex shrink-0 cursor-help">
+          <Icon className={cn('size-3.5', tone === 'error' ? 'text-destructive' : 'text-amber-600')} />
+        </button>
       </TooltipTrigger>
       <TooltipContent className="max-w-xs">{message}</TooltipContent>
     </Tooltip>

--- a/frontend/components/results-v2/assessments/assessment-rail.tsx
+++ b/frontend/components/results-v2/assessments/assessment-rail.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { IssueCountBadge } from '@/components/results/components/issue-count-badge';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Issue, WorkflowRunDetail, WorkflowRunType } from '@/lib/generated-api';
+import { summarizeReportedIssues } from '@/lib/health-status';
+import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { cn } from '@/lib/utils';
+import {
+  getDisplayStatus,
+  hasBlockingErrors,
+  hasCurrentRunErrors,
+  isWorkflowFailed,
+  isWorkflowProcessing,
+} from '@/lib/workflow-state';
+import { AlertTriangleIcon, ChevronDownIcon, Loader2, XCircleIcon } from 'lucide-react';
+import { useState } from 'react';
+
+/** The dot that carries a run's state, in the palette the status indicator uses. */
+const STATUS_DOT: Record<string, string> = {
+  completed: 'bg-green-500',
+  running: 'bg-primary animate-pulse',
+  pending: 'bg-muted-foreground/40',
+  failed: 'bg-red-500',
+  cancelled: 'bg-muted-foreground/40',
+  awaiting_approval: 'bg-amber-500',
+};
+
+interface AssessmentRailProps {
+  workflowDetails: WorkflowRunDetail[];
+  issues: Issue[];
+  selectedWorkflowType: WorkflowRunType | null;
+  onSelectWorkflowType: (type: WorkflowRunType) => void;
+  onStartNewAssessment: () => void;
+  readOnly: boolean;
+}
+
+/**
+ * The assessment list, which in this tab is the navigation rather than a
+ * filter: picking one is what fills the pane beside it. Internal workflows
+ * stay folded away — they run themselves, and nobody reads their results
+ * unless something has gone wrong.
+ */
+export function AssessmentRail({
+  workflowDetails,
+  issues,
+  selectedWorkflowType,
+  onSelectWorkflowType,
+  onStartNewAssessment,
+  readOnly,
+}: AssessmentRailProps) {
+  const { isWorkflowTypeVisible } = useWorkflowTypes();
+  const [internalOpen, setInternalOpen] = useState(false);
+
+  const visible = workflowDetails.filter((detail) => isWorkflowTypeVisible(detail.run.type));
+  const internal = workflowDetails.filter((detail) => !isWorkflowTypeVisible(detail.run.type));
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <div className="flex items-center justify-between px-2">
+          <h2 className="font-mono text-[10px] tracking-wide text-muted-foreground uppercase">Assessments</h2>
+          {!readOnly && (
+            <Button variant="link" size="sm" className="h-auto p-0 text-xs" onClick={onStartNewAssessment}>
+              Run more
+            </Button>
+          )}
+        </div>
+
+        <div className="mt-2 space-y-px">
+          {visible.map((detail) => (
+            <AssessmentRow
+              key={detail.run.id}
+              detail={detail}
+              issues={issues}
+              active={selectedWorkflowType === detail.run.type}
+              onSelect={() => onSelectWorkflowType(detail.run.type)}
+            />
+          ))}
+        </div>
+
+        {internal.length > 0 && (
+          <div className="mt-4">
+            <button
+              onClick={() => setInternalOpen(!internalOpen)}
+              aria-expanded={internalOpen}
+              className="group flex w-full cursor-pointer items-center gap-1 px-2 text-left"
+            >
+              <ChevronDownIcon
+                className={cn('size-3 text-muted-foreground transition-transform', !internalOpen && '-rotate-90')}
+              />
+              <h3 className="font-mono text-[10px] tracking-wide text-muted-foreground uppercase group-hover:text-foreground">
+                Pipeline steps
+              </h3>
+              <span className="font-mono text-[10px] text-muted-foreground">{internal.length}</span>
+            </button>
+            {internalOpen && (
+              <>
+                <p className="mt-1.5 px-2 text-[11px] leading-relaxed text-muted-foreground">
+                  These run on their own to prepare the document. You never start them.
+                </p>
+                <div className="mt-1.5 space-y-px">
+                  {internal.map((detail) => (
+                    <AssessmentRow
+                      key={detail.run.id}
+                      detail={detail}
+                      issues={issues}
+                      active={selectedWorkflowType === detail.run.type}
+                      onSelect={() => onSelectWorkflowType(detail.run.type)}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      <p className="shrink-0 border-t px-5 py-4 text-xs leading-relaxed text-muted-foreground">
+        Each assessment reads the document once and reports what it finds. Those findings are the issues the document
+        explorer marks up.
+      </p>
+    </div>
+  );
+}
+
+function AssessmentRow({
+  detail,
+  issues,
+  active,
+  onSelect,
+}: {
+  detail: WorkflowRunDetail;
+  issues: Issue[];
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const { getWorkflowTypeName } = useWorkflowTypes();
+  const processing = isWorkflowProcessing(detail);
+  const status = getDisplayStatus(detail);
+  const errored = hasBlockingErrors(detail);
+  // A recovered failure: the run finished, so flag it without the error tone.
+  const warned = !errored && hasCurrentRunErrors(detail);
+  const failed = isWorkflowFailed(detail);
+  // A run still working has nothing final to count.
+  const summary = processing ? null : summarizeReportedIssues(issues, detail.run.type);
+
+  return (
+    <button
+      onClick={onSelect}
+      aria-pressed={active}
+      className={cn(
+        'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+        active ? 'bg-accent text-accent-foreground font-medium' : 'hover:bg-accent/60',
+      )}
+    >
+      {processing ? (
+        <Loader2 className="text-primary size-3 shrink-0 animate-spin" />
+      ) : (
+        <span className={cn('block size-2 shrink-0 rounded-full', STATUS_DOT[status] ?? 'bg-muted-foreground/40')} />
+      )}
+
+      <span className="flex-1 truncate">{getWorkflowTypeName(detail.run.type)}</span>
+
+      {failed && (
+        <FlagIcon
+          tone="error"
+          message={detail.run.failure_message ?? 'This assessment failed before it could finish. Try running it again.'}
+        />
+      )}
+      {errored && !failed && (
+        <FlagIcon tone="error" message="This assessment finished with errors. Check them and run it again." />
+      )}
+      {warned && (
+        <FlagIcon tone="warning" message="This assessment finished, but parts of it returned incomplete results." />
+      )}
+
+      {summary && <IssueCountBadge summary={summary} />}
+    </button>
+  );
+}
+
+function FlagIcon({ tone, message }: { tone: 'error' | 'warning'; message: string }) {
+  const Icon = tone === 'error' ? XCircleIcon : AlertTriangleIcon;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Icon
+          className={cn('size-3.5 shrink-0 cursor-help', tone === 'error' ? 'text-destructive' : 'text-amber-600')}
+        />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{message}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/components/results-v2/assessments/assessment-rail.tsx
+++ b/frontend/components/results-v2/assessments/assessment-rail.tsx
@@ -7,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Issue, WorkflowRunDetail, WorkflowRunType } from '@/lib/generated-api';
 import { summarizeReportedIssues } from '@/lib/health-status';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { RAIL_ITEM_ACTIVE, RAIL_ITEM_IDLE } from '@/lib/rail-style';
 import { cn } from '@/lib/utils';
 import {
   getDisplayStatus,
@@ -147,13 +148,32 @@ function AssessmentRow({
   // A run still working has nothing final to count.
   const summary = processing ? null : summarizeReportedIssues(issues, detail.run.type);
 
-  return (
+  const name = getWorkflowTypeName(detail.run.type);
+  const flag = failed
+    ? {
+        tone: 'error' as const,
+        message: detail.run.failure_message ?? 'This assessment failed before it could finish. Try running it again.',
+      }
+    : errored
+      ? { tone: 'error' as const, message: 'This assessment finished with errors. Check them and run it again.' }
+      : warned
+        ? {
+            tone: 'warning' as const,
+            message: 'This assessment finished, but parts of it returned incomplete results.',
+          }
+        : null;
+
+  const row = (
     <button
       onClick={onSelect}
       aria-pressed={active}
+      // The flag's explanation belongs to the row it marks, so it goes in the
+      // row's own name rather than a control of its own: a button inside this
+      // button would be invalid, and the icon alone takes no focus.
+      aria-label={flag ? `${name}. ${flag.message}` : undefined}
       className={cn(
         'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
-        active ? 'bg-accent text-accent-foreground font-medium' : 'hover:bg-accent/60',
+        active ? RAIL_ITEM_ACTIVE : RAIL_ITEM_IDLE,
       )}
     >
       {processing ? (
@@ -162,39 +182,30 @@ function AssessmentRow({
         <span className={cn('block size-2 shrink-0 rounded-full', STATUS_DOT[status] ?? 'bg-muted-foreground/40')} />
       )}
 
-      <span className="flex-1 truncate">{getWorkflowTypeName(detail.run.type)}</span>
+      <span className="flex-1 truncate">{name}</span>
 
-      {failed && (
-        <FlagIcon
-          tone="error"
-          message={detail.run.failure_message ?? 'This assessment failed before it could finish. Try running it again.'}
-        />
-      )}
-      {errored && !failed && (
-        <FlagIcon tone="error" message="This assessment finished with errors. Check them and run it again." />
-      )}
-      {warned && (
-        <FlagIcon tone="warning" message="This assessment finished, but parts of it returned incomplete results." />
-      )}
+      {flag && <FlagIcon tone={flag.tone} />}
 
       {summary && <IssueCountBadge summary={summary} />}
     </button>
   );
-}
 
-function FlagIcon({ tone, message }: { tone: 'error' | 'warning'; message: string }) {
-  const Icon = tone === 'error' ? XCircleIcon : AlertTriangleIcon;
+  if (!flag) return row;
+
+  // On the row rather than the icon, so the message arrives on focus as well as
+  // on hover.
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        {/* A button rather than the icon itself: `asChild` would make the SVG
-            the trigger, and an SVG takes no focus, so the explanation would be
-            hover-only. */}
-        <button type="button" aria-label={message} className="inline-flex shrink-0 cursor-help">
-          <Icon className={cn('size-3.5', tone === 'error' ? 'text-destructive' : 'text-amber-600')} />
-        </button>
-      </TooltipTrigger>
-      <TooltipContent className="max-w-xs">{message}</TooltipContent>
+      <TooltipTrigger asChild>{row}</TooltipTrigger>
+      <TooltipContent className="max-w-xs">{flag.message}</TooltipContent>
     </Tooltip>
+  );
+}
+
+/** Marks the row; the message it stands for is carried by the row itself. */
+function FlagIcon({ tone }: { tone: 'error' | 'warning' }) {
+  const Icon = tone === 'error' ? XCircleIcon : AlertTriangleIcon;
+  return (
+    <Icon aria-hidden className={cn('size-3.5 shrink-0', tone === 'error' ? 'text-destructive' : 'text-amber-600')} />
   );
 }

--- a/frontend/components/results-v2/assessments/assessment-rail.tsx
+++ b/frontend/components/results-v2/assessments/assessment-rail.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { HelpLink } from '@/components/help/help-link';
 import { IssueCountBadge } from '@/components/results/components/issue-count-badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -119,7 +120,7 @@ export function AssessmentRail({
 
       <p className="shrink-0 border-t px-5 py-4 text-xs leading-relaxed text-muted-foreground">
         Each assessment reads the document once and reports what it finds. Those findings are the issues the document
-        explorer marks up.
+        explorer marks up. <HelpLink topic="assessments">More details</HelpLink>
       </p>
     </div>
   );

--- a/frontend/components/results-v2/assessments/assessments-tab.tsx
+++ b/frontend/components/results-v2/assessments/assessments-tab.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useWorkflowSelection } from '@/components/results/tabs/use-workflow-selection';
+import { WorkflowDuration } from '@/components/results/tabs/workflow-duration';
+import { WorkflowResultsContent } from '@/components/results/tabs/workflow-results-renderer';
+import { Button } from '@/components/ui/button';
+import { StatusIndicator } from '@/components/ui/status-indicator';
+import { StartWorkflowButton } from '@/components/workflows/start-workflow-button';
+import { WorkflowConfigDialog, WorkflowConfigFormValues } from '@/components/workflows/workflow-config-dialog';
+import { WorkflowRunCost } from '@/components/workflows/workflow-run-cost';
+import { useShare } from '@/context/share-context';
+import { getErrorMessage } from '@/lib/api-error';
+import { ProjectDetailed, startMultipleWorkflowsApiWorkflowsStartMultiplePost } from '@/lib/generated-api';
+import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { isPeerReviewWorkflowType } from '@/lib/peer-review';
+import { cn } from '@/lib/utils';
+import { getDisplayStatus } from '@/lib/workflow-state';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { formatDistanceToNow } from 'date-fns';
+import { ArrowRight, PanelLeft, PlusIcon } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { WorkflowRunHistory } from '@/components/workflows/workflow-run-history';
+import { AssessmentRail } from './assessment-rail';
+
+interface AssessmentsTabV2Props {
+  projectDetail: ProjectDetailed;
+  readOnly: boolean;
+  onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
+  onNavigateToReferences: () => void;
+  onNavigateToPeerReview?: () => void;
+}
+
+/**
+ * The assessments tab in the v2 frame. The rail lists what has run, the pane
+ * shows the selected run's results, and the right-hand pane holds that
+ * assessment's history — which the old tab buried in a popover, though it is
+ * the only place to see whether findings are falling as the draft is revised.
+ */
+export function AssessmentsTabV2({
+  projectDetail,
+  readOnly,
+  onNavigateToDocumentExplorer,
+  onNavigateToReferences,
+  onNavigateToPeerReview,
+}: AssessmentsTabV2Props) {
+  const projectId = projectDetail.project.id;
+  const workflowDetails = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
+  const { shareToken } = useShare();
+  const queryClient = useQueryClient();
+  const { getWorkflowTypeName, getWorkflowTypeDescription, isWorkflowTypeVisible } = useWorkflowTypes();
+
+  const [railOpen, setRailOpen] = useState(true);
+  const [configOpen, setConfigOpen] = useState(false);
+
+  // Opening on the first assessment beats opening on a prompt to click one.
+  const visibleWorkflows = useMemo(
+    () => workflowDetails.filter((detail) => isWorkflowTypeVisible(detail.run.type)),
+    [workflowDetails, isWorkflowTypeVisible],
+  );
+  const visibleCount = visibleWorkflows.length;
+  const firstVisibleType = visibleWorkflows[0]?.run.type ?? null;
+
+  const { selectedWorkflowType, selectedWorkflowRun, historyData, handleSelectWorkflowType, handleSelectRun } =
+    useWorkflowSelection({ projectId, workflowDetails, shareToken, defaultWorkflowType: firstVisibleType });
+
+  const { mutate: startWorkflows } = useMutation({
+    mutationFn: (values: WorkflowConfigFormValues) =>
+      startMultipleWorkflowsApiWorkflowsStartMultiplePost({
+        body: { project_id: projectId, workflow_types: values.workflowTypes },
+      }),
+    onSuccess: () => {
+      toast.success('Assessments started');
+      queryClient.invalidateQueries({ queryKey: ['project', projectId] });
+    },
+    onError: (error) => toast.error(getErrorMessage(error, 'Failed to start assessments')),
+  });
+
+  const description = selectedWorkflowRun ? getWorkflowTypeDescription(selectedWorkflowRun.run.type) : null;
+
+  return (
+    <div className="flex h-full min-h-0">
+      <WorkflowConfigDialog
+        isOpen={configOpen}
+        projectId={projectId}
+        onConfirm={(values) => {
+          setConfigOpen(false);
+          startWorkflows(values);
+        }}
+        onCancel={() => setConfigOpen(false)}
+      />
+
+      <aside
+        className={cn(
+          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
+          railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
+        )}
+      >
+        <AssessmentRail
+          workflowDetails={workflowDetails}
+          issues={projectDetail.issues ?? []}
+          selectedWorkflowType={selectedWorkflowType}
+          onSelectWorkflowType={handleSelectWorkflowType}
+          onStartNewAssessment={() => setConfigOpen(true)}
+          readOnly={readOnly}
+        />
+      </aside>
+
+      <main className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hidden size-7 xl:flex"
+                onClick={() => setRailOpen(!railOpen)}
+                aria-label={railOpen ? 'Hide assessments' : 'Show assessments'}
+                aria-pressed={railOpen}
+              >
+                <PanelLeft className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{railOpen ? 'Hide assessments' : 'Show assessments'}</TooltipContent>
+          </Tooltip>
+
+          {/* The count, not the selected name: the pane's own heading says which
+              assessment this is, one line below. */}
+          <span className="min-w-0 truncate text-xs text-muted-foreground">
+            {visibleCount} {visibleCount === 1 ? 'assessment' : 'assessments'}
+          </span>
+
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            {selectedWorkflowRun && (
+              <WorkflowRunHistory
+                projectId={projectId}
+                workflowType={selectedWorkflowRun.run.type}
+                currentRunId={selectedWorkflowRun.run.id}
+                onSelectRun={handleSelectRun}
+                historyData={historyData}
+                size="xs"
+                tooltip="Every time this assessment has run. Pick one to read its results."
+              />
+            )}
+
+            {!readOnly &&
+              selectedWorkflowRun &&
+              // Peer-review assessments are sequenced from their own tab;
+              // re-running one here could produce a guard report, not a result.
+              (isPeerReviewWorkflowType(selectedWorkflowRun.run.type) ? (
+                onNavigateToPeerReview && (
+                  <Button size="xs" variant="outline" onClick={onNavigateToPeerReview}>
+                    Manage in Peer Review
+                    <ArrowRight className="size-3" />
+                  </Button>
+                )
+              ) : (
+                <StartWorkflowButton
+                  type={selectedWorkflowRun.run.type}
+                  projectId={projectId}
+                  workflow={selectedWorkflowRun.run}
+                  size="xs"
+                  startLabel={
+                    selectedWorkflowRun.run.started_at
+                      ? `Re-run ${getWorkflowTypeName(selectedWorkflowRun.run.type)}`
+                      : undefined
+                  }
+                  tooltip="Running an assessment again replaces what the document explorer shows for it."
+                  onConfirm={() =>
+                    startMultipleWorkflowsApiWorkflowsStartMultiplePost({
+                      body: { project_id: projectId, workflow_types: [selectedWorkflowRun.run.type] },
+                    })
+                  }
+                />
+              ))}
+
+            {!readOnly && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="xs" variant="outline" onClick={() => setConfigOpen(true)}>
+                    <PlusIcon className="size-3" />
+                    New assessment
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Choose assessments to run on this document</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {selectedWorkflowRun ? (
+            <div className="mx-auto max-w-5xl px-6 py-5">
+              <header className="border-b pb-4">
+                <h1 className="text-base font-semibold tracking-tight">
+                  {getWorkflowTypeName(selectedWorkflowRun.run.type)}
+                </h1>
+                {description && <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">{description}</p>}
+                <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                  <StatusIndicator status={getDisplayStatus(selectedWorkflowRun)} />
+                  <span>
+                    Last updated {formatDistanceToNow(selectedWorkflowRun.run.last_updated_at, { addSuffix: true })}
+                  </span>
+                  <WorkflowDuration run={selectedWorkflowRun.run} />
+                  {selectedWorkflowRun.cost && (
+                    <WorkflowRunCost key={selectedWorkflowRun.run.id} cost={selectedWorkflowRun.cost} />
+                  )}
+                </div>
+              </header>
+
+              {/* The result components are shared with v1, whose pages run a
+                  larger type scale than this chrome. Scaling the subtree beats
+                  forking them or changing sizes v1 depends on. */}
+              <div className="text-scale-compact space-y-4 pt-4">
+                <WorkflowResultsContent
+                  projectDetail={projectDetail}
+                  workflowRun={selectedWorkflowRun}
+                  onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+                  onNavigateToReferences={onNavigateToReferences}
+                />
+              </div>
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center p-8">
+              <div className="max-w-sm space-y-2 text-center">
+                <p className="text-sm font-medium">No assessments yet</p>
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Assessments read the document and report what they find as issues in the explorer.
+                </p>
+                {!readOnly && (
+                  <Button size="sm" className="mt-1" onClick={() => setConfigOpen(true)}>
+                    <PlusIcon className="size-3.5" />
+                    Start an assessment
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/assessments/assessments-tab.tsx
+++ b/frontend/components/results-v2/assessments/assessments-tab.tsx
@@ -145,9 +145,14 @@ export function AssessmentsTabV2({
                   workflow={selectedWorkflowRun.run}
                   size="xs"
                   startLabel={
-                    selectedWorkflowRun.run.started_at
-                      ? `Re-run ${getWorkflowTypeName(selectedWorkflowRun.run.type)}`
-                      : undefined
+                    selectedWorkflowRun.run.started_at ? (
+                      <>
+                        {/* The name only where it fits: an assessment called
+                            "Claim Reference Validation" is wider than a phone. */}
+                        Re-run
+                        <span className="hidden sm:inline"> {getWorkflowTypeName(selectedWorkflowRun.run.type)}</span>
+                      </>
+                    ) : undefined
                   }
                   tooltip="Running an assessment again replaces what the document explorer shows for it."
                   onConfirm={() =>

--- a/frontend/components/results-v2/assessments/assessments-tab.tsx
+++ b/frontend/components/results-v2/assessments/assessments-tab.tsx
@@ -17,7 +17,7 @@ import { cn } from '@/lib/utils';
 import { getDisplayStatus } from '@/lib/workflow-state';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
-import { ArrowRight, PanelLeft, PlusIcon } from 'lucide-react';
+import { ArrowRight, PanelLeft, PlayIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -174,18 +174,6 @@ export function AssessmentsTabV2({
                   }
                 />
               ))}
-
-            {!readOnly && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="xs" variant="outline" onClick={() => setConfigOpen(true)}>
-                    <PlusIcon className="size-3" />
-                    New assessment
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Choose assessments to run on this document</TooltipContent>
-              </Tooltip>
-            )}
           </div>
         </div>
 
@@ -230,8 +218,8 @@ export function AssessmentsTabV2({
                 </p>
                 {!readOnly && (
                   <Button size="sm" className="mt-1" onClick={() => setConfigOpen(true)}>
-                    <PlusIcon className="size-3.5" />
-                    Start an assessment
+                    <PlayIcon className="size-3.5" />
+                    Run an assessment
                   </Button>
                 )}
               </div>

--- a/frontend/components/results-v2/assessments/assessments-tab.tsx
+++ b/frontend/components/results-v2/assessments/assessments-tab.tsx
@@ -13,15 +13,14 @@ import { getErrorMessage } from '@/lib/api-error';
 import { ProjectDetailed, startMultipleWorkflowsApiWorkflowsStartMultiplePost } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { isPeerReviewWorkflowType } from '@/lib/peer-review';
-import { cn } from '@/lib/utils';
 import { getDisplayStatus } from '@/lib/workflow-state';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
-import { ArrowRight, PanelLeft, PlayIcon } from 'lucide-react';
+import { ArrowRight, PlayIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { WorkflowRunHistory } from '@/components/workflows/workflow-run-history';
+import { Rail, RailToggle, useRailState } from '../panes';
 import { AssessmentRail } from './assessment-rail';
 
 interface AssessmentsTabV2Props {
@@ -51,7 +50,7 @@ export function AssessmentsTabV2({
   const queryClient = useQueryClient();
   const { getWorkflowTypeName, getWorkflowTypeDescription, isWorkflowTypeVisible } = useWorkflowTypes();
 
-  const [railOpen, setRailOpen] = useState(true);
+  const rail = useRailState();
   const [configOpen, setConfigOpen] = useState(false);
 
   // Opening on the first assessment beats opening on a prompt to click one.
@@ -91,39 +90,23 @@ export function AssessmentsTabV2({
         onCancel={() => setConfigOpen(false)}
       />
 
-      <aside
-        className={cn(
-          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
-          railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
-        )}
-      >
+      <Rail state={rail} label="Assessments">
         <AssessmentRail
           workflowDetails={workflowDetails}
           issues={projectDetail.issues ?? []}
           selectedWorkflowType={selectedWorkflowType}
-          onSelectWorkflowType={handleSelectWorkflowType}
+          onSelectWorkflowType={(type) => {
+            handleSelectWorkflowType(type);
+            rail.close();
+          }}
           onStartNewAssessment={() => setConfigOpen(true)}
           readOnly={readOnly}
         />
-      </aside>
+      </Rail>
 
       <main className="flex min-w-0 flex-1 flex-col">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hidden size-7 xl:flex"
-                onClick={() => setRailOpen(!railOpen)}
-                aria-label={railOpen ? 'Hide assessments' : 'Show assessments'}
-                aria-pressed={railOpen}
-              >
-                <PanelLeft className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{railOpen ? 'Hide assessments' : 'Show assessments'}</TooltipContent>
-          </Tooltip>
+          <RailToggle state={rail} label="Assessments" />
 
           {/* The count, not the selected name: the pane's own heading says which
               assessment this is, one line below. */}

--- a/frontend/components/results-v2/document-explorer-v2-panel.tsx
+++ b/frontend/components/results-v2/document-explorer-v2-panel.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useProjectView } from '@/components/results/project-view-context';
+import { DocumentExplorerTabV2 } from './document-explorer/document-explorer-tab';
+
+/**
+ * The v2 document explorer as a tab panel. Everything around it — title, tabs,
+ * revision switcher, reference-review banner — comes from ProjectResultsShell,
+ * exactly as it does for the production tabs, so the two routes differ only in
+ * the explorer itself.
+ */
+export function DocumentExplorerV2Panel() {
+  const { projectDetail, readOnly, selectedRevision, onRevisionChange, navigateToTab } = useProjectView();
+
+  return (
+    <DocumentExplorerTabV2
+      projectDetail={projectDetail}
+      readOnly={readOnly}
+      onNavigateToAnalyses={() => navigateToTab('analyses')}
+      selectedRevision={selectedRevision}
+      onRevisionChange={onRevisionChange}
+    />
+  );
+}

--- a/frontend/components/results-v2/document-explorer-v2-panel.tsx
+++ b/frontend/components/results-v2/document-explorer-v2-panel.tsx
@@ -5,20 +5,18 @@ import { DocumentExplorerTabV2 } from './document-explorer/document-explorer-tab
 
 /**
  * The v2 document explorer as a tab panel. Everything around it — title, tabs,
- * revision switcher, reference-review banner — comes from ProjectResultsShell,
+ * revision switcher, the banners — comes from ProjectResultsShell,
  * exactly as it does for the production tabs, so the two routes differ only in
  * the explorer itself.
  */
 export function DocumentExplorerV2Panel() {
-  const { projectDetail, readOnly, selectedRevision, onRevisionChange, navigateToTab } = useProjectView();
+  const { projectDetail, readOnly, navigateToTab } = useProjectView();
 
   return (
     <DocumentExplorerTabV2
       projectDetail={projectDetail}
       readOnly={readOnly}
       onNavigateToAnalyses={() => navigateToTab('analyses')}
-      selectedRevision={selectedRevision}
-      onRevisionChange={onRevisionChange}
     />
   );
 }

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -5,7 +5,6 @@ import { Callout } from '@/components/ui/callout';
 import { Issue, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useLineHashNavigation } from '@/lib/line-hash';
 import {
-  getFilteredIssues,
   getHighlightIssues,
   getPassingCount,
   getResolvedCount,
@@ -82,12 +81,8 @@ export function DocumentExplorerTabV2({
   const workflowErrors = useMemo(() => getBlockingWorkflowErrors(workflowDetails), [workflowDetails]);
   const outline = useMemo(() => extractOutline(mainDocumentMarkdown), [mainDocumentMarkdown]);
   const visibleIssues = useMemo(() => getVisibleIssues(issues, filter), [issues, filter]);
-  const resolvedCount = useMemo(() => getResolvedCount(issues, selectedLineRange), [issues, selectedLineRange]);
+  const resolvedCount = useMemo(() => getResolvedCount(issues, null), [issues]);
   const passingCount = useMemo(() => getPassingCount(issues), [issues]);
-  const filteredIssues = useMemo(
-    () => getFilteredIssues(visibleIssues, filter, selectedLineRange),
-    [visibleIssues, filter, selectedLineRange],
-  );
   const highlightIssues = useMemo(() => getHighlightIssues(visibleIssues, filter), [visibleIssues, filter]);
 
   // Falls back to the first issue on the selected lines, so arriving on a #L… hash
@@ -312,15 +307,11 @@ export function DocumentExplorerTabV2({
           <IssuesColumn
             ref={issuesRef}
             visibleIssues={visibleIssues}
-            filteredIssues={filteredIssues}
+            issues={highlightIssues}
             activeIssueId={activeIssueId}
             isAnyProcessing={isAnyProcessing}
             readOnly={readOnly}
             onSelectIssue={handleSelectIssue}
-            onClearSelection={() => {
-              setOpenIssueId(null);
-              clearLineSelection();
-            }}
           />
         </aside>
       </div>

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -19,11 +19,13 @@ import {
   isAnyWorkflowProcessing,
   isWorkflowProcessing,
 } from '@/lib/workflow-state';
+import { WIDE_ENOUGH_FOR_PANE, useMediaQuery } from '@/lib/use-media-query';
 import { cn } from '@/lib/utils';
-import { AlertTriangleIcon, Columns2, History, ListFilter, Loader2, PanelLeft } from 'lucide-react';
+import { AlertTriangleIcon, Columns2, History, ListFilter, Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { DocumentView, DocumentViewHandle } from './document-view';
 import { IssuesColumn, IssuesColumnHandle, issueCountLabel } from './issues-column';
+import { Rail, RailToggle, SidePane, useRailState } from '../panes';
 import { OutlineRail } from './outline-rail';
 import { OutlineEntry, extractOutline } from './outline';
 
@@ -66,7 +68,9 @@ export function DocumentExplorerTabV2({
   const { selectedLineRange, selectLineRange, clearLineSelection, filter, setFilter, clearFilters } =
     useDocumentExplorerStore();
 
-  const [railOpen, setRailOpen] = useState(true);
+  const rail = useRailState();
+  const isWideEnoughForColumn = useMediaQuery(WIDE_ENOUGH_FOR_PANE);
+  const [issuesOpen, setIssuesOpen] = useState(false);
   const [activeLine, setActiveLine] = useState<number | null>(null);
   // Margin puts each issue beside its paragraph in one shared scroll; list keeps
   // the ranked queue in a column of its own.
@@ -121,6 +125,11 @@ export function DocumentExplorerTabV2({
 
   useLineHashNavigation(handleLineHashNavigation);
 
+  const showIssuesColumn = isWideEnoughForColumn && (mode === 'list' || !rail.isWide);
+  // Margin notes only render once the document has a margin to put them in,
+  // which is the same width the rail sits beside the text at.
+  const issuesVisible = showIssuesColumn || (mode === 'margin' && rail.isWide);
+
   const handleSelectIssue = useCallback(
     (issue: Issue) => {
       const range = getIssueLineRange(issue);
@@ -161,13 +170,22 @@ export function DocumentExplorerTabV2({
         return;
       }
       const range = getIssueLineRange(issue);
-      if (range) {
-        setOpenIssueId(issue.id);
-        selectLineRange(range);
+      if (!range) return;
+
+      setOpenIssueId(issue.id);
+      selectLineRange(range);
+
+      if (issuesVisible) {
         issuesRef.current?.scrollToIssue(issue);
+        return;
       }
+
+      // Nowhere on screen is showing this issue, so bring the pane out and
+      // scroll once it has mounted — the ref is null until the sheet opens.
+      setIssuesOpen(true);
+      setTimeout(() => issuesRef.current?.scrollToIssue(issue), 250);
     },
-    [selectLineRange, clearLineSelection],
+    [issuesVisible, selectLineRange, clearLineSelection],
   );
 
   /**
@@ -186,6 +204,9 @@ export function DocumentExplorerTabV2({
     },
     [mode],
   );
+
+  // Margin mode puts the issues beside the text, so the column only earns its
+  // place there while the margin itself is too narrow to appear.
 
   const countLabel = issueCountLabel(visibleIssues, highlightIssues);
 
@@ -217,12 +238,7 @@ export function DocumentExplorerTabV2({
       )}
 
       <div className="flex min-h-0 flex-1">
-        <aside
-          className={cn(
-            'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
-            railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
-          )}
-        >
+        <Rail state={rail} label="Filters and outline">
           <OutlineRail
             outline={outline}
             visibleIssues={visibleIssues}
@@ -233,27 +249,16 @@ export function DocumentExplorerTabV2({
             resolvedCount={resolvedCount}
             passingCount={passingCount}
             activeLine={activeLine}
-            onJump={handleJumpToSection}
+            onJump={(entry) => {
+              handleJumpToSection(entry);
+              rail.close();
+            }}
           />
-        </aside>
+        </Rail>
 
         <main className="flex min-w-0 flex-1 flex-col">
           <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="hidden size-7 xl:flex"
-                  onClick={() => setRailOpen(!railOpen)}
-                  aria-label={railOpen ? 'Hide contents' : 'Show contents'}
-                  aria-pressed={railOpen}
-                >
-                  <PanelLeft className="size-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{railOpen ? 'Hide filters and outline' : 'Show filters and outline'}</TooltipContent>
-            </Tooltip>
+            <RailToggle state={rail} label="Filters and outline" />
             <span className="truncate text-xs text-muted-foreground">
               {outline.length > 0 ? `${outline.length} sections` : 'Document'}
               {mainDocumentMarkdown ? ` · ${mainDocumentMarkdown.split('\n').length} lines` : ''}
@@ -271,6 +276,18 @@ export function DocumentExplorerTabV2({
                   </span>
                 </TooltipTrigger>
                 <TooltipContent>Some results are still loading, see the Assessments tab for details</TooltipContent>
+              </Tooltip>
+            )}
+
+            {!issuesVisible && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="xs" variant="outline" className="ml-auto" onClick={() => setIssuesOpen(true)}>
+                    <ListFilter className="size-3" />
+                    Issues
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Every issue found in this document</TooltipContent>
               </Tooltip>
             )}
 
@@ -331,11 +348,15 @@ export function DocumentExplorerTabV2({
           </div>
         </main>
 
-        <aside
-          className={cn(
-            'hidden w-[24rem] shrink-0 border-l xl:w-[26rem]',
-            mode === 'list' ? 'lg:block' : 'lg:block xl:hidden',
-          )}
+        {/* A column wherever the margin is not already carrying the issues,
+            and a sheet the reader opens below that width — where neither the
+            margin nor a column fits. */}
+        {/* Asking for the pane must not keep it around once the margin or the
+            column has taken the issues back. */}
+        <SidePane
+          open={showIssuesColumn || (!issuesVisible && issuesOpen)}
+          onClose={() => setIssuesOpen(false)}
+          label="Issues"
         >
           <IssuesColumn
             ref={issuesRef}
@@ -346,7 +367,7 @@ export function DocumentExplorerTabV2({
             readOnly={readOnly}
             onSelectIssue={handleSelectIssue}
           />
-        </aside>
+        </SidePane>
       </div>
     </div>
   );

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -20,7 +20,7 @@ import {
   isWorkflowProcessing,
 } from '@/lib/workflow-state';
 import { cn } from '@/lib/utils';
-import { AlertTriangleIcon, History, Loader2, PanelLeft } from 'lucide-react';
+import { AlertTriangleIcon, Columns2, History, ListFilter, Loader2, PanelLeft } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { DocumentView, DocumentViewHandle } from './document-view';
 import { IssuesColumn, IssuesColumnHandle } from './issues-column';
@@ -57,6 +57,13 @@ export function DocumentExplorerTabV2({
 
   const [railOpen, setRailOpen] = useState(true);
   const [activeLine, setActiveLine] = useState<number | null>(null);
+  // Margin puts each issue beside its paragraph in one shared scroll; list keeps
+  // the ranked queue in a column of its own.
+  const [mode, setMode] = useState<'margin' | 'list'>('margin');
+  // Which margin note is open. Tracked rather than derived from the line range,
+  // because several issues can share a range and the one you clicked is the one
+  // that should expand.
+  const [openIssueId, setOpenIssueId] = useState<string | null>(null);
 
   const mainDocumentMarkdown = projectDetail.main_document_markdown ?? '';
   const currentRevision = projectDetail.project.current_revision ?? 1;
@@ -83,6 +90,18 @@ export function DocumentExplorerTabV2({
   );
   const highlightIssues = useMemo(() => getHighlightIssues(visibleIssues, filter), [visibleIssues, filter]);
 
+  // Falls back to the first issue on the selected lines, so arriving on a #L… hash
+  // from another tab still opens something.
+  const activeIssueId = useMemo(() => {
+    if (!selectedLineRange) return null;
+    if (openIssueId && highlightIssues.some((issue) => issue.id === openIssueId)) return openIssueId;
+    const match = highlightIssues.find((issue) => {
+      const range = getIssueLineRange(issue);
+      return range !== null && range[0] <= selectedLineRange[1] && range[1] >= selectedLineRange[0];
+    });
+    return match?.id ?? null;
+  }, [highlightIssues, selectedLineRange, openIssueId]);
+
   // Landing on a #L… hash (e.g. from an issue in another tab) both filters to
   // that range and brings it into view, matching a click on an issue in-tab.
   const handleLineHashNavigation = useCallback(
@@ -99,29 +118,66 @@ export function DocumentExplorerTabV2({
     (issue: Issue) => {
       const range = getIssueLineRange(issue);
       if (range) {
+        setOpenIssueId(issue.id);
         selectLineRange(range);
         issuesRef.current?.scrollToIssue(issue);
         documentRef.current?.scrollToLineRange(range);
       } else {
+        setOpenIssueId(null);
         clearLineSelection();
       }
     },
     [selectLineRange, clearLineSelection],
   );
 
+  /** Toggles a margin note without moving the document under the reader. */
+  const handleToggleMarginNote = useCallback(
+    (issue: Issue) => {
+      if (openIssueId === issue.id) {
+        setOpenIssueId(null);
+        clearLineSelection();
+        return;
+      }
+      const range = getIssueLineRange(issue);
+      setOpenIssueId(issue.id);
+      if (range) selectLineRange(range);
+      else clearLineSelection();
+    },
+    [openIssueId, selectLineRange, clearLineSelection],
+  );
+
   const handleIssueSelectFromDocument = useCallback(
     (issue: Issue | null) => {
       if (!issue) {
+        setOpenIssueId(null);
         clearLineSelection();
         return;
       }
       const range = getIssueLineRange(issue);
       if (range) {
+        setOpenIssueId(issue.id);
         selectLineRange(range);
         issuesRef.current?.scrollToIssue(issue);
       }
     },
     [selectLineRange, clearLineSelection],
+  );
+
+  /**
+   * Margin rows grow to fit the notes beside them, so the document is taller in
+   * margin mode than in list mode. Switching therefore lands on a different part
+   * of the text unless the reader's place is carried across.
+   */
+  const handleModeChange = useCallback(
+    (next: 'margin' | 'list') => {
+      if (next === mode) return;
+      const line = documentRef.current?.getTopVisibleLine() ?? null;
+      setMode(next);
+      if (line !== null) {
+        setTimeout(() => documentRef.current?.scrollToLine(line, 'auto'), 0);
+      }
+    },
+    [mode],
   );
 
   const handleJumpToSection = useCallback((entry: OutlineEntry) => {
@@ -161,6 +217,7 @@ export function DocumentExplorerTabV2({
           <OutlineRail
             outline={outline}
             visibleIssues={visibleIssues}
+            markedIssues={highlightIssues}
             filter={filter}
             onFilterChange={setFilter}
             onClearFilters={clearFilters}
@@ -187,6 +244,30 @@ export function DocumentExplorerTabV2({
               {outline.length > 0 ? `${outline.length} sections` : 'Document'}
               {mainDocumentMarkdown ? ` · ${mainDocumentMarkdown.split('\n').length} lines` : ''}
             </span>
+
+            <div className="ml-auto hidden items-center gap-1 rounded-md border p-0.5 xl:flex">
+              {(
+                [
+                  { id: 'margin' as const, label: 'Margin', icon: Columns2 },
+                  { id: 'list' as const, label: 'List', icon: ListFilter },
+                ] satisfies { id: 'margin' | 'list'; label: string; icon: typeof Columns2 }[]
+              ).map((option) => (
+                <button
+                  key={option.id}
+                  onClick={() => handleModeChange(option.id)}
+                  aria-pressed={mode === option.id}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs font-medium transition-colors',
+                    mode === option.id
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:bg-accent/60',
+                  )}
+                >
+                  <option.icon className="size-3.5" />
+                  {option.label}
+                </button>
+              ))}
+            </div>
           </div>
 
           <div className="min-h-0 flex-1">
@@ -196,6 +277,7 @@ export function DocumentExplorerTabV2({
               issues={highlightIssues}
               selectedLineRange={selectedLineRange}
               onIssueSelect={handleIssueSelectFromDocument}
+              margin={mode === 'margin' ? { activeIssueId, readOnly, onSelect: handleToggleMarginNote } : undefined}
               header={
                 isViewingOlderRevision ? (
                   <Callout variant="info" icon={History} title={`Viewing revision ${selectedRevision}`}>
@@ -221,15 +303,24 @@ export function DocumentExplorerTabV2({
           </div>
         </main>
 
-        <aside className="hidden w-[24rem] shrink-0 border-l lg:block xl:w-[26rem]">
+        <aside
+          className={cn(
+            'hidden w-[24rem] shrink-0 border-l xl:w-[26rem]',
+            mode === 'list' ? 'lg:block' : 'lg:block xl:hidden',
+          )}
+        >
           <IssuesColumn
             ref={issuesRef}
             visibleIssues={visibleIssues}
             filteredIssues={filteredIssues}
+            activeIssueId={activeIssueId}
             isAnyProcessing={isAnyProcessing}
             readOnly={readOnly}
             onSelectIssue={handleSelectIssue}
-            onClearSelection={clearLineSelection}
+            onClearSelection={() => {
+              setOpenIssueId(null);
+              clearLineSelection();
+            }}
           />
         </aside>
       </div>

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/lib/workflow-state';
 import { WIDE_ENOUGH_FOR_PANE, useMediaQuery } from '@/lib/use-media-query';
 import { cn } from '@/lib/utils';
-import { AlertTriangleIcon, Columns2, History, ListFilter, Loader2 } from 'lucide-react';
+import { AlertTriangleIcon, Columns2, ListFilter, Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { DocumentView, DocumentViewHandle } from './document-view';
 import { IssuesColumn, IssuesColumnHandle, issueCountLabel } from './issues-column';
@@ -44,10 +44,6 @@ interface DocumentExplorerTabProps {
   projectDetail: ProjectDetailed;
   readOnly?: boolean;
   onNavigateToAnalyses: () => void;
-  /** Currently displayed revision (for the non-current revision notice). */
-  selectedRevision?: number;
-  /** Callback to switch revisions (used by the "View current revision" action). */
-  onRevisionChange?: (revision: number) => void;
 }
 
 type IssueWithLines = Issue & { start_line?: number | null; end_line?: number | null };
@@ -62,8 +58,6 @@ export function DocumentExplorerTabV2({
   projectDetail,
   readOnly = false,
   onNavigateToAnalyses,
-  selectedRevision,
-  onRevisionChange,
 }: DocumentExplorerTabProps) {
   const { selectedLineRange, selectLineRange, clearLineSelection, filter, setFilter, clearFilters } =
     useDocumentExplorerStore();
@@ -81,8 +75,6 @@ export function DocumentExplorerTabV2({
   const [openIssueId, setOpenIssueId] = useState<string | null>(null);
 
   const mainDocumentMarkdown = projectDetail.main_document_markdown ?? '';
-  const currentRevision = projectDetail.project.current_revision ?? 1;
-  const isViewingOlderRevision = selectedRevision != null && selectedRevision !== currentRevision;
 
   const workflowDetails = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
   const issues = useMemo(() => projectDetail.issues ?? [], [projectDetail.issues]);
@@ -323,27 +315,6 @@ export function DocumentExplorerTabV2({
               selectedLineRange={selectedLineRange}
               onIssueSelect={handleIssueSelectFromDocument}
               margin={mode === 'margin' ? { activeIssueId, readOnly, onSelect: handleToggleMarginNote } : undefined}
-              header={
-                isViewingOlderRevision ? (
-                  <Callout variant="info" icon={History} title={`Viewing revision ${selectedRevision}`}>
-                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                      <p className="min-w-0 text-sm">
-                        You are viewing a previous revision of the main document (revision {selectedRevision}).
-                      </p>
-                      {onRevisionChange && (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="shrink-0"
-                          onClick={() => onRevisionChange(currentRevision)}
-                        >
-                          View current
-                        </Button>
-                      )}
-                    </div>
-                  </Callout>
-                ) : undefined
-              }
             />
           </div>
         </main>

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button';
 import { Callout } from '@/components/ui/callout';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Issue, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useLineHashNavigation } from '@/lib/line-hash';
 import {
@@ -22,7 +23,7 @@ import { cn } from '@/lib/utils';
 import { AlertTriangleIcon, Columns2, History, ListFilter, Loader2, PanelLeft } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { DocumentView, DocumentViewHandle } from './document-view';
-import { IssuesColumn, IssuesColumnHandle } from './issues-column';
+import { IssuesColumn, IssuesColumnHandle, issueCountLabel } from './issues-column';
 import { OutlineRail } from './outline-rail';
 import { OutlineEntry, extractOutline } from './outline';
 
@@ -175,6 +176,8 @@ export function DocumentExplorerTabV2({
     [mode],
   );
 
+  const countLabel = issueCountLabel(visibleIssues, highlightIssues);
+
   const handleJumpToSection = useCallback((entry: OutlineEntry) => {
     setActiveLine(entry.line);
     documentRef.current?.scrollToLine(entry.line);
@@ -238,7 +241,22 @@ export function DocumentExplorerTabV2({
             <span className="truncate text-xs text-muted-foreground">
               {outline.length > 0 ? `${outline.length} sections` : 'Document'}
               {mainDocumentMarkdown ? ` · ${mainDocumentMarkdown.split('\n').length} lines` : ''}
+              {` · ${countLabel ?? (isAnyProcessing ? 'Finding issues...' : 'No issues')}`}
             </span>
+
+            {isAnyProcessing && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex size-3.5 shrink-0 items-center justify-center text-muted-foreground"
+                    aria-label="Some results are still loading"
+                  >
+                    <Loader2 className="size-3.5 animate-spin" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>Some results are still loading, see the Assessments tab for details</TooltipContent>
+              </Tooltip>
+            )}
 
             <div className="ml-auto hidden items-center gap-1 rounded-md border p-0.5 xl:flex">
               {(

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Callout } from '@/components/ui/callout';
+import { Issue, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { useLineHashNavigation } from '@/lib/line-hash';
+import {
+  getFilteredIssues,
+  getHighlightIssues,
+  getPassingCount,
+  getResolvedCount,
+  getVisibleIssues,
+  LineRange,
+  useDocumentExplorerStore,
+} from '@/lib/stores/document-explorer-store';
+import {
+  getBlockingWorkflowErrors,
+  getWorkflowRunByType,
+  isAnyWorkflowProcessing,
+  isWorkflowProcessing,
+} from '@/lib/workflow-state';
+import { cn } from '@/lib/utils';
+import { AlertTriangleIcon, History, Loader2, PanelLeft } from 'lucide-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { DocumentView, DocumentViewHandle } from './document-view';
+import { IssuesColumn, IssuesColumnHandle } from './issues-column';
+import { OutlineRail } from './outline-rail';
+import { OutlineEntry, extractOutline } from './outline';
+
+interface DocumentExplorerTabProps {
+  projectDetail: ProjectDetailed;
+  readOnly?: boolean;
+  onNavigateToAnalyses: () => void;
+  /** Currently displayed revision (for the non-current revision notice). */
+  selectedRevision?: number;
+  /** Callback to switch revisions (used by the "View current revision" action). */
+  onRevisionChange?: (revision: number) => void;
+}
+
+type IssueWithLines = Issue & { start_line?: number | null; end_line?: number | null };
+
+function getIssueLineRange(issue: Issue): [number, number] | null {
+  const { start_line, end_line } = issue as IssueWithLines;
+  if (typeof start_line !== 'number' || typeof end_line !== 'number') return null;
+  return [start_line, end_line];
+}
+
+export function DocumentExplorerTabV2({
+  projectDetail,
+  readOnly = false,
+  onNavigateToAnalyses,
+  selectedRevision,
+  onRevisionChange,
+}: DocumentExplorerTabProps) {
+  const { selectedLineRange, selectLineRange, clearLineSelection, filter, setFilter, clearFilters } =
+    useDocumentExplorerStore();
+
+  const [railOpen, setRailOpen] = useState(true);
+  const [activeLine, setActiveLine] = useState<number | null>(null);
+
+  const mainDocumentMarkdown = projectDetail.main_document_markdown ?? '';
+  const currentRevision = projectDetail.project.current_revision ?? 1;
+  const isViewingOlderRevision = selectedRevision != null && selectedRevision !== currentRevision;
+
+  const workflowDetails = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
+  const issues = useMemo(() => projectDetail.issues ?? [], [projectDetail.issues]);
+
+  const documentProcessing = getWorkflowRunByType(workflowDetails, WorkflowRunType.DocumentProcessing);
+  const isDocumentProcessing = isWorkflowProcessing(documentProcessing);
+  const isAnyProcessing = isAnyWorkflowProcessing(workflowDetails);
+
+  const issuesRef = useRef<IssuesColumnHandle>(null);
+  const documentRef = useRef<DocumentViewHandle>(null);
+
+  const workflowErrors = useMemo(() => getBlockingWorkflowErrors(workflowDetails), [workflowDetails]);
+  const outline = useMemo(() => extractOutline(mainDocumentMarkdown), [mainDocumentMarkdown]);
+  const visibleIssues = useMemo(() => getVisibleIssues(issues, filter), [issues, filter]);
+  const resolvedCount = useMemo(() => getResolvedCount(issues, selectedLineRange), [issues, selectedLineRange]);
+  const passingCount = useMemo(() => getPassingCount(issues), [issues]);
+  const filteredIssues = useMemo(
+    () => getFilteredIssues(visibleIssues, filter, selectedLineRange),
+    [visibleIssues, filter, selectedLineRange],
+  );
+  const highlightIssues = useMemo(() => getHighlightIssues(visibleIssues, filter), [visibleIssues, filter]);
+
+  // Landing on a #L… hash (e.g. from an issue in another tab) both filters to
+  // that range and brings it into view, matching a click on an issue in-tab.
+  const handleLineHashNavigation = useCallback(
+    (range: LineRange) => {
+      selectLineRange(range);
+      documentRef.current?.scrollToLineRange(range);
+    },
+    [selectLineRange],
+  );
+
+  useLineHashNavigation(handleLineHashNavigation);
+
+  const handleSelectIssue = useCallback(
+    (issue: Issue) => {
+      const range = getIssueLineRange(issue);
+      if (range) {
+        selectLineRange(range);
+        issuesRef.current?.scrollToIssue(issue);
+        documentRef.current?.scrollToLineRange(range);
+      } else {
+        clearLineSelection();
+      }
+    },
+    [selectLineRange, clearLineSelection],
+  );
+
+  const handleIssueSelectFromDocument = useCallback(
+    (issue: Issue | null) => {
+      if (!issue) {
+        clearLineSelection();
+        return;
+      }
+      const range = getIssueLineRange(issue);
+      if (range) {
+        selectLineRange(range);
+        issuesRef.current?.scrollToIssue(issue);
+      }
+    },
+    [selectLineRange, clearLineSelection],
+  );
+
+  const handleJumpToSection = useCallback((entry: OutlineEntry) => {
+    setActiveLine(entry.line);
+    documentRef.current?.scrollToLine(entry.line);
+  }, []);
+
+  if (isDocumentProcessing && !mainDocumentMarkdown) {
+    return (
+      <div className="space-y-4 p-6">
+        {workflowErrors.length > 0 && <ProcessingErrorNotice onNavigateToAnalyses={onNavigateToAnalyses} />}
+        <div className="flex items-center justify-center py-12">
+          <div className="space-y-3 text-center">
+            <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
+            <p className="text-sm text-muted-foreground">Processing document(s)...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg">
+      {workflowErrors.length > 0 && (
+        <div className="border-b p-3">
+          <ProcessingErrorNotice onNavigateToAnalyses={onNavigateToAnalyses} />
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1">
+        <aside
+          className={cn(
+            'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
+            railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
+          )}
+        >
+          <OutlineRail
+            outline={outline}
+            visibleIssues={visibleIssues}
+            filter={filter}
+            onFilterChange={setFilter}
+            onClearFilters={clearFilters}
+            resolvedCount={resolvedCount}
+            passingCount={passingCount}
+            activeLine={activeLine}
+            onJump={handleJumpToSection}
+          />
+        </aside>
+
+        <main className="flex min-w-0 flex-1 flex-col">
+          <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="hidden size-7 xl:flex"
+              onClick={() => setRailOpen(!railOpen)}
+              aria-label={railOpen ? 'Hide contents' : 'Show contents'}
+              aria-pressed={railOpen}
+            >
+              <PanelLeft className="size-4" />
+            </Button>
+            <span className="truncate text-xs text-muted-foreground">
+              {outline.length > 0 ? `${outline.length} sections` : 'Document'}
+              {mainDocumentMarkdown ? ` · ${mainDocumentMarkdown.split('\n').length} lines` : ''}
+            </span>
+          </div>
+
+          <div className="min-h-0 flex-1">
+            <DocumentView
+              ref={documentRef}
+              markdown={mainDocumentMarkdown}
+              issues={highlightIssues}
+              selectedLineRange={selectedLineRange}
+              onIssueSelect={handleIssueSelectFromDocument}
+              header={
+                isViewingOlderRevision ? (
+                  <Callout variant="info" icon={History} title={`Viewing revision ${selectedRevision}`}>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <p className="min-w-0 text-sm">
+                        You are viewing a previous revision of the main document (revision {selectedRevision}).
+                      </p>
+                      {onRevisionChange && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="shrink-0"
+                          onClick={() => onRevisionChange(currentRevision)}
+                        >
+                          View current
+                        </Button>
+                      )}
+                    </div>
+                  </Callout>
+                ) : undefined
+              }
+            />
+          </div>
+        </main>
+
+        <aside className="hidden w-[24rem] shrink-0 border-l lg:block xl:w-[26rem]">
+          <IssuesColumn
+            ref={issuesRef}
+            visibleIssues={visibleIssues}
+            filteredIssues={filteredIssues}
+            isAnyProcessing={isAnyProcessing}
+            readOnly={readOnly}
+            onSelectIssue={handleSelectIssue}
+            onClearSelection={clearLineSelection}
+          />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function ProcessingErrorNotice({ onNavigateToAnalyses }: { onNavigateToAnalyses: () => void }) {
+  return (
+    <Callout variant="warning" icon={AlertTriangleIcon} title="Unexpected processing errors occurred">
+      <p className="text-sm">
+        Check the{' '}
+        <button onClick={onNavigateToAnalyses} className="cursor-pointer font-medium underline underline-offset-2">
+          Assessments tab
+        </button>{' '}
+        for details.
+      </p>
+    </Callout>
+  );
+}

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -27,6 +27,17 @@ import { IssuesColumn, IssuesColumnHandle, issueCountLabel } from './issues-colu
 import { OutlineRail } from './outline-rail';
 import { OutlineEntry, extractOutline } from './outline';
 
+/** The two ways to read the issues: beside the text, or gathered in a column. */
+const MODES = [
+  {
+    id: 'margin' as const,
+    label: 'Margin',
+    icon: Columns2,
+    hint: 'Issues sit beside the paragraph they belong to',
+  },
+  { id: 'list' as const, label: 'List', icon: ListFilter, hint: 'Issues in one column, grouped by severity' },
+];
+
 interface DocumentExplorerTabProps {
   projectDetail: ProjectDetailed;
   readOnly?: boolean;
@@ -228,16 +239,21 @@ export function DocumentExplorerTabV2({
 
         <main className="flex min-w-0 flex-1 flex-col">
           <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="hidden size-7 xl:flex"
-              onClick={() => setRailOpen(!railOpen)}
-              aria-label={railOpen ? 'Hide contents' : 'Show contents'}
-              aria-pressed={railOpen}
-            >
-              <PanelLeft className="size-4" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="hidden size-7 xl:flex"
+                  onClick={() => setRailOpen(!railOpen)}
+                  aria-label={railOpen ? 'Hide contents' : 'Show contents'}
+                  aria-pressed={railOpen}
+                >
+                  <PanelLeft className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{railOpen ? 'Hide filters and outline' : 'Show filters and outline'}</TooltipContent>
+            </Tooltip>
             <span className="truncate text-xs text-muted-foreground">
               {outline.length > 0 ? `${outline.length} sections` : 'Document'}
               {mainDocumentMarkdown ? ` · ${mainDocumentMarkdown.split('\n').length} lines` : ''}
@@ -259,26 +275,25 @@ export function DocumentExplorerTabV2({
             )}
 
             <div className="ml-auto hidden items-center gap-1 rounded-md border p-0.5 xl:flex">
-              {(
-                [
-                  { id: 'margin' as const, label: 'Margin', icon: Columns2 },
-                  { id: 'list' as const, label: 'List', icon: ListFilter },
-                ] satisfies { id: 'margin' | 'list'; label: string; icon: typeof Columns2 }[]
-              ).map((option) => (
-                <button
-                  key={option.id}
-                  onClick={() => handleModeChange(option.id)}
-                  aria-pressed={mode === option.id}
-                  className={cn(
-                    'flex cursor-pointer items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs font-medium transition-colors',
-                    mode === option.id
-                      ? 'bg-accent text-accent-foreground'
-                      : 'text-muted-foreground hover:bg-accent/60',
-                  )}
-                >
-                  <option.icon className="size-3.5" />
-                  {option.label}
-                </button>
+              {MODES.map((option) => (
+                <Tooltip key={option.id}>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => handleModeChange(option.id)}
+                      aria-pressed={mode === option.id}
+                      className={cn(
+                        'flex cursor-pointer items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs font-medium transition-colors',
+                        mode === option.id
+                          ? 'bg-accent text-accent-foreground'
+                          : 'text-muted-foreground hover:bg-accent/60',
+                      )}
+                    >
+                      <option.icon className="size-3.5" />
+                      {option.label}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{option.hint}</TooltipContent>
+                </Tooltip>
               ))}
             </div>
           </div>

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -96,8 +96,11 @@ export function DocumentExplorerTabV2({
   // Falls back to the first issue on the selected lines, so arriving on a #L… hash
   // from another tab still opens something.
   const activeIssueId = useMemo(() => {
-    if (!selectedLineRange) return null;
+    // Before the range check: an issue the reader opened stays open even when it
+    // has no lines to select, which is the only way to read one that carries
+    // none — nothing anchors it in the document for the fallback below to find.
     if (openIssueId && highlightIssues.some((issue) => issue.id === openIssueId)) return openIssueId;
+    if (!selectedLineRange) return null;
     const match = highlightIssues.find((issue) => {
       const range = getIssueLineRange(issue);
       return range !== null && range[0] <= selectedLineRange[1] && range[1] >= selectedLineRange[0];
@@ -125,13 +128,14 @@ export function DocumentExplorerTabV2({
   const handleSelectIssue = useCallback(
     (issue: Issue) => {
       const range = getIssueLineRange(issue);
+      // Opening the issue does not depend on it having a range: start_line is
+      // nullable, and an issue with none can only be read here.
+      setOpenIssueId(issue.id);
+      issuesRef.current?.scrollToIssue(issue);
       if (range) {
-        setOpenIssueId(issue.id);
         selectLineRange(range);
-        issuesRef.current?.scrollToIssue(issue);
         documentRef.current?.scrollToLineRange(range);
       } else {
-        setOpenIssueId(null);
         clearLineSelection();
       }
     },

--- a/frontend/components/results-v2/document-explorer/document-issues.tsx
+++ b/frontend/components/results-v2/document-explorer/document-issues.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Issue } from '@/lib/generated-api';
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { useState } from 'react';
+import { MarginNote } from './margin-note';
+
+/** How many document-level notes stand above the document before folding. */
+const COLLAPSED_COUNT = 3;
+
+interface DocumentIssuesProps {
+  issues: Issue[];
+  activeIssueId: string | null;
+  readOnly: boolean;
+  onSelect: (issue: Issue) => void;
+}
+
+/**
+ * The findings that are about the document rather than a place in it, gathered
+ * at the top of the margin. They are folded after a few: this block sits above
+ * the first paragraph, so a long one pushes the document itself off the screen —
+ * the opposite of what the margin is for.
+ */
+export function DocumentIssues({ issues, activeIssueId, readOnly, onSelect }: DocumentIssuesProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Opening one from the issues list must not leave it folded away, so the
+  // block unfolds around whatever is active rather than hiding it.
+  const activeIsFolded = issues.findIndex((issue) => issue.id === activeIssueId) >= COLLAPSED_COUNT;
+  const showAll = expanded || activeIsFolded;
+  const shown = showAll ? issues : issues.slice(0, COLLAPSED_COUNT);
+  const hidden = issues.length - shown.length;
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <p className="mb-1.5 flex w-fit cursor-help items-center gap-1.5 font-mono text-[9.5px] tracking-wide text-muted-foreground uppercase">
+            About the whole document
+            {issues.length > COLLAPSED_COUNT && <span className="tabular-nums">{issues.length}</span>}
+          </p>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs">
+          These findings are about the document as a whole rather than any particular passage, so they name no lines and
+          sit here instead of beside the text.
+        </TooltipContent>
+      </Tooltip>
+
+      {shown.map((issue) => (
+        <MarginNote
+          key={issue.id}
+          issue={issue}
+          anchored={false}
+          active={activeIssueId === issue.id}
+          readOnly={readOnly}
+          onSelect={onSelect}
+        />
+      ))}
+
+      {(hidden > 0 || (showAll && issues.length > COLLAPSED_COUNT)) && (
+        <button
+          onClick={() => setExpanded(!showAll)}
+          aria-expanded={showAll}
+          className="mt-0.5 flex cursor-pointer items-center gap-1 px-2 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+        >
+          {showAll ? <ChevronUpIcon className="size-3" /> : <ChevronDownIcon className="size-3" />}
+          {showAll ? 'Show fewer' : `Show ${hidden} more`}
+        </button>
+      )}
+    </>
+  );
+}

--- a/frontend/components/results-v2/document-explorer/document-issues.tsx
+++ b/frontend/components/results-v2/document-explorer/document-issues.tsx
@@ -58,9 +58,12 @@ export function DocumentIssues({ issues, activeIssueId, readOnly, onSelect }: Do
         />
       ))}
 
-      {(hidden > 0 || (showAll && issues.length > COLLAPSED_COUNT)) && (
+      {/* Nothing to offer while the open issue is one of the folded ones:
+          collapsing would hide what the reader is reading, so the control would
+          be pressed and do nothing. */}
+      {!activeIsFolded && (hidden > 0 || (showAll && issues.length > COLLAPSED_COUNT)) && (
         <button
-          onClick={() => setExpanded(!showAll)}
+          onClick={() => setExpanded(!expanded)}
           aria-expanded={showAll}
           className="mt-0.5 flex cursor-pointer items-center gap-1 px-2 text-[11px] font-medium text-muted-foreground hover:text-foreground"
         >

--- a/frontend/components/results-v2/document-explorer/document-view.tsx
+++ b/frontend/components/results-v2/document-explorer/document-view.tsx
@@ -5,7 +5,7 @@ import { SeverityEnum } from '@/lib/generated-api';
 import { cn } from '@/lib/utils';
 import type { Element } from 'hast';
 import { ImageOff } from 'lucide-react';
-import { SEVERITY } from './issue-note';
+import { SEVERITY } from '@/lib/severity-style';
 import { MarginNote } from './margin-note';
 import React, { Ref, createContext, useContext, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import ReactMarkdown, { type ExtraProps } from 'react-markdown';

--- a/frontend/components/results-v2/document-explorer/document-view.tsx
+++ b/frontend/components/results-v2/document-explorer/document-view.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+import type { Issue } from '@/lib/generated-api';
+import { SeverityEnum } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import type { Element } from 'hast';
+import { ImageOff } from 'lucide-react';
+import React, { Ref, createContext, useContext, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import ReactMarkdown, { type ExtraProps } from 'react-markdown';
+import rehypeMathML from '@daiji256/rehype-mathml';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import type { PluggableList } from 'unified';
+
+interface IssueWithLines extends Issue {
+  start_line?: number | null;
+  end_line?: number | null;
+}
+
+export interface DocumentViewHandle {
+  scrollToLineRange: (range: [number, number]) => void;
+  scrollToLine: (line: number) => void;
+}
+
+interface DocumentViewProps {
+  ref?: Ref<DocumentViewHandle>;
+  markdown: string;
+  issues: Issue[];
+  selectedLineRange: [number, number] | null;
+  onIssueSelect: (issue: Issue | null) => void;
+  /** Optional content rendered inside the scroll area, above the document. */
+  header?: React.ReactNode;
+}
+
+/** Gutter rule colour, one per severity. Same families the issue cards use. */
+const SEVERITY_RULE: Record<string, string> = {
+  [SeverityEnum.High]: 'bg-red-500',
+  [SeverityEnum.Medium]: 'bg-amber-500',
+  [SeverityEnum.Low]: 'bg-blue-500',
+  [SeverityEnum.None]: 'bg-green-500',
+};
+
+/** Resting wash on a flagged block — quiet enough to read through. */
+const SEVERITY_WASH: Record<string, string> = {
+  [SeverityEnum.High]: 'bg-red-50/70 dark:bg-red-950/20',
+  [SeverityEnum.Medium]: 'bg-amber-50/70 dark:bg-amber-950/20',
+  [SeverityEnum.Low]: 'bg-blue-50/70 dark:bg-blue-950/20',
+  [SeverityEnum.None]: 'bg-green-50/70 dark:bg-green-950/20',
+};
+
+/** Wash once the block is the selected one. */
+const SEVERITY_WASH_SELECTED: Record<string, string> = {
+  [SeverityEnum.High]: 'bg-red-100 dark:bg-red-950/50',
+  [SeverityEnum.Medium]: 'bg-amber-100 dark:bg-amber-950/50',
+  [SeverityEnum.Low]: 'bg-blue-100 dark:bg-blue-950/50',
+  [SeverityEnum.None]: 'bg-green-100 dark:bg-green-950/50',
+};
+
+const SEVERITY_RANK: Record<string, number> = {
+  [SeverityEnum.None]: 0,
+  [SeverityEnum.Low]: 1,
+  [SeverityEnum.Medium]: 2,
+  [SeverityEnum.High]: 3,
+};
+
+const CLEARED_CLASSES = [
+  ...new Set(
+    [...Object.values(SEVERITY_WASH), ...Object.values(SEVERITY_WASH_SELECTED)].flatMap((cls) => cls.split(' ')),
+  ),
+  'cursor-pointer',
+  'opacity-50',
+  'ring-1',
+  'ring-inset',
+  'ring-foreground/15',
+];
+
+function hasLineRange(issue: Issue): issue is IssueWithLines & { start_line: number; end_line: number } {
+  const start = (issue as IssueWithLines).start_line;
+  const end = (issue as IssueWithLines).end_line;
+  return typeof start === 'number' && typeof end === 'number';
+}
+
+function pickTopSeverityIssue(issues: IssueWithLines[], lineStart: number, lineEnd: number) {
+  let best: IssueWithLines | null = null;
+  for (const issue of issues) {
+    if (!hasLineRange(issue)) continue;
+    const overlaps = issue.start_line! <= lineEnd && issue.end_line! >= lineStart;
+    if (!overlaps) continue;
+    if (!best || SEVERITY_RANK[issue.severity] > SEVERITY_RANK[best.severity]) {
+      best = issue;
+    }
+  }
+  return best;
+}
+
+function rangesOverlap(a: [number, number], b: [number, number]): boolean {
+  return a[0] <= b[1] && a[1] >= b[0];
+}
+
+const SCROLL_RETRY_MS = 50;
+const SCROLL_MAX_ATTEMPTS = 20;
+
+/** First rendered block whose source lines overlap `range`, or null while none is laid out. */
+function findBlockForRange(container: HTMLElement, range: [number, number]): HTMLElement | null {
+  const blocks = container.querySelectorAll<HTMLElement>('[data-line-start][data-line-end]');
+  for (const block of blocks) {
+    const start = Number(block.getAttribute('data-line-start'));
+    const end = Number(block.getAttribute('data-line-end'));
+    if (Number.isFinite(start) && Number.isFinite(end) && rangesOverlap([start, end], range)) {
+      return block;
+    }
+  }
+  return null;
+}
+
+/**
+ * True inside a container block (list, quote, table). Nested blocks skip the
+ * gutter so only top-level blocks are numbered, the way an editor numbers lines.
+ */
+const NestedContext = createContext(false);
+
+/**
+ * `spacing` goes on the row rather than the element so the line number stays on
+ * the first line of its block — a heading's top margin has to move both columns
+ * or the number drifts above the text it belongs to.
+ */
+function blockFactory(Tag: string, spacing: string, className: string, isContainer = false, scrollWrap = false) {
+  function Block({ node, children, ...rest }: React.HTMLAttributes<HTMLElement> & ExtraProps) {
+    const nested = useContext(NestedContext);
+    const position = (node as Element | undefined)?.position;
+    const lineStart = position?.start.line;
+    const lineEnd = position?.end.line;
+
+    const dataProps: Record<string, string | number> = {};
+    if (lineStart !== undefined) dataProps['data-line-start'] = lineStart;
+    if (lineEnd !== undefined) dataProps['data-line-end'] = lineEnd;
+
+    const isRow = !nested && lineStart !== undefined;
+    const body = isContainer ? <NestedContext.Provider value>{children}</NestedContext.Provider> : children;
+    const element = React.createElement(
+      Tag,
+      {
+        ...rest,
+        ...dataProps,
+        className: cn(className, '-mx-2 rounded-sm px-2 transition-colors', !isRow && spacing, rest.className),
+      },
+      body,
+    );
+
+    const content = scrollWrap ? <div className="max-w-full overflow-x-auto">{element}</div> : element;
+
+    if (!isRow) return content;
+
+    return (
+      <div data-block-row className={cn('grid grid-cols-[3rem_minmax(0,1fr)] gap-x-2', spacing)}>
+        <div className="flex justify-end gap-2 select-none" aria-hidden>
+          <span className="pt-[0.15em] font-mono text-[10.5px] leading-[1.7] tabular-nums text-muted-foreground/60">
+            {lineStart}
+          </span>
+          <span data-rule className="w-[2px] shrink-0 rounded-full bg-transparent" />
+        </div>
+        <div className="min-w-0">{content}</div>
+      </div>
+    );
+  }
+  Block.displayName = `DocumentBlock-${Tag}`;
+  return Block;
+}
+
+const REMARK_PLUGINS: PluggableList = [remarkGfm, remarkMath];
+const REHYPE_PLUGINS: PluggableList = [rehypeMathML, [rehypeRaw, { tagfilter: true }]];
+
+const BLOCK_COMPONENTS = {
+  p: blockFactory('p', 'mb-3', 'leading-[1.7]'),
+  h1: blockFactory('h1', 'mt-6 mb-3', 'text-xl font-semibold tracking-tight'),
+  h2: blockFactory('h2', 'mt-7 mb-2', 'text-lg font-semibold tracking-tight'),
+  h3: blockFactory('h3', 'mt-5 mb-2', 'text-base font-semibold'),
+  h4: blockFactory('h4', 'mt-4 mb-2', 'text-base font-semibold'),
+  h5: blockFactory('h5', 'mt-4 mb-2', 'text-base font-medium'),
+  h6: blockFactory('h6', 'mt-4 mb-2', 'text-base font-medium'),
+  ul: blockFactory('ul', 'mb-3', 'ml-6 list-disc', true),
+  ol: blockFactory('ol', 'mb-3', 'ml-6 list-decimal', true),
+  li: blockFactory('li', 'mb-1', ''),
+  blockquote: blockFactory('blockquote', 'mb-3', 'border-l-2 border-border pl-4 text-muted-foreground', true),
+  pre: blockFactory('pre', 'mb-3', 'max-w-full overflow-x-auto rounded bg-muted px-2 py-1'),
+  table: blockFactory('table', 'mb-3', 'w-full border-collapse text-left text-[13px]', true, true),
+  thead: ({ children }: React.HTMLAttributes<HTMLElement>) => <thead className="border-b">{children}</thead>,
+  th: ({ children }: React.HTMLAttributes<HTMLElement>) => (
+    <th className="px-2 py-1.5 font-medium whitespace-nowrap">{children}</th>
+  ),
+  td: ({ children }: React.HTMLAttributes<HTMLElement>) => (
+    <td className="border-t px-2 py-1.5 align-top">{children}</td>
+  ),
+  hr: blockFactory('hr', 'my-5', ''),
+  // DOCX extraction leaves images with no src behind; rendering them as <img>
+  // makes the browser refetch the page, so show the alt text instead.
+  img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) =>
+    typeof src === 'string' && src.length > 0 ? (
+      // eslint-disable-next-line @next/next/no-img-element -- document content, not app chrome
+      <img src={src} alt={alt ?? ''} className="my-2 max-w-full rounded" />
+    ) : (
+      <span className="my-1 inline-flex items-center gap-1.5 rounded border border-dashed px-2 py-1 text-xs text-muted-foreground">
+        <ImageOff className="size-3" />
+        {alt || 'Image not extracted'}
+      </span>
+    ),
+};
+
+export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssueSelect, header }: DocumentViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Retried on a timer rather than via requestAnimationFrame: rAF never fires while
+   * the tab is hidden, and the document can still be laying out when a line jump
+   * arrives from another tab's route. Scrolls the container itself rather than
+   * block.scrollIntoView(), which would also scroll ancestors.
+   */
+  const scrollToRange = (range: [number, number], align: 'center' | 'start') => {
+    let attempts = 0;
+    const attempt = () => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const block = findBlockForRange(container, range);
+      if (!block || container.clientHeight === 0) {
+        if (attempts++ < SCROLL_MAX_ATTEMPTS) setTimeout(attempt, SCROLL_RETRY_MS);
+        return;
+      }
+
+      // `container` is positioned, so offsetTop is already relative to it.
+      const top =
+        align === 'center'
+          ? block.offsetTop - container.clientHeight / 2 + block.offsetHeight / 2
+          : block.offsetTop - 12;
+      container.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+    };
+    attempt();
+  };
+
+  useImperativeHandle(ref, () => ({
+    scrollToLineRange: (range: [number, number]) => scrollToRange(range, 'center'),
+    scrollToLine: (line: number) => scrollToRange([line, line], 'start'),
+  }));
+
+  const lineIssues = useMemo(() => issues.filter(hasLineRange) as IssueWithLines[], [issues]);
+
+  // The parsed tree only depends on the markdown; highlights and click handlers
+  // are applied imperatively below so a filter change never reparses.
+  const renderedMarkdown = useMemo(
+    () => (
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} components={BLOCK_COMPONENTS}>
+        {markdown}
+      </ReactMarkdown>
+    ),
+    [markdown],
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const blocks = container.querySelectorAll<HTMLElement>('[data-line-start][data-line-end]');
+    const cleanups: Array<() => void> = [];
+
+    blocks.forEach((block) => {
+      const lineStart = Number(block.getAttribute('data-line-start'));
+      const lineEnd = Number(block.getAttribute('data-line-end'));
+      if (!Number.isFinite(lineStart) || !Number.isFinite(lineEnd)) return;
+
+      const rule = block.closest('[data-block-row]')?.querySelector<HTMLElement>('[data-rule]');
+
+      block.classList.remove(...CLEARED_CLASSES);
+      block.removeAttribute('data-issue-id');
+      block.removeAttribute('data-issue-selected');
+      if (rule) {
+        rule.className = 'w-[2px] shrink-0 rounded-full bg-transparent';
+      }
+
+      const issue = pickTopSeverityIssue(lineIssues, lineStart, lineEnd);
+      if (!issue) return;
+
+      const issueRange: [number, number] = [issue.start_line!, issue.end_line!];
+      const isSelected = selectedLineRange !== null && rangesOverlap(issueRange, selectedLineRange);
+
+      const wash = isSelected ? SEVERITY_WASH_SELECTED[issue.severity] : SEVERITY_WASH[issue.severity];
+      if (wash) block.classList.add(...wash.split(' '));
+      block.classList.add('cursor-pointer');
+      block.setAttribute('data-issue-id', issue.id);
+
+      if (rule) {
+        rule.className = cn('w-[2px] shrink-0 rounded-full', SEVERITY_RULE[issue.severity]);
+      }
+
+      if (selectedLineRange) {
+        block.setAttribute('data-issue-selected', String(isSelected));
+        if (isSelected) {
+          block.classList.add('ring-1', 'ring-inset', 'ring-foreground/15');
+        } else {
+          block.classList.add('opacity-50');
+          if (rule) rule.classList.add('opacity-50');
+        }
+      }
+
+      const handler = (event: Event) => {
+        event.stopPropagation();
+        onIssueSelect(isSelected ? null : issue);
+      };
+      block.addEventListener('click', handler);
+      cleanups.push(() => block.removeEventListener('click', handler));
+    });
+
+    return () => {
+      for (const cleanup of cleanups) cleanup();
+    };
+  }, [markdown, lineIssues, selectedLineRange, onIssueSelect]);
+
+  return (
+    <div ref={containerRef} className="relative h-full overflow-x-hidden overflow-y-auto px-5 py-5 text-sm break-words">
+      {header && <div className="mb-4">{header}</div>}
+      <div className="mx-auto max-w-[78ch]">{renderedMarkdown}</div>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/document-explorer/document-view.tsx
+++ b/frontend/components/results-v2/document-explorer/document-view.tsx
@@ -168,7 +168,10 @@ function blockFactory(Tag: string, spacing: string, className: string, isContain
       {
         ...rest,
         ...dataProps,
-        className: cn(className, '-mx-2 rounded-sm px-2 transition-colors', !isRow && spacing, rest.className),
+        // The shared classes come first so a block's own padding wins: tailwind-merge
+        // drops the earlier of two conflicting utilities, which was silently
+        // removing the lists' indent and leaving their markers over the gutter.
+        className: cn('-mx-2 rounded-sm px-2 transition-colors', className, !isRow && spacing, rest.className),
       },
       body,
     );
@@ -212,7 +215,7 @@ function blockFactory(Tag: string, spacing: string, className: string, isContain
   return Block;
 }
 
-const REMARK_PLUGINS: PluggableList = [remarkGfm, remarkMath];
+const REMARK_PLUGINS: PluggableList = [remarkGfm, [remarkMath, { singleDollarTextMath: false }]];
 const REHYPE_PLUGINS: PluggableList = [rehypeMathML, [rehypeRaw, { tagfilter: true }]];
 
 const BLOCK_COMPONENTS = {
@@ -223,9 +226,9 @@ const BLOCK_COMPONENTS = {
   h4: blockFactory('h4', 'mt-4 mb-2', 'text-base font-semibold'),
   h5: blockFactory('h5', 'mt-4 mb-2', 'text-base font-medium'),
   h6: blockFactory('h6', 'mt-4 mb-2', 'text-base font-medium'),
-  ul: blockFactory('ul', 'mb-3', 'ml-6 list-disc', true),
-  ol: blockFactory('ol', 'mb-3', 'ml-6 list-decimal', true),
-  li: blockFactory('li', 'mb-1', ''),
+  ul: blockFactory('ul', 'mb-3', 'list-disc pl-8', true),
+  ol: blockFactory('ol', 'mb-3', 'list-decimal pl-8', true),
+  li: blockFactory('li', 'mb-1', 'leading-[1.7]'),
   blockquote: blockFactory('blockquote', 'mb-3', 'border-l-2 border-border pl-4 text-muted-foreground', true),
   pre: blockFactory('pre', 'mb-3', 'max-w-full overflow-x-auto rounded bg-muted px-2 py-1'),
   table: blockFactory('table', 'mb-3', 'w-full border-collapse text-left text-[13px]', true, true),
@@ -377,7 +380,15 @@ export function DocumentView({
   const marginState: MarginState | null = margin ? { issues: lineIssues, ...margin } : null;
 
   return (
-    <div ref={containerRef} className="relative h-full overflow-x-hidden overflow-y-auto px-5 py-5 text-sm break-words">
+    <div
+      ref={containerRef}
+      className={cn(
+        'relative h-full overflow-x-hidden overflow-y-auto px-5 py-5 text-sm break-words',
+        // MathML does not wrap, so give it its own scroll rather than letting it
+        // run past the text column.
+        '[&_math]:inline-block [&_math]:max-w-full [&_math]:overflow-x-auto [&_math]:align-middle',
+      )}
+    >
       {header && <div className="mb-4">{header}</div>}
       <MarginContext.Provider value={marginState}>
         <div className={cn('mx-auto', WIDTH_BASE, marginState && WIDTH_WITH_MARGIN)}>{renderedMarkdown}</div>

--- a/frontend/components/results-v2/document-explorer/document-view.tsx
+++ b/frontend/components/results-v2/document-explorer/document-view.tsx
@@ -33,8 +33,6 @@ interface DocumentViewProps {
   issues: Issue[];
   selectedLineRange: [number, number] | null;
   onIssueSelect: (issue: Issue | null) => void;
-  /** Optional content rendered inside the scroll area, above the document. */
-  header?: React.ReactNode;
   /**
    * When set, issues are rendered in a margin column beside the paragraph they
    * belong to, sharing this pane's scroll. Omit for a plain document.
@@ -254,15 +252,7 @@ const BLOCK_COMPONENTS = {
     ),
 };
 
-export function DocumentView({
-  ref,
-  markdown,
-  issues,
-  selectedLineRange,
-  onIssueSelect,
-  header,
-  margin,
-}: DocumentViewProps) {
+export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssueSelect, margin }: DocumentViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   /**
@@ -389,7 +379,6 @@ export function DocumentView({
         '[&_math]:inline-block [&_math]:max-w-full [&_math]:overflow-x-auto [&_math]:align-middle',
       )}
     >
-      {header && <div className="mb-4">{header}</div>}
       <MarginContext.Provider value={marginState}>
         <div className={cn('mx-auto', WIDTH_BASE, marginState && WIDTH_WITH_MARGIN)}>{renderedMarkdown}</div>
       </MarginContext.Provider>

--- a/frontend/components/results-v2/document-explorer/document-view.tsx
+++ b/frontend/components/results-v2/document-explorer/document-view.tsx
@@ -5,6 +5,8 @@ import { SeverityEnum } from '@/lib/generated-api';
 import { cn } from '@/lib/utils';
 import type { Element } from 'hast';
 import { ImageOff } from 'lucide-react';
+import { SEVERITY } from './issue-note';
+import { MarginNote } from './margin-note';
 import React, { Ref, createContext, useContext, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import ReactMarkdown, { type ExtraProps } from 'react-markdown';
 import rehypeMathML from '@daiji256/rehype-mathml';
@@ -20,7 +22,9 @@ interface IssueWithLines extends Issue {
 
 export interface DocumentViewHandle {
   scrollToLineRange: (range: [number, number]) => void;
-  scrollToLine: (line: number) => void;
+  scrollToLine: (line: number, behavior?: ScrollBehavior) => void;
+  /** Source line of the block currently at the top of the pane. */
+  getTopVisibleLine: () => number | null;
 }
 
 interface DocumentViewProps {
@@ -31,31 +35,12 @@ interface DocumentViewProps {
   onIssueSelect: (issue: Issue | null) => void;
   /** Optional content rendered inside the scroll area, above the document. */
   header?: React.ReactNode;
+  /**
+   * When set, issues are rendered in a margin column beside the paragraph they
+   * belong to, sharing this pane's scroll. Omit for a plain document.
+   */
+  margin?: { activeIssueId: string | null; readOnly: boolean; onSelect: (issue: Issue) => void };
 }
-
-/** Gutter rule colour, one per severity. Same families the issue cards use. */
-const SEVERITY_RULE: Record<string, string> = {
-  [SeverityEnum.High]: 'bg-red-500',
-  [SeverityEnum.Medium]: 'bg-amber-500',
-  [SeverityEnum.Low]: 'bg-blue-500',
-  [SeverityEnum.None]: 'bg-green-500',
-};
-
-/** Resting wash on a flagged block — quiet enough to read through. */
-const SEVERITY_WASH: Record<string, string> = {
-  [SeverityEnum.High]: 'bg-red-50/70 dark:bg-red-950/20',
-  [SeverityEnum.Medium]: 'bg-amber-50/70 dark:bg-amber-950/20',
-  [SeverityEnum.Low]: 'bg-blue-50/70 dark:bg-blue-950/20',
-  [SeverityEnum.None]: 'bg-green-50/70 dark:bg-green-950/20',
-};
-
-/** Wash once the block is the selected one. */
-const SEVERITY_WASH_SELECTED: Record<string, string> = {
-  [SeverityEnum.High]: 'bg-red-100 dark:bg-red-950/50',
-  [SeverityEnum.Medium]: 'bg-amber-100 dark:bg-amber-950/50',
-  [SeverityEnum.Low]: 'bg-blue-100 dark:bg-blue-950/50',
-  [SeverityEnum.None]: 'bg-green-100 dark:bg-green-950/50',
-};
 
 const SEVERITY_RANK: Record<string, number> = {
   [SeverityEnum.None]: 0,
@@ -64,15 +49,13 @@ const SEVERITY_RANK: Record<string, number> = {
   [SeverityEnum.High]: 3,
 };
 
+/** Resting mark on flagged text, as in the mock: the mark is on the text, not behind it. */
+const FLAGGED_CLASSES = ['underline', 'decoration-dotted', 'underline-offset-4', 'decoration-muted-foreground/50'];
+
 const CLEARED_CLASSES = [
-  ...new Set(
-    [...Object.values(SEVERITY_WASH), ...Object.values(SEVERITY_WASH_SELECTED)].flatMap((cls) => cls.split(' ')),
-  ),
+  ...new Set(Object.values(SEVERITY).flatMap((style) => style.wash.split(' '))),
+  ...FLAGGED_CLASSES,
   'cursor-pointer',
-  'opacity-50',
-  'ring-1',
-  'ring-inset',
-  'ring-foreground/15',
 ];
 
 function hasLineRange(issue: Issue): issue is IssueWithLines & { start_line: number; end_line: number } {
@@ -115,10 +98,52 @@ function findBlockForRange(container: HTMLElement, range: [number, number]): HTM
 }
 
 /**
+ * Both modes must give the text column the same width, or switching between them
+ * rewraps the document and the reader's place in it moves.
+ *
+ * The trick is to keep the non-text overhead identical: in margin mode that is
+ * the gutter plus the margin column, and in list mode it is the gutter plus the
+ * issues aside, which sits outside this pane. The extra pixel matches the
+ * aside's left border. Below `xl` the margin column is not rendered and the
+ * aside takes over, so two columns are the base and the third arrives at `xl`.
+ *
+ * Written out in full because Tailwind reads class names as literal strings.
+ */
+const GRID_BASE = 'grid-cols-[3rem_minmax(0,46rem)]';
+const GRID_WITH_MARGIN = 'xl:grid-cols-[3rem_minmax(0,46rem)_calc(26rem_+_1px)]';
+const WIDTH_BASE = 'max-w-[calc(3rem_+_46rem)]';
+const WIDTH_WITH_MARGIN = 'xl:max-w-[calc(3rem_+_46rem_+_26rem_+_1px)]';
+
+/**
  * True inside a container block (list, quote, table). Nested blocks skip the
  * gutter so only top-level blocks are numbered, the way an editor numbers lines.
  */
 const NestedContext = createContext(false);
+
+interface MarginState {
+  issues: IssueWithLines[];
+  activeIssueId: string | null;
+  readOnly: boolean;
+  onSelect: (issue: Issue) => void;
+}
+
+const MarginContext = createContext<MarginState | null>(null);
+
+/**
+ * Notes for one row: the issues that *begin* inside it. An issue can span several
+ * blocks, so anchoring on its first line keeps each note in exactly one place —
+ * and keeps this pure, which claiming into a shared set was not: React invokes a
+ * component's render more than once, and the second pass would find its own
+ * issues already taken.
+ */
+function useRowNotes(lineStart: number | undefined, lineEnd: number | undefined) {
+  const margin = useContext(MarginContext);
+  if (!margin || lineStart === undefined || lineEnd === undefined) return null;
+
+  const notes = margin.issues.filter((issue) => issue.start_line! >= lineStart && issue.start_line! <= lineEnd);
+
+  return { notes, margin };
+}
 
 /**
  * `spacing` goes on the row rather than the element so the line number stays on
@@ -149,18 +174,37 @@ function blockFactory(Tag: string, spacing: string, className: string, isContain
     );
 
     const content = scrollWrap ? <div className="max-w-full overflow-x-auto">{element}</div> : element;
+    const row = useRowNotes(isRow ? lineStart : undefined, isRow ? lineEnd : undefined);
 
     if (!isRow) return content;
 
     return (
-      <div data-block-row className={cn('grid grid-cols-[3rem_minmax(0,1fr)] gap-x-2', spacing)}>
-        <div className="flex justify-end gap-2 select-none" aria-hidden>
-          <span className="pt-[0.15em] font-mono text-[10.5px] leading-[1.7] tabular-nums text-muted-foreground/60">
+      <div data-block-row className={cn('grid', spacing, GRID_BASE, row && GRID_WITH_MARGIN)}>
+        {/* The rule sits beside the text rather than in the gutter cell so it
+            measures the paragraph, not the row — a row can be tall because its
+            margin holds several notes. */}
+        <div className="justify-end pt-[0.15em] pr-2 text-right select-none" aria-hidden>
+          <span className="font-mono text-[10.5px] leading-[1.7] tabular-nums text-muted-foreground/60">
             {lineStart}
           </span>
-          <span data-rule className="w-[2px] shrink-0 rounded-full bg-transparent" />
         </div>
-        <div className="min-w-0">{content}</div>
+        <div className="flex min-w-0 gap-2 self-start">
+          <span data-rule className="w-[2px] shrink-0 rounded-full bg-transparent" />
+          <div className="min-w-0 flex-1">{content}</div>
+        </div>
+        {row && (
+          <div className="col-start-3 hidden self-start pl-4 xl:block">
+            {row.notes.map((issue) => (
+              <MarginNote
+                key={issue.id}
+                issue={issue}
+                active={row.margin.activeIssueId === issue.id}
+                readOnly={row.margin.readOnly}
+                onSelect={row.margin.onSelect}
+              />
+            ))}
+          </div>
+        )}
       </div>
     );
   }
@@ -207,7 +251,15 @@ const BLOCK_COMPONENTS = {
     ),
 };
 
-export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssueSelect, header }: DocumentViewProps) {
+export function DocumentView({
+  ref,
+  markdown,
+  issues,
+  selectedLineRange,
+  onIssueSelect,
+  header,
+  margin,
+}: DocumentViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   /**
@@ -216,7 +268,7 @@ export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssue
    * arrives from another tab's route. Scrolls the container itself rather than
    * block.scrollIntoView(), which would also scroll ancestors.
    */
-  const scrollToRange = (range: [number, number], align: 'center' | 'start') => {
+  const scrollToRange = (range: [number, number], align: 'center' | 'start', behavior: ScrollBehavior = 'smooth') => {
     let attempts = 0;
     const attempt = () => {
       const container = containerRef.current;
@@ -233,14 +285,26 @@ export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssue
         align === 'center'
           ? block.offsetTop - container.clientHeight / 2 + block.offsetHeight / 2
           : block.offsetTop - 12;
-      container.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+      container.scrollTo({ top: Math.max(0, top), behavior });
     };
     attempt();
   };
 
   useImperativeHandle(ref, () => ({
     scrollToLineRange: (range: [number, number]) => scrollToRange(range, 'center'),
-    scrollToLine: (line: number) => scrollToRange([line, line], 'start'),
+    scrollToLine: (line: number, behavior: ScrollBehavior = 'smooth') => scrollToRange([line, line], 'start', behavior),
+    getTopVisibleLine: () => {
+      const container = containerRef.current;
+      if (!container) return null;
+      const blocks = container.querySelectorAll<HTMLElement>('[data-line-start]');
+      for (const block of blocks) {
+        if (block.offsetTop + block.offsetHeight > container.scrollTop) {
+          const line = Number(block.getAttribute('data-line-start'));
+          return Number.isFinite(line) ? line : null;
+        }
+      }
+      return null;
+    },
   }));
 
   const lineIssues = useMemo(() => issues.filter(hasLineRange) as IssueWithLines[], [issues]);
@@ -280,26 +344,21 @@ export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssue
       const issue = pickTopSeverityIssue(lineIssues, lineStart, lineEnd);
       if (!issue) return;
 
-      const issueRange: [number, number] = [issue.start_line!, issue.end_line!];
-      const isSelected = selectedLineRange !== null && rangesOverlap(issueRange, selectedLineRange);
+      // Selected means this block is inside the selected lines — not merely that
+      // it carries an issue overlapping them. Otherwise a heading whose own issue
+      // spans into the selection lights up alongside the paragraph you picked.
+      const isSelected = selectedLineRange !== null && rangesOverlap([lineStart, lineEnd], selectedLineRange);
 
-      const wash = isSelected ? SEVERITY_WASH_SELECTED[issue.severity] : SEVERITY_WASH[issue.severity];
-      if (wash) block.classList.add(...wash.split(' '));
-      block.classList.add('cursor-pointer');
+      block.classList.add('cursor-pointer', ...FLAGGED_CLASSES);
       block.setAttribute('data-issue-id', issue.id);
+      block.setAttribute('data-issue-selected', String(isSelected));
 
-      if (rule) {
-        rule.className = cn('w-[2px] shrink-0 rounded-full', SEVERITY_RULE[issue.severity]);
+      if (isSelected) {
+        block.classList.add(...SEVERITY[issue.severity].wash.split(' '));
       }
 
-      if (selectedLineRange) {
-        block.setAttribute('data-issue-selected', String(isSelected));
-        if (isSelected) {
-          block.classList.add('ring-1', 'ring-inset', 'ring-foreground/15');
-        } else {
-          block.classList.add('opacity-50');
-          if (rule) rule.classList.add('opacity-50');
-        }
+      if (rule) {
+        rule.className = cn('w-[2px] shrink-0 rounded-full', SEVERITY[issue.severity].dot);
       }
 
       const handler = (event: Event) => {
@@ -315,10 +374,14 @@ export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssue
     };
   }, [markdown, lineIssues, selectedLineRange, onIssueSelect]);
 
+  const marginState: MarginState | null = margin ? { issues: lineIssues, ...margin } : null;
+
   return (
     <div ref={containerRef} className="relative h-full overflow-x-hidden overflow-y-auto px-5 py-5 text-sm break-words">
       {header && <div className="mb-4">{header}</div>}
-      <div className="mx-auto max-w-[78ch]">{renderedMarkdown}</div>
+      <MarginContext.Provider value={marginState}>
+        <div className={cn('mx-auto', WIDTH_BASE, marginState && WIDTH_WITH_MARGIN)}>{renderedMarkdown}</div>
+      </MarginContext.Provider>
     </div>
   );
 }

--- a/frontend/components/results-v2/document-explorer/document-view.tsx
+++ b/frontend/components/results-v2/document-explorer/document-view.tsx
@@ -161,6 +161,9 @@ function blockFactory(Tag: string, spacing: string, className: string, isContain
     if (lineEnd !== undefined) dataProps['data-line-end'] = lineEnd;
 
     const isRow = !nested && lineStart !== undefined;
+    // The gutter rule belongs to the row, and a row is shared with every block
+    // nested inside it. Marking its owner keeps the others from writing to it.
+    if (isRow) dataProps['data-block-owner'] = '';
     const body = isContainer ? <NestedContext.Provider value>{children}</NestedContext.Provider> : children;
     const element = React.createElement(
       Tag,
@@ -330,7 +333,12 @@ export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssue
       const lineEnd = Number(block.getAttribute('data-line-end'));
       if (!Number.isFinite(lineStart) || !Number.isFinite(lineEnd)) return;
 
-      const rule = block.closest('[data-block-row]')?.querySelector<HTMLElement>('[data-rule]');
+      // Only the row's own block. A list and each of its items resolve to the
+      // same row, so letting nested blocks write here meant the last item
+      // decided: an issue on the first bullet was cleared by the four below it.
+      const rule = block.hasAttribute('data-block-owner')
+        ? block.closest('[data-block-row]')?.querySelector<HTMLElement>('[data-rule]')
+        : null;
 
       block.classList.remove(...CLEARED_CLASSES);
       block.removeAttribute('data-issue-id');

--- a/frontend/components/results-v2/document-explorer/document-view.tsx
+++ b/frontend/components/results-v2/document-explorer/document-view.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 import type { Element } from 'hast';
 import { ImageOff } from 'lucide-react';
 import { SEVERITY } from '@/lib/severity-style';
+import { DocumentIssues } from './document-issues';
 import { MarginNote } from './margin-note';
 import React, { Ref, createContext, useContext, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import ReactMarkdown, { type ExtraProps } from 'react-markdown';
@@ -301,6 +302,10 @@ export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssue
   }));
 
   const lineIssues = useMemo(() => issues.filter(hasLineRange) as IssueWithLines[], [issues]);
+  // The rest: findings about the document rather than a place in it, like a
+  // missing Abbreviations section. Nothing anchors them, so the margin would
+  // drop them entirely and the header would count issues that are not on screen.
+  const documentIssues = useMemo(() => issues.filter((issue) => !hasLineRange(issue)), [issues]);
 
   // The parsed tree only depends on the markdown; highlights and click handlers
   // are applied imperatively below so a filter change never reparses.
@@ -380,7 +385,25 @@ export function DocumentView({ ref, markdown, issues, selectedLineRange, onIssue
       )}
     >
       <MarginContext.Provider value={marginState}>
-        <div className={cn('mx-auto', WIDTH_BASE, marginState && WIDTH_WITH_MARGIN)}>{renderedMarkdown}</div>
+        <div className={cn('mx-auto', WIDTH_BASE, marginState && WIDTH_WITH_MARGIN)}>
+          {marginState && documentIssues.length > 0 && (
+            <div className={cn('grid', GRID_BASE, GRID_WITH_MARGIN)}>
+              {/* Empty gutter and text cells: these notes sit above the document
+                  rather than beside any part of it. */}
+              <div aria-hidden />
+              <div aria-hidden />
+              <div className="col-start-3 hidden self-start pb-4 pl-4 xl:block">
+                <DocumentIssues
+                  issues={documentIssues}
+                  activeIssueId={marginState.activeIssueId}
+                  readOnly={marginState.readOnly}
+                  onSelect={marginState.onSelect}
+                />
+              </div>
+            </div>
+          )}
+          {renderedMarkdown}
+        </div>
       </MarginContext.Provider>
     </div>
   );

--- a/frontend/components/results-v2/document-explorer/issue-note.tsx
+++ b/frontend/components/results-v2/document-explorer/issue-note.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { Markdown } from '@/components/markdown';
+import { IssueFeedbackButtons } from '@/components/results/components/document-issue-card';
+import { Button } from '@/components/ui/button';
+import { Issue, SeverityEnum } from '@/lib/generated-api';
+import { useIssueActions } from '@/lib/hooks/use-issue-actions';
+import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { isIssueResolved } from '@/lib/stores/document-explorer-store';
+import { cn } from '@/lib/utils';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon, LightbulbIcon, UndoIcon } from 'lucide-react';
+import { useState } from 'react';
+
+export interface SeverityStyle {
+  /** Severity marker: the dot beside a note and the rule in the document gutter. */
+  dot: string;
+  /** Border of an open note. */
+  edge: string;
+  /** Fill for the selected block and the open note. */
+  wash: string;
+  label: string;
+  text: string;
+}
+
+/**
+ * The one severity palette. The document, the margin and the list all read from
+ * here so a colour cannot drift between where an issue is marked and where it is
+ * read.
+ */
+export const SEVERITY: Record<SeverityEnum, SeverityStyle> = {
+  [SeverityEnum.High]: {
+    dot: 'bg-red-500',
+    edge: 'border-red-400 dark:border-red-700',
+    wash: 'bg-red-50 dark:bg-red-950/30',
+    label: 'High',
+    text: 'text-red-700 dark:text-red-300',
+  },
+  [SeverityEnum.Medium]: {
+    dot: 'bg-amber-500',
+    edge: 'border-amber-400 dark:border-amber-700',
+    wash: 'bg-amber-50 dark:bg-amber-950/30',
+    label: 'Medium',
+    text: 'text-amber-800 dark:text-amber-300',
+  },
+  [SeverityEnum.Low]: {
+    dot: 'bg-blue-500',
+    edge: 'border-blue-400 dark:border-blue-700',
+    wash: 'bg-blue-50 dark:bg-blue-950/30',
+    label: 'Low',
+    text: 'text-blue-700 dark:text-blue-300',
+  },
+  [SeverityEnum.None]: {
+    dot: 'bg-green-500',
+    edge: 'border-green-400 dark:border-green-700',
+    wash: 'bg-green-50 dark:bg-green-950/30',
+    label: 'Passing',
+    text: 'text-green-700 dark:text-green-300',
+  },
+};
+
+export function lineLabel(issue: Issue): string | null {
+  const { start_line: start, end_line: end } = issue as Issue & {
+    start_line?: number | null;
+    end_line?: number | null;
+  };
+  if (typeof start !== 'number' || typeof end !== 'number') return null;
+  return start === end ? `L${start}` : `L${start}–${end}`;
+}
+
+/** The line above an issue's title: where it came from and where it lands. */
+export function IssueMeta({ issue, showDot = true }: { issue: Issue; showDot?: boolean }) {
+  const { getWorkflowTypeName } = useWorkflowTypes();
+  const resolved = isIssueResolved(issue);
+  const line = lineLabel(issue);
+
+  return (
+    <span className="flex items-center gap-1.5">
+      {showDot && <span className={cn('block size-1.5 shrink-0 rounded-full', SEVERITY[issue.severity].dot)} />}
+      <span className="truncate font-mono text-[10px] tracking-wide text-muted-foreground uppercase">
+        {getWorkflowTypeName(issue.workflow_type)}
+      </span>
+      {resolved && (
+        <span className="inline-flex shrink-0 items-center gap-0.5 font-mono text-[10px] text-muted-foreground uppercase">
+          <CheckIcon className="size-3" />
+          Resolved
+        </span>
+      )}
+      {line && (
+        <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">{line}</span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Everything an open issue shows below its title — description, suggested
+ * action, details, and the actions that change it. Shared so the margin note and
+ * the list row cannot drift apart.
+ */
+export function IssueBody({ issue, readOnly }: { issue: Issue; readOnly: boolean }) {
+  const { resolveIssue, unresolveIssue, isResolving, isUnresolving } = useIssueActions();
+  const [showDetails, setShowDetails] = useState(false);
+
+  const resolved = isIssueResolved(issue);
+  const busy = isResolving || isUnresolving;
+
+  return (
+    <div className="space-y-2">
+      <div className="text-foreground/80 text-xs leading-relaxed [&_p]:mb-1 [&_p:last-child]:mb-0">
+        <Markdown>{issue.description}</Markdown>
+      </div>
+
+      {issue.suggested_action && (
+        <div className="bg-background/60 rounded border border-dashed px-2 py-1.5">
+          <p className="mb-1 flex items-center gap-1 font-mono text-[9.5px] tracking-wide text-muted-foreground uppercase">
+            <LightbulbIcon className="size-3" />
+            Suggested action
+          </p>
+          <div className="text-xs leading-relaxed [&_p]:mb-1 [&_p:last-child]:mb-0">
+            <Markdown>{issue.suggested_action}</Markdown>
+          </div>
+        </div>
+      )}
+
+      {issue.long_description && (
+        <>
+          <button
+            onClick={(event) => {
+              event.stopPropagation();
+              setShowDetails(!showDetails);
+            }}
+            aria-expanded={showDetails}
+            className="flex cursor-pointer items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+          >
+            {showDetails ? <ChevronUpIcon className="size-3" /> : <ChevronDownIcon className="size-3" />}
+            {showDetails ? 'Hide details' : 'Show details'}
+          </button>
+          {showDetails && (
+            <div className="text-foreground/80 text-xs leading-relaxed [&_p]:mb-1 [&_p:last-child]:mb-0">
+              <Markdown>{issue.long_description}</Markdown>
+            </div>
+          )}
+        </>
+      )}
+
+      {!readOnly && issue.id && (
+        <div className="flex items-center gap-1.5 pt-0.5" onClick={(event) => event.stopPropagation()}>
+          <Button
+            size="sm"
+            variant={resolved ? 'outline' : 'default'}
+            className="h-6 px-2 text-[11px]"
+            disabled={busy}
+            onClick={() => (resolved ? unresolveIssue(issue.id) : resolveIssue(issue.id))}
+          >
+            {resolved ? <UndoIcon className="size-3" /> : <CheckIcon className="size-3" />}
+            {resolved ? 'Mark unresolved' : 'Mark resolved'}
+          </Button>
+          <span className="ml-auto">
+            <IssueFeedbackButtons issueId={issue.id} />
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/results-v2/document-explorer/issue-note.tsx
+++ b/frontend/components/results-v2/document-explorer/issue-note.tsx
@@ -21,6 +21,34 @@ export function lineLabel(issue: Issue): string | null {
   return start === end ? `L${start}` : `L${start}–${end}`;
 }
 
+/**
+ * The description as one line of plain prose, for a note that is closed.
+ *
+ * Descriptions are markdown, and a preview cannot render it: block elements
+ * would break the single line, and the raw source would show its own asterisks
+ * and brackets. So the markup is flattened to the text it stands for, and the
+ * line is cut by CSS rather than by counting characters, which keeps the cut at
+ * the edge of whatever width the note happens to have.
+ */
+function previewText(description: string): string {
+  return description
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
+    .replace(/^\s*(?:[#>]+|[-+*]|\d+\.)\s*/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** One line of the description, shown under the title while the note is closed. */
+export function IssuePreview({ issue }: { issue: Issue }) {
+  const text = previewText(issue.description ?? '');
+  if (!text) return null;
+
+  return <span className="mt-0.5 block truncate text-[12px] leading-snug text-muted-foreground">{text}</span>;
+}
+
 /** The line above an issue's title: its severity, where it came from, where it lands. */
 export function IssueMeta({ issue }: { issue: Issue }) {
   const { getWorkflowTypeName } = useWorkflowTypes();

--- a/frontend/components/results-v2/document-explorer/issue-note.tsx
+++ b/frontend/components/results-v2/document-explorer/issue-note.tsx
@@ -3,60 +3,14 @@
 import { Markdown } from '@/components/markdown';
 import { IssueFeedbackButtons } from '@/components/results/components/document-issue-card';
 import { Button } from '@/components/ui/button';
-import { Issue, SeverityEnum } from '@/lib/generated-api';
+import { Issue } from '@/lib/generated-api';
 import { useIssueActions } from '@/lib/hooks/use-issue-actions';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { SEVERITY } from '@/lib/severity-style';
 import { isIssueResolved } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon, LightbulbIcon, UndoIcon } from 'lucide-react';
 import { useState } from 'react';
-
-export interface SeverityStyle {
-  /** Severity marker: the dot beside a note and the rule in the document gutter. */
-  dot: string;
-  /** Border of an open note. */
-  edge: string;
-  /** Fill for the selected block and the open note. */
-  wash: string;
-  label: string;
-  text: string;
-}
-
-/**
- * The one severity palette. The document, the margin and the list all read from
- * here so a colour cannot drift between where an issue is marked and where it is
- * read.
- */
-export const SEVERITY: Record<SeverityEnum, SeverityStyle> = {
-  [SeverityEnum.High]: {
-    dot: 'bg-red-500',
-    edge: 'border-red-400 dark:border-red-700',
-    wash: 'bg-red-50 dark:bg-red-950/30',
-    label: 'High',
-    text: 'text-red-700 dark:text-red-300',
-  },
-  [SeverityEnum.Medium]: {
-    dot: 'bg-amber-500',
-    edge: 'border-amber-400 dark:border-amber-700',
-    wash: 'bg-amber-50 dark:bg-amber-950/30',
-    label: 'Medium',
-    text: 'text-amber-800 dark:text-amber-300',
-  },
-  [SeverityEnum.Low]: {
-    dot: 'bg-blue-500',
-    edge: 'border-blue-400 dark:border-blue-700',
-    wash: 'bg-blue-50 dark:bg-blue-950/30',
-    label: 'Low',
-    text: 'text-blue-700 dark:text-blue-300',
-  },
-  [SeverityEnum.None]: {
-    dot: 'bg-green-500',
-    edge: 'border-green-400 dark:border-green-700',
-    wash: 'bg-green-50 dark:bg-green-950/30',
-    label: 'Passing',
-    text: 'text-green-700 dark:text-green-300',
-  },
-};
 
 export function lineLabel(issue: Issue): string | null {
   const { start_line: start, end_line: end } = issue as Issue & {

--- a/frontend/components/results-v2/document-explorer/issue-note.tsx
+++ b/frontend/components/results-v2/document-explorer/issue-note.tsx
@@ -67,15 +67,15 @@ export function lineLabel(issue: Issue): string | null {
   return start === end ? `L${start}` : `L${start}–${end}`;
 }
 
-/** The line above an issue's title: where it came from and where it lands. */
-export function IssueMeta({ issue, showDot = true }: { issue: Issue; showDot?: boolean }) {
+/** The line above an issue's title: its severity, where it came from, where it lands. */
+export function IssueMeta({ issue }: { issue: Issue }) {
   const { getWorkflowTypeName } = useWorkflowTypes();
   const resolved = isIssueResolved(issue);
   const line = lineLabel(issue);
 
   return (
     <span className="flex items-center gap-1.5">
-      {showDot && <span className={cn('block size-1.5 shrink-0 rounded-full', SEVERITY[issue.severity].dot)} />}
+      <span className={cn('block size-1.5 shrink-0 rounded-full', SEVERITY[issue.severity].dot)} />
       <span className="truncate font-mono text-[10px] tracking-wide text-muted-foreground uppercase">
         {getWorkflowTypeName(issue.workflow_type)}
       </span>

--- a/frontend/components/results-v2/document-explorer/issues-column.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-column.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { IssuesList, IssuesListHandle } from './issues-list';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Issue } from '@/lib/generated-api';
 import { getIssueCount, hasActiveFilters, useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
-import { Loader2, X } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { Ref, useImperativeHandle, useRef, useState } from 'react';
+import { IssuesList, IssuesListHandle } from './issues-list';
 
 export interface IssuesColumnHandle {
   scrollToIssue: (issue: Issue) => void;
@@ -14,27 +14,33 @@ export interface IssuesColumnHandle {
 
 interface IssuesColumnProps {
   ref?: Ref<IssuesColumnHandle>;
+  /** Issues after the passing/resolved toggles, before severity and type. */
   visibleIssues: Issue[];
-  filteredIssues: Issue[];
+  /** Issues after every filter — what the list shows. */
+  issues: Issue[];
   /** The issue whose row is expanded. */
   activeIssueId: string | null;
   isAnyProcessing: boolean;
   readOnly: boolean;
   onSelectIssue: (issue: Issue) => void;
-  onClearSelection: () => void;
 }
 
+/**
+ * The whole issue queue, always. Selecting an issue or a paragraph opens and
+ * scrolls to its row rather than narrowing the list to it: the margin already
+ * answers "what is on this paragraph", so filtering here only cost the reader
+ * their sense of what else the document holds.
+ */
 export function IssuesColumn({
   ref,
   visibleIssues,
-  filteredIssues,
+  issues,
   activeIssueId,
   isAnyProcessing,
   readOnly,
   onSelectIssue,
-  onClearSelection,
 }: IssuesColumnProps) {
-  const { selectedLineRange, filter, clearFilters } = useDocumentExplorerStore();
+  const { filter, clearFilters } = useDocumentExplorerStore();
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
   const listRef = useRef<IssuesListHandle>(null);
 
@@ -45,13 +51,7 @@ export function IssuesColumn({
   }));
 
   const visibleCount = getIssueCount(visibleIssues);
-  const filteredCount = getIssueCount(filteredIssues);
-
-  const selectionLabel = selectedLineRange
-    ? selectedLineRange[0] === selectedLineRange[1]
-      ? `Line ${selectedLineRange[0]}`
-      : `Lines ${selectedLineRange[0]}–${selectedLineRange[1]}`
-    : null;
+  const shownCount = getIssueCount(issues);
 
   return (
     <div className="flex h-full flex-col">
@@ -71,17 +71,10 @@ export function IssuesColumn({
             </Tooltip>
           )}
           {visibleCount > 0 &&
-            (filteredCount === visibleCount ? `${visibleCount} issues` : `${filteredCount} of ${visibleCount} issues`)}
+            (shownCount === visibleCount ? `${visibleCount} issues` : `${shownCount} of ${visibleCount} issues`)}
           {visibleCount === 0 && isAnyProcessing && 'Finding issues...'}
           {visibleCount === 0 && !isAnyProcessing && 'No issues'}
         </span>
-
-        {selectionLabel && (
-          <Button variant="outline" size="sm" className="ml-auto h-6 gap-1 px-2 text-xs" onClick={onClearSelection}>
-            {selectionLabel}
-            <X />
-          </Button>
-        )}
       </div>
 
       <div ref={setScrollContainer} className="min-h-0 flex-1 overflow-y-auto">
@@ -89,10 +82,10 @@ export function IssuesColumn({
           <p className="p-4 text-sm text-muted-foreground">No issues found for this document.</p>
         )}
 
-        {visibleIssues.length > 0 && filteredIssues.length === 0 && !isAnyProcessing && (
+        {visibleIssues.length > 0 && issues.length === 0 && !isAnyProcessing && (
           <div className="space-y-1 py-8 text-center text-sm text-muted-foreground">
-            <p>{selectedLineRange ? 'No issues on the selected lines.' : 'No issues match the current filters.'}</p>
-            {hasActiveFilters(filter) && !selectedLineRange && (
+            <p>No issues match the current filters.</p>
+            {hasActiveFilters(filter) && (
               <Button variant="link" size="sm" className="text-xs" onClick={clearFilters}>
                 Clear filters
               </Button>
@@ -102,7 +95,7 @@ export function IssuesColumn({
 
         <IssuesList
           ref={listRef}
-          issues={filteredIssues}
+          issues={issues}
           scrollElement={scrollContainer}
           activeIssueId={activeIssueId}
           onSelect={onSelectIssue}

--- a/frontend/components/results-v2/document-explorer/issues-column.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-column.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { DocumentIssuesList, DocumentIssuesListHandle } from '@/components/results/components/document-issues-list';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Issue } from '@/lib/generated-api';
+import { getIssueCount, hasActiveFilters, useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
+import { Loader2, X } from 'lucide-react';
+import { Ref, useImperativeHandle, useRef, useState } from 'react';
+
+export interface IssuesColumnHandle {
+  scrollToIssue: (issue: Issue) => void;
+}
+
+interface IssuesColumnProps {
+  ref?: Ref<IssuesColumnHandle>;
+  visibleIssues: Issue[];
+  filteredIssues: Issue[];
+  isAnyProcessing: boolean;
+  readOnly: boolean;
+  onSelectIssue: (issue: Issue) => void;
+  onClearSelection: () => void;
+}
+
+export function IssuesColumn({
+  ref,
+  visibleIssues,
+  filteredIssues,
+  isAnyProcessing,
+  readOnly,
+  onSelectIssue,
+  onClearSelection,
+}: IssuesColumnProps) {
+  const { selectedLineRange, filter, clearFilters } = useDocumentExplorerStore();
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
+  const listRef = useRef<DocumentIssuesListHandle>(null);
+
+  useImperativeHandle(ref, () => ({
+    scrollToIssue: (issue: Issue) => {
+      requestAnimationFrame(() => listRef.current?.scrollToIssue(issue));
+    },
+  }));
+
+  const visibleCount = getIssueCount(visibleIssues);
+  const filteredCount = getIssueCount(filteredIssues);
+
+  const selectionLabel = selectedLineRange
+    ? selectedLineRange[0] === selectedLineRange[1]
+      ? `Line ${selectedLineRange[0]}`
+      : `Lines ${selectedLineRange[0]}–${selectedLineRange[1]}`
+    : null;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b px-4">
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          {isAnyProcessing && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="inline-flex size-3.5 items-center justify-center"
+                  aria-label="Some results are still loading"
+                >
+                  <Loader2 className="size-3.5 animate-spin" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Some results are still loading, see the Assessments tab for details</TooltipContent>
+            </Tooltip>
+          )}
+          {visibleCount > 0 &&
+            (filteredCount === visibleCount ? `${visibleCount} issues` : `${filteredCount} of ${visibleCount} issues`)}
+          {visibleCount === 0 && isAnyProcessing && 'Finding issues...'}
+          {visibleCount === 0 && !isAnyProcessing && 'No issues'}
+        </span>
+
+        {selectionLabel && (
+          <Button variant="outline" size="sm" className="ml-auto h-6 gap-1 px-2 text-xs" onClick={onClearSelection}>
+            {selectionLabel}
+            <X />
+          </Button>
+        )}
+      </div>
+
+      <div ref={setScrollContainer} className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+        {visibleIssues.length === 0 && !isAnyProcessing && (
+          <p className="py-4 text-sm text-muted-foreground">No issues found for this document.</p>
+        )}
+
+        {visibleIssues.length > 0 && filteredIssues.length === 0 && !isAnyProcessing && (
+          <div className="space-y-1 py-8 text-center text-sm text-muted-foreground">
+            <p>{selectedLineRange ? 'No issues on the selected lines.' : 'No issues match the current filters.'}</p>
+            {hasActiveFilters(filter) && !selectedLineRange && (
+              <Button variant="link" size="sm" className="text-xs" onClick={clearFilters}>
+                Clear filters
+              </Button>
+            )}
+          </div>
+        )}
+
+        <DocumentIssuesList
+          ref={listRef}
+          issues={filteredIssues}
+          scrollElement={scrollContainer}
+          hideJumpButton={selectedLineRange !== null}
+          onSelect={onSelectIssue}
+          readOnly={readOnly}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/document-explorer/issues-column.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-column.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DocumentIssuesList, DocumentIssuesListHandle } from '@/components/results/components/document-issues-list';
+import { IssuesList, IssuesListHandle } from './issues-list';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Issue } from '@/lib/generated-api';
@@ -16,6 +16,8 @@ interface IssuesColumnProps {
   ref?: Ref<IssuesColumnHandle>;
   visibleIssues: Issue[];
   filteredIssues: Issue[];
+  /** The issue whose row is expanded. */
+  activeIssueId: string | null;
   isAnyProcessing: boolean;
   readOnly: boolean;
   onSelectIssue: (issue: Issue) => void;
@@ -26,6 +28,7 @@ export function IssuesColumn({
   ref,
   visibleIssues,
   filteredIssues,
+  activeIssueId,
   isAnyProcessing,
   readOnly,
   onSelectIssue,
@@ -33,7 +36,7 @@ export function IssuesColumn({
 }: IssuesColumnProps) {
   const { selectedLineRange, filter, clearFilters } = useDocumentExplorerStore();
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
-  const listRef = useRef<DocumentIssuesListHandle>(null);
+  const listRef = useRef<IssuesListHandle>(null);
 
   useImperativeHandle(ref, () => ({
     scrollToIssue: (issue: Issue) => {
@@ -81,9 +84,9 @@ export function IssuesColumn({
         )}
       </div>
 
-      <div ref={setScrollContainer} className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+      <div ref={setScrollContainer} className="min-h-0 flex-1 overflow-y-auto">
         {visibleIssues.length === 0 && !isAnyProcessing && (
-          <p className="py-4 text-sm text-muted-foreground">No issues found for this document.</p>
+          <p className="p-4 text-sm text-muted-foreground">No issues found for this document.</p>
         )}
 
         {visibleIssues.length > 0 && filteredIssues.length === 0 && !isAnyProcessing && (
@@ -97,11 +100,11 @@ export function IssuesColumn({
           </div>
         )}
 
-        <DocumentIssuesList
+        <IssuesList
           ref={listRef}
           issues={filteredIssues}
           scrollElement={scrollContainer}
-          hideJumpButton={selectedLineRange !== null}
+          activeIssueId={activeIssueId}
           onSelect={onSelectIssue}
           readOnly={readOnly}
         />

--- a/frontend/components/results-v2/document-explorer/issues-column.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-column.tsx
@@ -1,12 +1,23 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Issue } from '@/lib/generated-api';
 import { getIssueCount, hasActiveFilters, useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
-import { Loader2 } from 'lucide-react';
 import { Ref, useImperativeHandle, useRef, useState } from 'react';
 import { IssuesList, IssuesListHandle } from './issues-list';
+
+/**
+ * "12 issues", or "3 of 12 issues" once filters narrow the list. Null when the
+ * document has none to report, so callers can leave the slot empty.
+ */
+export function issueCountLabel(visibleIssues: Issue[], issues: Issue[]): string | null {
+  const visibleCount = getIssueCount(visibleIssues);
+  if (visibleCount === 0) return null;
+
+  const shownCount = getIssueCount(issues);
+  const noun = visibleCount === 1 ? 'issue' : 'issues';
+  return shownCount === visibleCount ? `${visibleCount} ${noun}` : `${shownCount} of ${visibleCount} ${noun}`;
+}
 
 export interface IssuesColumnHandle {
   scrollToIssue: (issue: Issue) => void;
@@ -50,33 +61,8 @@ export function IssuesColumn({
     },
   }));
 
-  const visibleCount = getIssueCount(visibleIssues);
-  const shownCount = getIssueCount(issues);
-
   return (
     <div className="flex h-full flex-col">
-      <div className="flex h-10 shrink-0 items-center gap-2 border-b px-4">
-        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-          {isAnyProcessing && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="inline-flex size-3.5 items-center justify-center"
-                  aria-label="Some results are still loading"
-                >
-                  <Loader2 className="size-3.5 animate-spin" />
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>Some results are still loading, see the Assessments tab for details</TooltipContent>
-            </Tooltip>
-          )}
-          {visibleCount > 0 &&
-            (shownCount === visibleCount ? `${visibleCount} issues` : `${shownCount} of ${visibleCount} issues`)}
-          {visibleCount === 0 && isAnyProcessing && 'Finding issues...'}
-          {visibleCount === 0 && !isAnyProcessing && 'No issues'}
-        </span>
-      </div>
-
       <div ref={setScrollContainer} className="min-h-0 flex-1 overflow-y-auto">
         {visibleIssues.length === 0 && !isAnyProcessing && (
           <p className="p-4 text-sm text-muted-foreground">No issues found for this document.</p>

--- a/frontend/components/results-v2/document-explorer/issues-list.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-list.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { Issue, SeverityEnum } from '@/lib/generated-api';
+import { isIssueResolved } from '@/lib/stores/document-explorer-store';
+import { cn } from '@/lib/utils';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { Ref, useImperativeHandle, useMemo } from 'react';
+import { IssueBody, IssueMeta, SEVERITY } from './issue-note';
+
+/** Worst first, matching the order the store already sorts issues into. */
+const SEVERITY_ORDER: SeverityEnum[] = [SeverityEnum.High, SeverityEnum.Medium, SeverityEnum.Low, SeverityEnum.None];
+
+type Row = { kind: 'header'; severity: SeverityEnum; count: number } | { kind: 'issue'; issue: Issue };
+
+export interface IssuesListHandle {
+  scrollToIssue: (issue: Issue) => void;
+}
+
+interface IssuesListProps {
+  ref?: Ref<IssuesListHandle>;
+  issues: Issue[];
+  scrollElement: HTMLElement | null;
+  activeIssueId: string | null;
+  readOnly: boolean;
+  onSelect: (issue: Issue) => void;
+}
+
+/**
+ * The issue queue: grouped by severity, one flat row per issue, expanding in
+ * place into the same body the margin note shows. Virtualised, because turning
+ * passing checks on can push this past six hundred rows.
+ */
+export function IssuesList({ ref, issues, scrollElement, activeIssueId, readOnly, onSelect }: IssuesListProps) {
+  const rows = useMemo<Row[]>(() => {
+    const out: Row[] = [];
+    for (const severity of SEVERITY_ORDER) {
+      const group = issues.filter((issue) => issue.severity === severity);
+      if (group.length === 0) continue;
+      out.push({ kind: 'header', severity, count: group.length });
+      for (const issue of group) out.push({ kind: 'issue', issue });
+    }
+    return out;
+  }, [issues]);
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: (index) => (rows[index].kind === 'header' ? 33 : 56),
+    overscan: 8,
+    getItemKey: (index) => {
+      const row = rows[index];
+      return row.kind === 'header' ? `header-${row.severity}` : row.issue.id;
+    },
+  });
+
+  // Expanding a row in place should not yank the scroll position around it.
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => false;
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToIssue: (issue: Issue) => {
+        const index = rows.findIndex((row) => row.kind === 'issue' && row.issue.id === issue.id);
+        if (index >= 0) virtualizer.scrollToIndex(index, { align: 'start' });
+      },
+    }),
+    [rows, virtualizer],
+  );
+
+  return (
+    <div style={{ height: virtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
+      {virtualizer.getVirtualItems().map((virtualItem) => {
+        const row = rows[virtualItem.index];
+        return (
+          <div
+            key={virtualItem.key}
+            data-index={virtualItem.index}
+            ref={virtualizer.measureElement}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${virtualItem.start}px)`,
+            }}
+          >
+            {row.kind === 'header' ? (
+              <GroupHeader severity={row.severity} count={row.count} />
+            ) : (
+              <IssueRow
+                issue={row.issue}
+                active={activeIssueId === row.issue.id}
+                readOnly={readOnly}
+                onSelect={onSelect}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function GroupHeader({ severity, count }: { severity: SeverityEnum; count: number }) {
+  const style = SEVERITY[severity];
+  return (
+    <div className="bg-background flex items-center gap-2 border-b px-4 py-2">
+      <span className={cn('block size-2 rounded-[2px]', style.dot)} />
+      <span className="text-xs font-medium">{style.label}</span>
+      <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{count}</span>
+    </div>
+  );
+}
+
+function IssueRow({
+  issue,
+  active,
+  readOnly,
+  onSelect,
+}: {
+  issue: Issue;
+  active: boolean;
+  readOnly: boolean;
+  onSelect: (issue: Issue) => void;
+}) {
+  const resolved = isIssueResolved(issue);
+  const style = SEVERITY[issue.severity];
+
+  return (
+    <div
+      onClick={() => onSelect(issue)}
+      role="button"
+      tabIndex={0}
+      aria-expanded={active}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(issue);
+        }
+      }}
+      className={cn(
+        'w-full cursor-pointer border-b px-4 py-3 text-left transition-colors',
+        active ? style.wash : 'hover:bg-accent/50',
+        resolved && !active && 'opacity-60',
+      )}
+    >
+      <IssueMeta issue={issue} showDot={false} />
+      <span className="mt-1 block text-[13.5px] leading-snug font-medium">{issue.title}</span>
+      {active && (
+        <div className="mt-2">
+          <IssueBody issue={issue} readOnly={readOnly} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/results-v2/document-explorer/issues-list.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-list.tsx
@@ -144,8 +144,11 @@ function IssueRow({
         resolved && !active && 'opacity-60',
       )}
     >
-      <IssueMeta issue={issue} showDot={false} />
-      <span className="mt-1 block text-[13.5px] leading-snug font-medium">{issue.title}</span>
+      <IssueMeta issue={issue} />
+      <span className="mt-1 flex items-start gap-2">
+        <span className="flex-1 text-[13.5px] leading-snug font-medium">{issue.title}</span>
+        {active && <span className={cn('shrink-0 font-mono text-[10px] uppercase', style.text)}>{style.label}</span>}
+      </span>
       {active && (
         <div className="mt-2">
           <IssueBody issue={issue} readOnly={readOnly} />

--- a/frontend/components/results-v2/document-explorer/issues-list.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-list.tsx
@@ -5,7 +5,8 @@ import { isIssueResolved } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Ref, useImperativeHandle, useMemo } from 'react';
-import { IssueBody, IssueMeta, SEVERITY } from './issue-note';
+import { SEVERITY } from '@/lib/severity-style';
+import { IssueBody, IssueMeta } from './issue-note';
 
 /** Worst first, matching the order the store already sorts issues into. */
 const SEVERITY_ORDER: SeverityEnum[] = [SeverityEnum.High, SeverityEnum.Medium, SeverityEnum.Low, SeverityEnum.None];

--- a/frontend/components/results-v2/document-explorer/issues-list.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-list.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Ref, useImperativeHandle, useMemo } from 'react';
 import { SEVERITY } from '@/lib/severity-style';
-import { IssueBody, IssueMeta } from './issue-note';
+import { IssueBody, IssueMeta, IssuePreview } from './issue-note';
 
 /** Worst first, matching the order the store already sorts issues into. */
 const SEVERITY_ORDER: SeverityEnum[] = [SeverityEnum.High, SeverityEnum.Medium, SeverityEnum.Low, SeverityEnum.None];
@@ -154,6 +154,7 @@ function IssueRow({
         <span className="flex-1 text-[13.5px] leading-snug font-medium">{issue.title}</span>
         {active && <span className={cn('shrink-0 font-mono text-[10px] uppercase', style.text)}>{style.label}</span>}
       </span>
+      {!active && <IssuePreview issue={issue} />}
       {active && (
         <div className="mt-2">
           <IssueBody issue={issue} readOnly={readOnly} />

--- a/frontend/components/results-v2/document-explorer/issues-list.tsx
+++ b/frontend/components/results-v2/document-explorer/issues-list.tsx
@@ -134,6 +134,10 @@ function IssueRow({
       tabIndex={0}
       aria-expanded={active}
       onKeyDown={(event) => {
+        // Only when the row itself has focus: an expanded row holds Resolve and
+        // feedback buttons, and swallowing their Enter would collapse the row
+        // rather than press them.
+        if (event.target !== event.currentTarget) return;
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
           onSelect(issue);

--- a/frontend/components/results-v2/document-explorer/margin-note.tsx
+++ b/frontend/components/results-v2/document-explorer/margin-note.tsx
@@ -11,6 +11,12 @@ interface MarginNoteProps {
   active: boolean;
   readOnly: boolean;
   onSelect: (issue: Issue) => void;
+  /**
+   * Whether this note belongs to a paragraph. Document-level issues sit at the
+   * top of the margin with nothing beside them, so they drop the leader rather
+   * than point at a paragraph that is not theirs.
+   */
+  anchored?: boolean;
 }
 
 /**
@@ -23,14 +29,14 @@ interface MarginNoteProps {
  * it. Growing the row instead pushes the notes below it down and leaves the
  * anchored paragraph where it is, since the text cell sits at the row's top.
  */
-export function MarginNote({ issue, active, readOnly, onSelect }: MarginNoteProps) {
+export function MarginNote({ issue, active, readOnly, onSelect, anchored = true }: MarginNoteProps) {
   const resolved = isIssueResolved(issue);
   const style = SEVERITY[issue.severity];
 
   if (active) {
     return (
       <div className="relative mb-1.5">
-        <Leader severity={issue.severity} />
+        {anchored && <Leader severity={issue.severity} />}
         <div className={cn('rounded-md border', style.edge, style.wash)}>
           <button
             onClick={() => onSelect(issue)}

--- a/frontend/components/results-v2/document-explorer/margin-note.tsx
+++ b/frontend/components/results-v2/document-explorer/margin-note.tsx
@@ -4,7 +4,7 @@ import { Issue, SeverityEnum } from '@/lib/generated-api';
 import { isIssueResolved } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
 import { SEVERITY } from '@/lib/severity-style';
-import { IssueBody, IssueMeta } from './issue-note';
+import { IssueBody, IssueMeta, IssuePreview } from './issue-note';
 
 interface MarginNoteProps {
   issue: Issue;
@@ -69,6 +69,7 @@ export function MarginNote({ issue, active, readOnly, onSelect, anchored = true 
       >
         <IssueMeta issue={issue} />
         <span className="mt-0.5 block text-[13px] leading-snug font-medium">{issue.title}</span>
+        <IssuePreview issue={issue} />
       </button>
     </div>
   );

--- a/frontend/components/results-v2/document-explorer/margin-note.tsx
+++ b/frontend/components/results-v2/document-explorer/margin-note.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Issue, SeverityEnum } from '@/lib/generated-api';
+import { isIssueResolved } from '@/lib/stores/document-explorer-store';
+import { cn } from '@/lib/utils';
+import { IssueBody, IssueMeta, SEVERITY } from './issue-note';
+
+interface MarginNoteProps {
+  issue: Issue;
+  active: boolean;
+  readOnly: boolean;
+  onSelect: (issue: Issue) => void;
+}
+
+/**
+ * One issue in the document's margin, on the same grid row as the paragraph it
+ * belongs to. Collapsed it is two lines, so a document with a hundred issues
+ * stays readable; open it carries everything the issue list does.
+ */
+export function MarginNote({ issue, active, readOnly, onSelect }: MarginNoteProps) {
+  const resolved = isIssueResolved(issue);
+  const style = SEVERITY[issue.severity];
+
+  return (
+    <div className="relative mb-1">
+      {/* The open note floats over the ones below rather than growing the row:
+          expanding in place would shift the paragraph you are reading. */}
+      {active && (
+        <div className="bg-background absolute top-0 left-0 z-20 w-full rounded-md shadow-lg">
+          <Leader severity={issue.severity} />
+          <div className={cn('rounded-md border', style.edge, style.wash)}>
+            <button
+              onClick={() => onSelect(issue)}
+              className="w-full cursor-pointer px-2.5 pt-2 text-left"
+              aria-label="Collapse issue"
+            >
+              <IssueMeta issue={issue} />
+              <span className="mt-0.5 flex items-start gap-2">
+                <span className="flex-1 text-[13px] leading-snug font-medium">{issue.title}</span>
+                <span className={cn('shrink-0 font-mono text-[10px] uppercase', style.text)}>{style.label}</span>
+              </span>
+            </button>
+            <div className="px-2.5 pt-1.5 pb-2">
+              <IssueBody issue={issue} readOnly={readOnly} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <button
+        onClick={() => onSelect(issue)}
+        aria-expanded={active}
+        className={cn(
+          'hover:bg-accent/60 w-full cursor-pointer rounded-md px-2 py-1.5 text-left transition-colors',
+          resolved && 'opacity-60',
+          active && 'invisible',
+        )}
+      >
+        <IssueMeta issue={issue} />
+        <span className="mt-0.5 block text-[13px] leading-snug font-medium">{issue.title}</span>
+      </button>
+    </div>
+  );
+}
+
+/** Hairline from the text column into the margin, tying a note to its paragraph. */
+function Leader({ severity }: { severity: SeverityEnum }) {
+  return <span aria-hidden className={cn('absolute top-3.5 -left-6 h-px w-6 opacity-60', SEVERITY[severity].dot)} />;
+}

--- a/frontend/components/results-v2/document-explorer/margin-note.tsx
+++ b/frontend/components/results-v2/document-explorer/margin-note.tsx
@@ -16,44 +16,48 @@ interface MarginNoteProps {
  * One issue in the document's margin, on the same grid row as the paragraph it
  * belongs to. Collapsed it is two lines, so a document with a hundred issues
  * stays readable; open it carries everything the issue list does.
+ *
+ * The open note expands in place rather than floating over its neighbours. A
+ * paragraph can carry several issues, and a floating card hid the ones beneath
+ * it. Growing the row instead pushes the notes below it down and leaves the
+ * anchored paragraph where it is, since the text cell sits at the row's top.
  */
 export function MarginNote({ issue, active, readOnly, onSelect }: MarginNoteProps) {
   const resolved = isIssueResolved(issue);
   const style = SEVERITY[issue.severity];
 
-  return (
-    <div className="relative mb-1">
-      {/* The open note floats over the ones below rather than growing the row:
-          expanding in place would shift the paragraph you are reading. */}
-      {active && (
-        <div className="bg-background absolute top-0 left-0 z-20 w-full rounded-md shadow-lg">
-          <Leader severity={issue.severity} />
-          <div className={cn('rounded-md border', style.edge, style.wash)}>
-            <button
-              onClick={() => onSelect(issue)}
-              className="w-full cursor-pointer px-2.5 pt-2 text-left"
-              aria-label="Collapse issue"
-            >
-              <IssueMeta issue={issue} />
-              <span className="mt-0.5 flex items-start gap-2">
-                <span className="flex-1 text-[13px] leading-snug font-medium">{issue.title}</span>
-                <span className={cn('shrink-0 font-mono text-[10px] uppercase', style.text)}>{style.label}</span>
-              </span>
-            </button>
-            <div className="px-2.5 pt-1.5 pb-2">
-              <IssueBody issue={issue} readOnly={readOnly} />
-            </div>
+  if (active) {
+    return (
+      <div className="relative mb-1.5">
+        <Leader severity={issue.severity} />
+        <div className={cn('rounded-md border', style.edge, style.wash)}>
+          <button
+            onClick={() => onSelect(issue)}
+            className="w-full cursor-pointer px-2.5 pt-2 text-left"
+            aria-label="Collapse issue"
+          >
+            <IssueMeta issue={issue} />
+            <span className="mt-0.5 flex items-start gap-2">
+              <span className="flex-1 text-[13px] leading-snug font-medium">{issue.title}</span>
+              <span className={cn('shrink-0 font-mono text-[10px] uppercase', style.text)}>{style.label}</span>
+            </span>
+          </button>
+          <div className="px-2.5 pt-1.5 pb-2">
+            <IssueBody issue={issue} readOnly={readOnly} />
           </div>
         </div>
-      )}
+      </div>
+    );
+  }
 
+  return (
+    <div className="relative mb-1">
       <button
         onClick={() => onSelect(issue)}
-        aria-expanded={active}
+        aria-expanded={false}
         className={cn(
           'hover:bg-accent/60 w-full cursor-pointer rounded-md px-2 py-1.5 text-left transition-colors',
           resolved && 'opacity-60',
-          active && 'invisible',
         )}
       >
         <IssueMeta issue={issue} />

--- a/frontend/components/results-v2/document-explorer/margin-note.tsx
+++ b/frontend/components/results-v2/document-explorer/margin-note.tsx
@@ -3,7 +3,8 @@
 import { Issue, SeverityEnum } from '@/lib/generated-api';
 import { isIssueResolved } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
-import { IssueBody, IssueMeta, SEVERITY } from './issue-note';
+import { SEVERITY } from '@/lib/severity-style';
+import { IssueBody, IssueMeta } from './issue-note';
 
 interface MarginNoteProps {
   issue: Issue;

--- a/frontend/components/results-v2/document-explorer/outline-rail.tsx
+++ b/frontend/components/results-v2/document-explorer/outline-rail.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { HelpLink } from '@/components/help/help-link';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Issue, SeverityEnum, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { DocumentExplorerFilter, hasActiveFilters } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
+import { CircleHelp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { OutlineEntry, issuesInSection } from './outline';
 
@@ -224,6 +226,18 @@ export function OutlineRail({
           </ol>
         )}
       </section>
+
+      {/* A row rather than a paragraph: this rail already carries filters and a
+          whole outline, and prose at the foot of it costs more than it explains. */}
+      <div className="shrink-0 border-t p-3">
+        <HelpLink
+          topic="issues"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm no-underline transition-colors hover:bg-accent/60 hover:text-foreground"
+        >
+          <CircleHelp className="size-3.5 shrink-0" aria-hidden />
+          Help
+        </HelpLink>
+      </div>
     </div>
   );
 }

--- a/frontend/components/results-v2/document-explorer/outline-rail.tsx
+++ b/frontend/components/results-v2/document-explorer/outline-rail.tsx
@@ -7,6 +7,7 @@ import { Issue, SeverityEnum, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { SEVERITY } from '@/lib/severity-style';
 import { DocumentExplorerFilter, hasActiveFilters } from '@/lib/stores/document-explorer-store';
+import { RAIL_ITEM_ACTIVE, RAIL_ITEM_IDLE } from '@/lib/rail-style';
 import { cn } from '@/lib/utils';
 import { CircleHelp } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -113,7 +114,7 @@ export function OutlineRail({
                 aria-pressed={on}
                 className={cn(
                   'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
-                  on ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
+                  on ? RAIL_ITEM_ACTIVE : RAIL_ITEM_IDLE,
                 )}
               >
                 <span className={cn('block size-2 rounded-[2px]', SEVERITY[severity].dot)} />
@@ -198,7 +199,7 @@ export function OutlineRail({
                     onClick={() => onJump(entry)}
                     className={cn(
                       'flex w-full cursor-pointer items-center gap-2 rounded-md py-1.5 pr-2 text-left text-sm transition-colors',
-                      isActive ? 'bg-accent text-accent-foreground font-medium' : 'hover:bg-accent/60',
+                      isActive ? RAIL_ITEM_ACTIVE : RAIL_ITEM_IDLE,
                     )}
                     style={{ paddingLeft: `${0.5 + (entry.level - 1) * 0.75}rem` }}
                   >

--- a/frontend/components/results-v2/document-explorer/outline-rail.tsx
+++ b/frontend/components/results-v2/document-explorer/outline-rail.tsx
@@ -100,7 +100,7 @@ export function OutlineRail({
     <div className="flex h-full min-h-0 flex-col">
       <section className="max-h-[55%] shrink-0 overflow-y-auto px-3 py-4">
         <div className="flex items-center justify-between px-2">
-          <h3 className="font-mono text-[10px] tracking-[0.14em] text-muted-foreground uppercase">Filter issues</h3>
+          <h3 className="font-mono text-[10px] tracking-wide text-muted-foreground uppercase">Filter issues</h3>
           {hasActiveFilters(filter) && (
             <Button variant="link" size="sm" className="h-auto p-0 text-xs" onClick={onClearFilters}>
               Clear
@@ -190,9 +190,7 @@ export function OutlineRail({
       <div className="border-t" />
 
       <section className="min-h-0 flex-1 overflow-y-auto px-3 py-4">
-        <h3 className="px-2 font-mono text-[10px] tracking-[0.14em] text-muted-foreground uppercase">
-          Document outline
-        </h3>
+        <h3 className="px-2 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">Document outline</h3>
         {outline.length === 0 ? (
           <p className="px-2 pt-2 text-xs text-muted-foreground">This document has no headings.</p>
         ) : (

--- a/frontend/components/results-v2/document-explorer/outline-rail.tsx
+++ b/frontend/components/results-v2/document-explorer/outline-rail.tsx
@@ -6,7 +6,7 @@ import { Issue, SeverityEnum, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { DocumentExplorerFilter, hasActiveFilters } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { OutlineEntry, issuesInSection } from './outline';
 
 const SEVERITY_ROWS = [
@@ -14,6 +14,9 @@ const SEVERITY_ROWS = [
   { value: SeverityEnum.Medium, label: 'Medium', dot: 'bg-amber-500' },
   { value: SeverityEnum.Low, label: 'Low', dot: 'bg-blue-500' },
 ] as const;
+
+/** Assessments shown before the list is collapsed behind a toggle. */
+const VISIBLE_ASSESSMENTS = 4;
 
 const SEVERITY_DOT: Record<SeverityEnum, string> = {
   [SeverityEnum.High]: 'bg-red-500',
@@ -56,6 +59,7 @@ export function OutlineRail({
   onJump,
 }: OutlineRailProps) {
   const { getWorkflowTypeName } = useWorkflowTypes();
+  const [showAllWorkflows, setShowAllWorkflows] = useState(false);
 
   const workflowCounts = useMemo(() => {
     const counts = new Map<WorkflowRunType, number>();
@@ -64,6 +68,19 @@ export function OutlineRail({
     }
     return [...counts.entries()].sort((a, b) => b[1] - a[1]);
   }, [visibleIssues]);
+
+  /**
+   * A project can run a dozen assessments, and the full set of chips pushes the
+   * outline off the rail. Show the ones carrying the most issues, plus anything
+   * selected so an active filter is never out of sight, and put the rest behind
+   * a toggle.
+   */
+  const shownWorkflows = useMemo(() => {
+    if (showAllWorkflows) return workflowCounts;
+    return workflowCounts.filter(([type], index) => index < VISIBLE_ASSESSMENTS || filter.workflowType.includes(type));
+  }, [workflowCounts, showAllWorkflows, filter.workflowType]);
+
+  const hiddenWorkflowCount = workflowCounts.length - shownWorkflows.length;
 
   const toggleSeverity = (value: SeverityEnum) => {
     const next = filter.severity.includes(value)
@@ -115,7 +132,7 @@ export function OutlineRail({
 
         {workflowCounts.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-1.5 px-2">
-            {workflowCounts.map(([type, count]) => {
+            {shownWorkflows.map(([type, count]) => {
               const on = filter.workflowType.includes(type);
               return (
                 <button
@@ -135,6 +152,16 @@ export function OutlineRail({
                 </button>
               );
             })}
+
+            {(hiddenWorkflowCount > 0 || showAllWorkflows) && (
+              <button
+                onClick={() => setShowAllWorkflows(!showAllWorkflows)}
+                aria-expanded={showAllWorkflows}
+                className="cursor-pointer rounded-full px-2 py-0.5 text-[11px] font-medium text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              >
+                {showAllWorkflows ? 'Show fewer' : `${hiddenWorkflowCount} more`}
+              </button>
+            )}
           </div>
         )}
 

--- a/frontend/components/results-v2/document-explorer/outline-rail.tsx
+++ b/frontend/components/results-v2/document-explorer/outline-rail.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Issue, SeverityEnum, WorkflowRunType } from '@/lib/generated-api';
+import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { DocumentExplorerFilter, hasActiveFilters } from '@/lib/stores/document-explorer-store';
+import { cn } from '@/lib/utils';
+import { useMemo } from 'react';
+import { OutlineEntry, issuesInSection } from './outline';
+
+const SEVERITY_ROWS = [
+  { value: SeverityEnum.High, label: 'High', dot: 'bg-red-500' },
+  { value: SeverityEnum.Medium, label: 'Medium', dot: 'bg-amber-500' },
+  { value: SeverityEnum.Low, label: 'Low', dot: 'bg-blue-500' },
+] as const;
+
+const SEVERITY_DOT: Record<SeverityEnum, string> = {
+  [SeverityEnum.High]: 'bg-red-500',
+  [SeverityEnum.Medium]: 'bg-amber-500',
+  [SeverityEnum.Low]: 'bg-blue-500',
+  [SeverityEnum.None]: 'bg-green-500',
+};
+
+interface OutlineRailProps {
+  outline: OutlineEntry[];
+  /** Issues after the passing/resolved toggles, before severity and type. */
+  visibleIssues: Issue[];
+  filter: DocumentExplorerFilter;
+  onFilterChange: (partial: Partial<DocumentExplorerFilter>) => void;
+  onClearFilters: () => void;
+  resolvedCount: number;
+  passingCount: number;
+  activeLine: number | null;
+  onJump: (entry: OutlineEntry) => void;
+}
+
+export function OutlineRail({
+  outline,
+  visibleIssues,
+  filter,
+  onFilterChange,
+  onClearFilters,
+  resolvedCount,
+  passingCount,
+  activeLine,
+  onJump,
+}: OutlineRailProps) {
+  const { getWorkflowTypeName } = useWorkflowTypes();
+
+  const workflowCounts = useMemo(() => {
+    const counts = new Map<WorkflowRunType, number>();
+    for (const issue of visibleIssues) {
+      counts.set(issue.workflow_type, (counts.get(issue.workflow_type) ?? 0) + 1);
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  }, [visibleIssues]);
+
+  const toggleSeverity = (value: SeverityEnum) => {
+    const next = filter.severity.includes(value)
+      ? filter.severity.filter((s) => s !== value)
+      : [...filter.severity, value];
+    onFilterChange({ severity: next });
+  };
+
+  const toggleWorkflowType = (value: WorkflowRunType) => {
+    const next = filter.workflowType.includes(value)
+      ? filter.workflowType.filter((t) => t !== value)
+      : [...filter.workflowType, value];
+    onFilterChange({ workflowType: next });
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <section className="max-h-[55%] shrink-0 overflow-y-auto px-3 py-4">
+        <div className="flex items-center justify-between px-2">
+          <h3 className="font-mono text-[10px] tracking-[0.14em] text-muted-foreground uppercase">Filter issues</h3>
+          {hasActiveFilters(filter) && (
+            <Button variant="link" size="sm" className="h-auto p-0 text-xs" onClick={onClearFilters}>
+              Clear
+            </Button>
+          )}
+        </div>
+
+        <div className="mt-2 space-y-px">
+          {SEVERITY_ROWS.map((row) => {
+            const count = visibleIssues.filter((i) => i.severity === row.value).length;
+            const on = filter.severity.includes(row.value);
+            return (
+              <button
+                key={row.value}
+                onClick={() => toggleSeverity(row.value)}
+                aria-pressed={on}
+                className={cn(
+                  'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+                  on ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
+                )}
+              >
+                <span className={cn('block size-2 rounded-[2px]', row.dot)} />
+                <span className="flex-1 text-left">{row.label}</span>
+                <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {workflowCounts.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1.5 px-2">
+            {workflowCounts.map(([type, count]) => {
+              const on = filter.workflowType.includes(type);
+              return (
+                <button
+                  key={type}
+                  onClick={() => toggleWorkflowType(type)}
+                  aria-pressed={on}
+                  title={getWorkflowTypeName(type)}
+                  className={cn(
+                    'max-w-full cursor-pointer truncate rounded-full border px-2 py-0.5 text-[11px] transition-colors',
+                    on
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                  )}
+                >
+                  {getWorkflowTypeName(type)}
+                  <span className="ml-1 tabular-nums opacity-70">{count}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="mt-4 space-y-2.5 px-2">
+          <label className="flex cursor-pointer items-center gap-2 text-sm">
+            <Switch
+              checked={filter.showPassing}
+              onCheckedChange={(showPassing) => onFilterChange({ showPassing })}
+              className="scale-90"
+            />
+            <span className="flex-1">Passing checks</span>
+            <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{passingCount}</span>
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-sm">
+            <Switch
+              checked={filter.showResolved}
+              onCheckedChange={(showResolved) => onFilterChange({ showResolved })}
+              className="scale-90"
+            />
+            <span className="flex-1">Resolved</span>
+            <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{resolvedCount}</span>
+          </label>
+        </div>
+      </section>
+
+      <div className="border-t" />
+
+      <section className="min-h-0 flex-1 overflow-y-auto px-3 py-4">
+        <h3 className="px-2 font-mono text-[10px] tracking-[0.14em] text-muted-foreground uppercase">
+          Document outline
+        </h3>
+        {outline.length === 0 ? (
+          <p className="px-2 pt-2 text-xs text-muted-foreground">This document has no headings.</p>
+        ) : (
+          <ol className="mt-2 space-y-px">
+            {outline.map((entry) => {
+              const marks = issuesInSection(visibleIssues, entry).filter((i) => i.severity !== SeverityEnum.None);
+              const isActive = activeLine !== null && activeLine >= entry.line && activeLine <= entry.endLine;
+              return (
+                <li key={entry.id}>
+                  <button
+                    onClick={() => onJump(entry)}
+                    className={cn(
+                      'flex w-full cursor-pointer items-center gap-2 rounded-md py-1.5 pr-2 text-left text-sm transition-colors',
+                      isActive ? 'bg-accent text-accent-foreground font-medium' : 'hover:bg-accent/60',
+                    )}
+                    style={{ paddingLeft: `${0.5 + (entry.level - 1) * 0.75}rem` }}
+                  >
+                    <span className="w-6 shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+                      {entry.line}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">{entry.text}</span>
+                    <span className="flex shrink-0 items-center gap-[3px]">
+                      {marks.slice(0, 4).map((m) => (
+                        <span key={m.id} className={cn('block size-1.5 rounded-full', SEVERITY_DOT[m.severity])} />
+                      ))}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/document-explorer/outline-rail.tsx
+++ b/frontend/components/results-v2/document-explorer/outline-rail.tsx
@@ -24,8 +24,16 @@ const SEVERITY_DOT: Record<SeverityEnum, string> = {
 
 interface OutlineRailProps {
   outline: OutlineEntry[];
-  /** Issues after the passing/resolved toggles, before severity and type. */
+  /**
+   * Issues after the passing/resolved toggles, before severity and type. Drives
+   * the filter counts, so they keep showing what turning a filter on would add.
+   */
   visibleIssues: Issue[];
+  /**
+   * Issues after every filter — the same set the document highlights. Drives the
+   * section dots, so the outline always agrees with what is marked in the text.
+   */
+  markedIssues: Issue[];
   filter: DocumentExplorerFilter;
   onFilterChange: (partial: Partial<DocumentExplorerFilter>) => void;
   onClearFilters: () => void;
@@ -38,6 +46,7 @@ interface OutlineRailProps {
 export function OutlineRail({
   outline,
   visibleIssues,
+  markedIssues,
   filter,
   onFilterChange,
   onClearFilters,
@@ -162,7 +171,7 @@ export function OutlineRail({
         ) : (
           <ol className="mt-2 space-y-px">
             {outline.map((entry) => {
-              const marks = issuesInSection(visibleIssues, entry).filter((i) => i.severity !== SeverityEnum.None);
+              const marks = issuesInSection(markedIssues, entry);
               const isActive = activeLine !== null && activeLine >= entry.line && activeLine <= entry.endLine;
               return (
                 <li key={entry.id}>

--- a/frontend/components/results-v2/document-explorer/outline-rail.tsx
+++ b/frontend/components/results-v2/document-explorer/outline-rail.tsx
@@ -5,27 +5,19 @@ import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Issue, SeverityEnum, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { SEVERITY } from '@/lib/severity-style';
 import { DocumentExplorerFilter, hasActiveFilters } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
 import { CircleHelp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { OutlineEntry, issuesInSection } from './outline';
 
-const SEVERITY_ROWS = [
-  { value: SeverityEnum.High, label: 'High', dot: 'bg-red-500' },
-  { value: SeverityEnum.Medium, label: 'Medium', dot: 'bg-amber-500' },
-  { value: SeverityEnum.Low, label: 'Low', dot: 'bg-blue-500' },
-] as const;
+/** The severities this rail filters by, worst first. Their colours and labels
+ *  come from the shared palette so the rail cannot drift from the margin. */
+const SEVERITY_ROWS = [SeverityEnum.High, SeverityEnum.Medium, SeverityEnum.Low] as const;
 
 /** Assessments shown before the list is collapsed behind a toggle. */
 const VISIBLE_ASSESSMENTS = 4;
-
-const SEVERITY_DOT: Record<SeverityEnum, string> = {
-  [SeverityEnum.High]: 'bg-red-500',
-  [SeverityEnum.Medium]: 'bg-amber-500',
-  [SeverityEnum.Low]: 'bg-blue-500',
-  [SeverityEnum.None]: 'bg-green-500',
-};
 
 interface OutlineRailProps {
   outline: OutlineEntry[];
@@ -111,21 +103,21 @@ export function OutlineRail({
         </div>
 
         <div className="mt-2 space-y-px">
-          {SEVERITY_ROWS.map((row) => {
-            const count = visibleIssues.filter((i) => i.severity === row.value).length;
-            const on = filter.severity.includes(row.value);
+          {SEVERITY_ROWS.map((severity) => {
+            const count = visibleIssues.filter((i) => i.severity === severity).length;
+            const on = filter.severity.includes(severity);
             return (
               <button
-                key={row.value}
-                onClick={() => toggleSeverity(row.value)}
+                key={severity}
+                onClick={() => toggleSeverity(severity)}
                 aria-pressed={on}
                 className={cn(
                   'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
                   on ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
                 )}
               >
-                <span className={cn('block size-2 rounded-[2px]', row.dot)} />
-                <span className="flex-1 text-left">{row.label}</span>
+                <span className={cn('block size-2 rounded-[2px]', SEVERITY[severity].dot)} />
+                <span className="flex-1 text-left">{SEVERITY[severity].label}</span>
                 <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{count}</span>
               </button>
             );
@@ -216,7 +208,7 @@ export function OutlineRail({
                     <span className="min-w-0 flex-1 truncate">{entry.text}</span>
                     <span className="flex shrink-0 items-center gap-[3px]">
                       {marks.slice(0, 4).map((m) => (
-                        <span key={m.id} className={cn('block size-1.5 rounded-full', SEVERITY_DOT[m.severity])} />
+                        <span key={m.id} className={cn('block size-1.5 rounded-full', SEVERITY[m.severity].dot)} />
                       ))}
                     </span>
                   </button>

--- a/frontend/components/results-v2/document-explorer/outline.ts
+++ b/frontend/components/results-v2/document-explorer/outline.ts
@@ -1,0 +1,62 @@
+import type { Issue } from '@/lib/generated-api';
+
+export interface OutlineEntry {
+  id: string;
+  level: number;
+  text: string;
+  line: number;
+  /** Line the next heading starts on, or Infinity for the last one. */
+  endLine: number;
+}
+
+const HEADING = /^(#{1,3})\s+(.*\S)\s*$/;
+const FENCE = /^\s*(```|~~~)/;
+
+/**
+ * Reads the document outline straight off the markdown source so heading line
+ * numbers match the ones the renderer puts in the gutter. Only levels 1–3, since
+ * deeper headings make the rail unreadable on a long report.
+ */
+export function extractOutline(markdown: string): OutlineEntry[] {
+  const entries: OutlineEntry[] = [];
+  let inFence = false;
+
+  markdown.split('\n').forEach((raw, index) => {
+    if (FENCE.test(raw)) {
+      inFence = !inFence;
+      return;
+    }
+    if (inFence) return;
+
+    const match = HEADING.exec(raw);
+    if (!match) return;
+
+    entries.push({
+      id: `outline-${index + 1}`,
+      level: match[1].length,
+      // Strip the inline markdown that would otherwise show up as literal syntax.
+      text: match[2].replace(/[*_`]/g, '').trim(),
+      line: index + 1,
+      endLine: Infinity,
+    });
+  });
+
+  entries.forEach((entry, i) => {
+    entry.endLine = i + 1 < entries.length ? entries[i + 1].line - 1 : Infinity;
+  });
+
+  return entries;
+}
+
+function issueStartLine(issue: Issue): number | null {
+  const start = (issue as Issue & { start_line?: number | null }).start_line;
+  return typeof start === 'number' ? start : null;
+}
+
+/** Issues whose start line falls inside a section, for the rail's severity dots. */
+export function issuesInSection(issues: Issue[], entry: OutlineEntry): Issue[] {
+  return issues.filter((issue) => {
+    const line = issueStartLine(issue);
+    return line !== null && line >= entry.line && line <= entry.endLine;
+  });
+}

--- a/frontend/components/results-v2/document-explorer/outline.ts
+++ b/frontend/components/results-v2/document-explorer/outline.ts
@@ -10,7 +10,7 @@ export interface OutlineEntry {
 }
 
 const HEADING = /^(#{1,3})\s+(.*\S)\s*$/;
-const FENCE = /^\s*(```|~~~)/;
+const FENCE = /^\s*(`{3,}|~{3,})/;
 
 /**
  * Reads the document outline straight off the markdown source so heading line
@@ -19,14 +19,24 @@ const FENCE = /^\s*(```|~~~)/;
  */
 export function extractOutline(markdown: string): OutlineEntry[] {
   const entries: OutlineEntry[] = [];
-  let inFence = false;
+  // The delimiter that opened the current fence, or null outside one. Markdown
+  // closes a fence only on the same character, at least as long as the opener,
+  // so a ~~~ line inside a ``` block is content rather than the end of it.
+  let fence: { char: string; length: number } | null = null;
 
   markdown.split('\n').forEach((raw, index) => {
-    if (FENCE.test(raw)) {
-      inFence = !inFence;
-      return;
+    const delimiter = FENCE.exec(raw)?.[1];
+    if (delimiter) {
+      if (!fence) {
+        fence = { char: delimiter[0], length: delimiter.length };
+        return;
+      }
+      if (delimiter[0] === fence.char && delimiter.length >= fence.length) {
+        fence = null;
+        return;
+      }
     }
-    if (inFence) return;
+    if (fence) return;
 
     const match = HEADING.exec(raw);
     if (!match) return;

--- a/frontend/components/results-v2/files-v2-panel.tsx
+++ b/frontend/components/results-v2/files-v2-panel.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useProjectView } from '@/components/results/project-view-context';
+import { FilesTabV2 } from './files/files-tab';
+
+/** The v2 files tab as a tab panel, taking its project from the shell. */
+export function FilesV2Panel() {
+  const { projectDetail, readOnly, onRevisionCreated } = useProjectView();
+
+  return <FilesTabV2 projectDetail={projectDetail} readOnly={readOnly} onRevisionCreated={onRevisionCreated} />;
+}

--- a/frontend/components/results-v2/files/file-detail.tsx
+++ b/frontend/components/results-v2/files/file-detail.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { Markdown } from '@/components/markdown';
+import { formatFileSize } from '@/components/analysis-form/utils';
+import { useRemoveFileMutation } from '@/components/results/tabs/reference-review/mutations';
+import { FileTypeIcon } from '@/components/shared/file-type-icon';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { FileDownloadLink } from '@/components/ui/file-download-link';
+import { ComposedReference } from '@/lib/composed-references';
+import { FileListItem, FileRole } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import { format } from 'date-fns';
+import { Download, Loader2, RefreshCw, Trash2 } from 'lucide-react';
+import { ReactNode, useState } from 'react';
+import { GROUP, fileGroup, revisionLabel } from './role';
+
+interface FileDetailProps {
+  file: FileListItem;
+  projectId: string;
+  currentRevision: number;
+  matchedReference?: ComposedReference;
+  readOnly: boolean;
+  onReplaceMain: () => void;
+}
+
+/**
+ * One file's particulars and the things you can do to it. The list stays a
+ * list — name, role, size, date — and everything that needs a second look or a
+ * confirmation happens here.
+ */
+export function FileDetail({
+  file,
+  projectId,
+  currentRevision,
+  matchedReference,
+  readOnly,
+  onReplaceMain,
+}: FileDetailProps) {
+  const [removeOpen, setRemoveOpen] = useState(false);
+  const removeFile = useRemoveFileMutation(projectId, file.id);
+
+  const group = fileGroup(file.role);
+  const isMain = file.role === FileRole.Main;
+  const isCurrentMain = isMain && file.revision === currentRevision;
+  const revision = revisionLabel(file, currentRevision);
+
+  return (
+    <div className="flex h-full flex-col">
+      <AlertDialog open={removeOpen} onOpenChange={setRemoveOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this file?</AlertDialogTitle>
+            <AlertDialogDescription className="break-all">
+              {file.file_name} will be removed from the project for good. If a reference was matched to it, that
+              reference goes back to having no source file.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => removeFile.mutate()}>Remove</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <div className="bg-background/90 sticky top-0 z-10 flex h-10 shrink-0 items-center gap-2 border-b px-4 backdrop-blur">
+        <FileTypeIcon fileType={file.file_type} className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="truncate text-xs font-medium" title={file.file_name}>
+          {file.file_name}
+        </span>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-4 py-4">
+        <dl className="divide-y rounded-md border text-[12.5px]">
+          {/* The header truncates; these names run to eighty characters, and
+              the whole point of the pane is to be able to read one. */}
+          <div className="px-3 py-2">
+            <dt className="text-muted-foreground">File name</dt>
+            <dd className="mt-0.5 break-all">{file.file_name}</dd>
+          </div>
+
+          <div className="px-3 py-2">
+            <div className="flex items-center justify-between gap-3">
+              <dt className="shrink-0 text-muted-foreground">Role</dt>
+              <dd>
+                <span className={cn('rounded px-1.5 py-0.5 text-[11px] font-medium', GROUP[group].className)}>
+                  {GROUP[group].label}
+                </span>
+              </dd>
+            </div>
+            <p className="mt-1.5 text-[11.5px] leading-relaxed text-muted-foreground">{GROUP[group].description}</p>
+          </div>
+          {revision && <Fact label="Revision">{revision}</Fact>}
+          <Fact label="Size">{formatFileSize(file.file_size)}</Fact>
+          {/* `uploaded_by` holds a user id, not a name, and there is nothing
+              here to resolve it against — a raw UUID tells the reader less
+              than no row at all. */}
+          <Fact label="Added">{format(file.created_at, 'MMM d, yyyy')}</Fact>
+        </dl>
+
+        <div className="flex flex-wrap gap-1.5">
+          <Button asChild size="xs" variant="outline">
+            <FileDownloadLink fileId={file.id}>
+              <Download className="size-3" />
+              Download
+            </FileDownloadLink>
+          </Button>
+
+          {!readOnly && isCurrentMain && (
+            <Button size="xs" variant="outline" onClick={onReplaceMain}>
+              <RefreshCw className="size-3" />
+              Replace, opening revision {currentRevision + 1}
+            </Button>
+          )}
+
+          {!readOnly && !isMain && (
+            <Button size="xs" variant="outline" disabled={removeFile.isPending} onClick={() => setRemoveOpen(true)}>
+              {removeFile.isPending ? <Loader2 className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
+              Remove
+            </Button>
+          )}
+        </div>
+
+        {matchedReference && (
+          <Section title="Matched reference">
+            <div className="rounded-md border px-3 py-2 text-[12.5px] leading-relaxed [&_p]:mb-0">
+              <Markdown>{matchedReference.text}</Markdown>
+            </div>
+          </Section>
+        )}
+
+        {isMain && !isCurrentMain && (
+          <p className="text-[11.5px] leading-relaxed text-muted-foreground">
+            Superseded main documents are kept so earlier revisions stay readable. They cannot be removed.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Fact({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2">
+      <dt className="shrink-0 text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 truncate text-right">{children}</dd>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-2 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">{title}</h3>
+      {children}
+    </section>
+  );
+}

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { HelpLink } from '@/components/help/help-link';
 import { formatFileSize } from '@/components/analysis-form/utils';
 import { ReplaceMainDocumentDialog } from '@/components/results/components/replace-main-document-dialog';
 import { FileUploadDialog } from '@/components/results/tabs/reference-review/file-upload-dialog';
@@ -373,7 +374,7 @@ function KindRail({
 
       <p className="shrink-0 border-t px-5 py-4 text-xs leading-relaxed text-muted-foreground">
         Every file this project holds: the draft under review and the source documents behind its references.
-        Assessments read these files.
+        Assessments read these files. <HelpLink topic="source-files">More details</HelpLink>
       </p>
     </div>
   );

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -1,0 +1,365 @@
+'use client';
+
+import { formatFileSize } from '@/components/analysis-form/utils';
+import { ReplaceMainDocumentDialog } from '@/components/results/components/replace-main-document-dialog';
+import { FileUploadDialog } from '@/components/results/tabs/reference-review/file-upload-dialog';
+import { FileTypeIcon } from '@/components/shared/file-type-icon';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
+import { buildReferenceByFileIdMap, composeReferences } from '@/lib/composed-references';
+import { FileListItem, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import { getWorkflowRunByType } from '@/lib/workflow-state';
+import { Download, FileText, Loader2, PanelLeft, Search, Upload } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { FileDetail } from './file-detail';
+import { FileGroup, GROUP, fileGroup, revisionLabel, sortFiles } from './role';
+
+type Lens = 'all' | FileGroup;
+
+interface FilesTabV2Props {
+  projectDetail: ProjectDetailed;
+  readOnly: boolean;
+  onRevisionCreated?: () => void;
+}
+
+/**
+ * Every file the project holds, in the v2 frame: a rail that narrows by kind,
+ * a toolbar that acts on all of them, a table, and a detail pane for the one
+ * you have selected.
+ */
+export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: FilesTabV2Props) {
+  const projectId = projectDetail.project.id;
+  const currentRevision = projectDetail.project.current_revision ?? 1;
+  const files = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
+  const workflowRuns = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
+
+  const [railOpen, setRailOpen] = useState(true);
+  const [lens, setLens] = useState<Lens>('all');
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [replaceOpen, setReplaceOpen] = useState(false);
+
+  const { downloadAll, isDownloading } = useDownloadAllProjectFiles(projectId);
+
+  const referenceExtraction = getWorkflowRunByType(workflowRuns, WorkflowRunType.ReferenceExtraction);
+  const referenceFileMatching = getWorkflowRunByType(workflowRuns, WorkflowRunType.ReferenceFileMatching);
+
+  const referenceByFileId = useMemo(
+    () =>
+      buildReferenceByFileIdMap(
+        composeReferences(
+          referenceExtraction?.state?.extracted_references,
+          referenceFileMatching?.state?.matches,
+          files,
+        ),
+      ),
+    [referenceExtraction?.state?.extracted_references, referenceFileMatching?.state?.matches, files],
+  );
+
+  const sorted = useMemo(() => sortFiles(files), [files]);
+
+  const counts = useMemo(
+    () => ({
+      all: files.length,
+      main: files.filter((file) => fileGroup(file.role) === 'main').length,
+      source: files.filter((file) => fileGroup(file.role) === 'source').length,
+      memo: files.filter((file) => fileGroup(file.role) === 'memo').length,
+    }),
+    [files],
+  );
+
+  const shown = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return sorted.filter((file) => {
+      if (lens !== 'all' && fileGroup(file.role) !== lens) return false;
+      if (!query) return true;
+      return (
+        file.file_name?.toLowerCase().includes(query) ||
+        file.description?.toLowerCase().includes(query) ||
+        !!referenceByFileId.get(file.id)?.text?.toLowerCase().includes(query)
+      );
+    });
+  }, [sorted, lens, search, referenceByFileId]);
+
+  const filtered = lens !== 'all' || search.trim() !== '';
+  // Looked up in the filtered list, so the pane never describes a hidden row.
+  const selected = shown.find((file) => file.id === selectedId) ?? null;
+
+  return (
+    <div className="flex h-full min-h-0">
+      <ReplaceMainDocumentDialog
+        isOpen={replaceOpen}
+        projectId={projectId}
+        onClose={() => setReplaceOpen(false)}
+        onRevisionCreated={onRevisionCreated}
+      />
+      <FileUploadDialog
+        isOpen={uploadOpen}
+        projectId={projectId}
+        title="Add files"
+        description="Add source documents or reviewer memos to this project."
+        multiple
+        allowRoleSelection
+        allowRevisionSelection
+        currentRevision={currentRevision}
+        onCancel={() => setUploadOpen(false)}
+        onComplete={() => setUploadOpen(false)}
+      />
+
+      <aside
+        className={cn(
+          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
+          railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
+        )}
+      >
+        <KindRail lens={lens} onLensChange={setLens} counts={counts} />
+      </aside>
+
+      <main className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="hidden size-7 xl:flex"
+            onClick={() => setRailOpen(!railOpen)}
+            aria-label={railOpen ? 'Hide filters' : 'Show filters'}
+            aria-pressed={railOpen}
+          >
+            <PanelLeft className="size-4" />
+          </Button>
+
+          <span className="shrink-0 truncate text-xs text-muted-foreground">
+            {filtered ? `${shown.length} of ${counts.all} files` : `${counts.all} files`}
+          </span>
+
+          <div className="relative ml-2 hidden max-w-64 min-w-0 flex-1 sm:block">
+            <Search className="absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search files and matched references"
+              className="h-7 pl-7 text-xs"
+            />
+          </div>
+
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            {!readOnly && (
+              <Button size="xs" variant="outline" onClick={() => setUploadOpen(true)}>
+                <Upload className="size-3" />
+                Add files
+              </Button>
+            )}
+            {counts.all > 0 && (
+              <Button size="xs" variant="outline" disabled={isDownloading} onClick={() => downloadAll()}>
+                {isDownloading ? <Loader2 className="size-3 animate-spin" /> : <Download className="size-3" />}
+                {isDownloading ? 'Preparing zip…' : 'Download all'}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {counts.all === 0 ? (
+            <EmptyState />
+          ) : shown.length === 0 ? (
+            <div className="space-y-1 py-12 text-center text-sm text-muted-foreground">
+              <p>No files match this view.</p>
+              <Button
+                variant="link"
+                size="sm"
+                className="text-xs"
+                onClick={() => {
+                  setLens('all');
+                  setSearch('');
+                }}
+              >
+                Clear filters
+              </Button>
+            </div>
+          ) : (
+            <table className="w-full table-fixed border-collapse text-sm">
+              {/* Fixed layout: left to itself the file-name column takes the
+                  whole width and pushes role, size and date off the pane. */}
+              <thead>
+                <tr className="border-b text-left font-mono text-[10px] tracking-wide text-muted-foreground uppercase">
+                  <th className="bg-background sticky top-0 py-2 pl-4 font-normal">File</th>
+                  <th className="bg-background sticky top-0 w-44 py-2 font-normal">Role</th>
+                  <th className="bg-background sticky top-0 w-24 py-2 pr-4 text-right font-normal">Size</th>
+                </tr>
+              </thead>
+              <tbody>
+                {shown.map((file) => (
+                  <FileRow
+                    key={file.id}
+                    file={file}
+                    currentRevision={currentRevision}
+                    matchedReferenceText={referenceByFileId.get(file.id)?.text}
+                    active={file.id === selectedId}
+                    onSelect={() => setSelectedId(file.id)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </main>
+
+      {counts.all > 0 && (
+        <aside className="hidden w-[24rem] shrink-0 border-l lg:block xl:w-[26rem]">
+          {selected ? (
+            <FileDetail
+              key={selected.id}
+              file={selected}
+              projectId={projectId}
+              currentRevision={currentRevision}
+              matchedReference={referenceByFileId.get(selected.id)}
+              readOnly={readOnly}
+              onReplaceMain={() => setReplaceOpen(true)}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center p-8">
+              <p className="max-w-56 text-center text-xs leading-relaxed text-muted-foreground">
+                Select a file to see more details, download it or remove it.
+              </p>
+            </div>
+          )}
+        </aside>
+      )}
+    </div>
+  );
+}
+
+function FileRow({
+  file,
+  currentRevision,
+  matchedReferenceText,
+  active,
+  onSelect,
+}: {
+  file: FileListItem;
+  currentRevision: number;
+  matchedReferenceText?: string;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const group = fileGroup(file.role);
+  const revision = revisionLabel(file, currentRevision);
+  const superseded = group === 'main' && file.revision !== currentRevision;
+
+  return (
+    <tr
+      role="button"
+      tabIndex={0}
+      aria-pressed={active}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      className={cn(
+        'cursor-pointer border-b transition-colors',
+        active
+          ? 'bg-accent [&>td:first-child]:before:bg-primary [&>td:first-child]:relative [&>td:first-child]:before:absolute [&>td:first-child]:before:inset-y-0 [&>td:first-child]:before:left-0 [&>td:first-child]:before:w-0.5'
+          : 'hover:bg-accent/40',
+      )}
+    >
+      <td className="py-2.5 pl-4">
+        <span className="flex min-w-0 items-center gap-2">
+          <FileTypeIcon fileType={file.file_type} className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className={cn('truncate text-[13px]', superseded && 'text-muted-foreground')}>{file.file_name}</span>
+        </span>
+        {matchedReferenceText && (
+          <span className="mt-0.5 ml-[1.375rem] block truncate text-[11.5px] text-muted-foreground">
+            {matchedReferenceText}
+          </span>
+        )}
+      </td>
+      <td className="py-2.5">
+        <span className={cn('inline-flex flex-col rounded-md px-2 py-0.5 leading-tight', GROUP[group].className)}>
+          <span className="text-[11px] font-semibold">{GROUP[group].label}</span>
+          {revision && <span className="text-[10px] font-medium opacity-70">{revision}</span>}
+        </span>
+      </td>
+      <td className="py-2.5 pr-4 text-right font-mono text-[11.5px] tabular-nums text-muted-foreground">
+        {formatFileSize(file.file_size)}
+      </td>
+    </tr>
+  );
+}
+
+const LENSES: { id: Lens; label: string }[] = [
+  { id: 'all', label: 'All files' },
+  { id: 'main', label: GROUP.main.plural },
+  { id: 'source', label: GROUP.source.plural },
+  { id: 'memo', label: GROUP.memo.plural },
+];
+
+function KindRail({
+  lens,
+  onLensChange,
+  counts,
+}: {
+  lens: Lens;
+  onLensChange: (lens: Lens) => void;
+  counts: Record<Lens, number>;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <div className="flex items-center justify-between px-2">
+          <h2 className="font-mono text-[10px] tracking-wide text-muted-foreground uppercase">Filter files</h2>
+          {lens !== 'all' && (
+            <Button variant="link" size="sm" className="h-auto p-0 text-xs" onClick={() => onLensChange('all')}>
+              Clear
+            </Button>
+          )}
+        </div>
+        <div className="mt-2 space-y-px">
+          {LENSES.map((entry) => {
+            const count = counts[entry.id];
+            if (entry.id !== 'all' && count === 0) return null;
+            return (
+              <button
+                key={entry.id}
+                onClick={() => onLensChange(entry.id)}
+                aria-pressed={lens === entry.id}
+                className={cn(
+                  'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+                  lens === entry.id ? 'bg-accent text-accent-foreground font-medium' : 'hover:bg-accent/60',
+                )}
+              >
+                <span className="flex-1 truncate">{entry.label}</span>
+                <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="shrink-0 border-t px-5 py-4 text-xs leading-relaxed text-muted-foreground">
+        Every file this project holds: the draft under review and the source documents behind its references.
+        Assessments read these files.
+      </p>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex h-full items-center justify-center p-8">
+      <div className="max-w-sm space-y-2 text-center">
+        <FileText className="mx-auto size-7 text-muted-foreground" />
+        <p className="text-sm font-medium">No files yet</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          The main document and any sources you provide will be listed here.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -7,6 +7,7 @@ import { FileTypeIcon } from '@/components/shared/file-type-icon';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
 import { buildReferenceByFileIdMap, composeReferences } from '@/lib/composed-references';
 import { FileListItem, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
@@ -37,6 +38,9 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
   const files = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
   const workflowRuns = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
 
+  // Reviewer memos only feed the alpha Peer Review tab, so the role picker is
+  // offered to the same users who can see that tab.
+  const { showExperimentalFeatures } = useExperimentalFeatures();
   const rail = useRailState();
   const [lens, setLens] = useState<Lens>('all');
   const [search, setSearch] = useState('');
@@ -102,9 +106,13 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
         isOpen={uploadOpen}
         projectId={projectId}
         title="Add files"
-        description="Add source documents or reviewer memos to this project."
+        description={
+          showExperimentalFeatures
+            ? 'Add source documents or reviewer memos to this project.'
+            : 'Add source documents to this project.'
+        }
         multiple
-        allowRoleSelection
+        allowRoleSelection={showExperimentalFeatures}
         allowRevisionSelection
         currentRevision={currentRevision}
         onCancel={() => setUploadOpen(false)}

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -38,8 +38,10 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
   const currentRevision = projectDetail.project.current_revision ?? 1;
   const allFiles = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
   // Supporting candidates are a staging role the reference downloader uses
-  // while it works, not files the project holds, so the tab neither lists them
-  // nor puts them in the zip.
+  // while it works, not files the project holds. The API already leaves them
+  // out of projectDetail.files — get_project_files_list_items filters the role
+  // in SQL — so this is belt and braces, and the tab's counts match the badge
+  // in the header because both read this same list.
   const files = useMemo(() => allFiles.filter((file) => file.role !== FileRole.SupportingCandidate), [allFiles]);
   const workflowRuns = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
 

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -10,7 +10,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
 import { buildReferenceByFileIdMap, composeReferences } from '@/lib/composed-references';
-import { FileListItem, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { FileListItem, FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { cn } from '@/lib/utils';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
 import { Download, FileText, Loader2, Search, Upload } from 'lucide-react';
@@ -35,7 +35,11 @@ interface FilesTabV2Props {
 export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: FilesTabV2Props) {
   const projectId = projectDetail.project.id;
   const currentRevision = projectDetail.project.current_revision ?? 1;
-  const files = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
+  const allFiles = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
+  // Supporting candidates are a staging role the reference downloader uses
+  // while it works, not files the project holds, so the tab neither lists them
+  // nor puts them in the zip.
+  const files = useMemo(() => allFiles.filter((file) => file.role !== FileRole.SupportingCandidate), [allFiles]);
   const workflowRuns = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
 
   // Reviewer memos only feed the alpha Peer Review tab, so the role picker is
@@ -48,7 +52,14 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
   const [uploadOpen, setUploadOpen] = useState(false);
   const [replaceOpen, setReplaceOpen] = useState(false);
 
-  const { downloadAll, isDownloading } = useDownloadAllProjectFiles(projectId);
+  // Every role this table lists, not the hook's default of main and support:
+  // reviewer memos are rows here too, and "Download all" would otherwise hand
+  // back a zip quietly missing them.
+  const { downloadAll, isDownloading } = useDownloadAllProjectFiles(projectId, [
+    FileRole.Main,
+    FileRole.Support,
+    FileRole.ReviewerMemo,
+  ]);
 
   const referenceExtraction = getWorkflowRunByType(workflowRuns, WorkflowRunType.ReferenceExtraction);
   const referenceFileMatching = getWorkflowRunByType(workflowRuns, WorkflowRunType.ReferenceFileMatching);
@@ -59,10 +70,10 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
         composeReferences(
           referenceExtraction?.state?.extracted_references,
           referenceFileMatching?.state?.matches,
-          files,
+          allFiles,
         ),
       ),
-    [referenceExtraction?.state?.extracted_references, referenceFileMatching?.state?.matches, files],
+    [referenceExtraction?.state?.extracted_references, referenceFileMatching?.state?.matches, allFiles],
   );
 
   const sorted = useMemo(() => sortFiles(files), [files]);

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -12,8 +12,9 @@ import { buildReferenceByFileIdMap, composeReferences } from '@/lib/composed-ref
 import { FileListItem, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { cn } from '@/lib/utils';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
-import { Download, FileText, Loader2, PanelLeft, Search, Upload } from 'lucide-react';
+import { Download, FileText, Loader2, Search, Upload } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { Rail, RailToggle, SidePane, useRailState } from '../panes';
 import { FileDetail } from './file-detail';
 import { FileGroup, GROUP, fileGroup, revisionLabel, sortFiles } from './role';
 
@@ -36,7 +37,7 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
   const files = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
   const workflowRuns = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
 
-  const [railOpen, setRailOpen] = useState(true);
+  const rail = useRailState();
   const [lens, setLens] = useState<Lens>('all');
   const [search, setSearch] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -110,32 +111,20 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
         onComplete={() => setUploadOpen(false)}
       />
 
-      <aside
-        className={cn(
-          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
-          railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
-        )}
-      >
-        <KindRail lens={lens} onLensChange={setLens} counts={counts} />
-      </aside>
+      <Rail state={rail} label="Filters">
+        <KindRail
+          lens={lens}
+          onLensChange={(next) => {
+            setLens(next);
+            rail.close();
+          }}
+          counts={counts}
+        />
+      </Rail>
 
       <main className="flex min-w-0 flex-1 flex-col">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hidden size-7 xl:flex"
-                onClick={() => setRailOpen(!railOpen)}
-                aria-label={railOpen ? 'Hide filters' : 'Show filters'}
-                aria-pressed={railOpen}
-              >
-                <PanelLeft className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{railOpen ? 'Hide filters' : 'Show filters'}</TooltipContent>
-          </Tooltip>
+          <RailToggle state={rail} label="Filters" />
 
           <span className="shrink-0 truncate text-xs text-muted-foreground">
             {filtered ? `${shown.length} of ${counts.all} files` : `${counts.all} files`}
@@ -225,8 +214,19 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
       </main>
 
       {counts.all > 0 && (
-        <aside className="hidden w-[24rem] shrink-0 border-l lg:block xl:w-[26rem]">
-          {selected ? (
+        <SidePane
+          open={selected !== null}
+          onClose={() => setSelectedId(null)}
+          label="File details"
+          empty={
+            <div className="flex h-full items-center justify-center p-8">
+              <p className="max-w-56 text-center text-xs leading-relaxed text-muted-foreground">
+                Select a file to see more details, download it or remove it.
+              </p>
+            </div>
+          }
+        >
+          {selected && (
             <FileDetail
               key={selected.id}
               file={selected}
@@ -236,14 +236,8 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
               readOnly={readOnly}
               onReplaceMain={() => setReplaceOpen(true)}
             />
-          ) : (
-            <div className="flex h-full items-center justify-center p-8">
-              <p className="max-w-56 text-center text-xs leading-relaxed text-muted-foreground">
-                Select a file to see more details, download it or remove it.
-              </p>
-            </div>
           )}
-        </aside>
+        </SidePane>
       )}
     </div>
   );

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -283,17 +283,12 @@ function FileRow({
   const superseded = group === 'main' && file.revision !== currentRevision;
 
   return (
+    // The row keeps its own role: overriding it with `button` leaves the cells
+    // without a row parent in the accessibility tree. Clicking anywhere is a
+    // convenience; the file name is the real control, and the one keyboards and
+    // screen readers reach.
     <tr
-      role="button"
-      tabIndex={0}
-      aria-pressed={active}
       onClick={onSelect}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          onSelect();
-        }
-      }}
       className={cn(
         'cursor-pointer border-b transition-colors',
         active
@@ -302,10 +297,19 @@ function FileRow({
       )}
     >
       <td className="py-2.5 pl-4">
-        <span className="flex min-w-0 items-center gap-2">
+        <button
+          type="button"
+          aria-pressed={active}
+          onClick={(event) => {
+            // The row handles it; without this the click would select twice.
+            event.stopPropagation();
+            onSelect();
+          }}
+          className="flex w-full min-w-0 cursor-pointer items-center gap-2 text-left"
+        >
           <FileTypeIcon fileType={file.file_type} className="size-3.5 shrink-0 text-muted-foreground" />
           <span className={cn('truncate text-[13px]', superseded && 'text-muted-foreground')}>{file.file_name}</span>
-        </span>
+        </button>
         {matchedReferenceText && (
           <span className="mt-0.5 ml-[1.375rem] block truncate text-[11.5px] text-muted-foreground">
             {matchedReferenceText}

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -12,6 +12,7 @@ import { useExperimentalFeatures } from '@/context/experimental-features-context
 import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
 import { buildReferenceByFileIdMap, composeReferences } from '@/lib/composed-references';
 import { FileListItem, FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { RAIL_ITEM_ACTIVE, RAIL_ITEM_IDLE } from '@/lib/rail-style';
 import { cn } from '@/lib/utils';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
 import { Download, FileText, Loader2, Search, Upload } from 'lucide-react';
@@ -367,7 +368,7 @@ function KindRail({
                 aria-pressed={lens === entry.id}
                 className={cn(
                   'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
-                  lens === entry.id ? 'bg-accent text-accent-foreground font-medium' : 'hover:bg-accent/60',
+                  lens === entry.id ? RAIL_ITEM_ACTIVE : RAIL_ITEM_IDLE,
                 )}
               >
                 <span className="flex-1 truncate">{entry.label}</span>

--- a/frontend/components/results-v2/files/files-tab.tsx
+++ b/frontend/components/results-v2/files/files-tab.tsx
@@ -6,6 +6,7 @@ import { FileUploadDialog } from '@/components/results/tabs/reference-review/fil
 import { FileTypeIcon } from '@/components/shared/file-type-icon';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
 import { buildReferenceByFileIdMap, composeReferences } from '@/lib/composed-references';
 import { FileListItem, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
@@ -120,16 +121,21 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
 
       <main className="flex min-w-0 flex-1 flex-col">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="hidden size-7 xl:flex"
-            onClick={() => setRailOpen(!railOpen)}
-            aria-label={railOpen ? 'Hide filters' : 'Show filters'}
-            aria-pressed={railOpen}
-          >
-            <PanelLeft className="size-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hidden size-7 xl:flex"
+                onClick={() => setRailOpen(!railOpen)}
+                aria-label={railOpen ? 'Hide filters' : 'Show filters'}
+                aria-pressed={railOpen}
+              >
+                <PanelLeft className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{railOpen ? 'Hide filters' : 'Show filters'}</TooltipContent>
+          </Tooltip>
 
           <span className="shrink-0 truncate text-xs text-muted-foreground">
             {filtered ? `${shown.length} of ${counts.all} files` : `${counts.all} files`}
@@ -148,16 +154,26 @@ export function FilesTabV2({ projectDetail, readOnly, onRevisionCreated }: Files
 
           <div className="ml-auto flex shrink-0 items-center gap-1.5">
             {!readOnly && (
-              <Button size="xs" variant="outline" onClick={() => setUploadOpen(true)}>
-                <Upload className="size-3" />
-                Add files
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="xs" variant="outline" onClick={() => setUploadOpen(true)}>
+                    <Upload className="size-3" />
+                    Add files
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Add source documents or reviewer memos to this project</TooltipContent>
+              </Tooltip>
             )}
             {counts.all > 0 && (
-              <Button size="xs" variant="outline" disabled={isDownloading} onClick={() => downloadAll()}>
-                {isDownloading ? <Loader2 className="size-3 animate-spin" /> : <Download className="size-3" />}
-                {isDownloading ? 'Preparing zip…' : 'Download all'}
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="xs" variant="outline" disabled={isDownloading} onClick={() => downloadAll()}>
+                    {isDownloading ? <Loader2 className="size-3 animate-spin" /> : <Download className="size-3" />}
+                    {isDownloading ? 'Preparing zip…' : 'Download all'}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Download every file in this project as a zip</TooltipContent>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/frontend/components/results-v2/files/role.ts
+++ b/frontend/components/results-v2/files/role.ts
@@ -1,0 +1,52 @@
+import { FileListItem, FileRole } from '@/lib/generated-api';
+
+/** The three kinds of file a project holds, as the tab groups them. */
+export type FileGroup = 'main' | 'source' | 'memo';
+
+export const GROUP: Record<FileGroup, { label: string; plural: string; description: string; className: string }> = {
+  main: {
+    label: 'Main document',
+    plural: 'Main document',
+    description: 'The draft under review. Every assessment reads this document, and it is what the explorer shows.',
+    className: 'bg-primary/10 text-primary',
+  },
+  source: {
+    label: 'Source',
+    plural: 'Sources',
+    description: 'A document one of your references cites. Assessments that check citations read it.',
+    className: 'bg-secondary text-secondary-foreground',
+  },
+  memo: {
+    label: 'Reviewer memo',
+    plural: 'Reviewer memos',
+    description: 'Peer-review feedback on a draft, read by the Peer Review assessments.',
+    className: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200',
+  },
+};
+
+/** Supporting candidates read as sources too — the distinction is internal. */
+export function fileGroup(role: FileRole): FileGroup {
+  if (role === FileRole.Main) return 'main';
+  if (role === FileRole.ReviewerMemo) return 'memo';
+  return 'source';
+}
+
+/** The line under a role tag: which revision this file belongs to, and whether it still stands. */
+export function revisionLabel(file: FileListItem, currentRevision: number): string | null {
+  if (file.revision == null) return null;
+  if (file.role !== FileRole.Main) return `Revision ${file.revision}`;
+  return file.revision === currentRevision
+    ? `Revision ${file.revision} · current`
+    : `Revision ${file.revision} · superseded`;
+}
+
+/** Main first (newest revision first), then memos, then sources by name. */
+export function sortFiles(files: FileListItem[]): FileListItem[] {
+  const rank = (role: FileRole) => (role === FileRole.Main ? 0 : role === FileRole.ReviewerMemo ? 1 : 2);
+  return [...files].sort((a, b) => {
+    const byRank = rank(a.role) - rank(b.role);
+    if (byRank !== 0) return byRank;
+    if (a.role === FileRole.Main && b.role === FileRole.Main) return (b.revision ?? 0) - (a.revision ?? 0);
+    return (a.file_name || '').localeCompare(b.file_name || '');
+  });
+}

--- a/frontend/components/results-v2/files/role.ts
+++ b/frontend/components/results-v2/files/role.ts
@@ -24,7 +24,7 @@ export const GROUP: Record<FileGroup, { label: string; plural: string; descripti
   },
 };
 
-/** Supporting candidates read as sources too — the distinction is internal. */
+/** Supporting candidates are filtered out before this, and read as sources if any slip through. */
 export function fileGroup(role: FileRole): FileGroup {
   if (role === FileRole.Main) return 'main';
   if (role === FileRole.ReviewerMemo) return 'memo';

--- a/frontend/components/results-v2/new-assessment-button.tsx
+++ b/frontend/components/results-v2/new-assessment-button.tsx
@@ -49,9 +49,11 @@ export function NewAssessmentButton({ projectId }: { projectId: string }) {
 
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button size="xs" onClick={() => setOpen(true)}>
+          <Button size="xs" onClick={() => setOpen(true)} aria-label="Run assessments">
             <PlayIcon />
-            Run assessments
+            {/* A phone header cannot carry five labelled controls; here the
+                icon and its tooltip say it instead. */}
+            <span className="hidden sm:inline">Run assessments</span>
           </Button>
         </TooltipTrigger>
         <TooltipContent>Choose assessments to run on this document</TooltipContent>

--- a/frontend/components/results-v2/new-assessment-button.tsx
+++ b/frontend/components/results-v2/new-assessment-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { WorkflowConfigDialog, WorkflowConfigFormValues } from '@/components/workflows/workflow-config-dialog';
+import { getErrorMessage } from '@/lib/api-error';
+import { startMultipleWorkflowsApiWorkflowsStartMultiplePost } from '@/lib/generated-api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { PlayIcon } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Starts assessments from the project header, so it is reachable from every
+ * tab. Running one is the thing people come back to do, and burying it in the
+ * Assessments tab made it a two-step trip from wherever they were reading.
+ *
+ * "Run", not "New": nothing is created here. The dialog is a multi-select over
+ * the assessments that already exist, and every other control in this view
+ * speaks the same way — "Ready to run", "Run more", "Re-run X".
+ */
+export function NewAssessmentButton({ projectId }: { projectId: string }) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { mutate: startWorkflows } = useMutation({
+    mutationFn: (values: WorkflowConfigFormValues) =>
+      startMultipleWorkflowsApiWorkflowsStartMultiplePost({
+        body: { project_id: projectId, workflow_types: values.workflowTypes },
+      }),
+    onSuccess: () => {
+      toast.success('Assessments started');
+      queryClient.invalidateQueries({ queryKey: ['project', projectId] });
+    },
+    onError: (error) => toast.error(getErrorMessage(error, 'Failed to start assessments')),
+  });
+
+  return (
+    <>
+      <WorkflowConfigDialog
+        isOpen={open}
+        projectId={projectId}
+        onConfirm={(values) => {
+          setOpen(false);
+          startWorkflows(values);
+        }}
+        onCancel={() => setOpen(false)}
+      />
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="xs" onClick={() => setOpen(true)}>
+            <PlayIcon />
+            Run assessments
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Choose assessments to run on this document</TooltipContent>
+      </Tooltip>
+    </>
+  );
+}

--- a/frontend/components/results-v2/old-revision-banner.tsx
+++ b/frontend/components/results-v2/old-revision-banner.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { HelpCenter } from '@/components/help/help-center';
+import { HelpLink } from '@/components/help/help-link';
 import { Button } from '@/components/ui/button';
 import { History } from 'lucide-react';
-import { useState } from 'react';
 
 interface OldRevisionBannerProps {
   selectedRevision: number;
@@ -18,8 +17,6 @@ interface OldRevisionBannerProps {
  * notice would otherwise scroll away and take the explanation with it.
  */
 export function OldRevisionBanner({ selectedRevision, currentRevision, onViewCurrent }: OldRevisionBannerProps) {
-  const [showExplanation, setShowExplanation] = useState(false);
-
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-blue-50 px-3 py-2 dark:bg-blue-950/30">
       <History className="size-4 shrink-0 text-blue-700 dark:text-blue-400" />
@@ -28,12 +25,7 @@ export function OldRevisionBanner({ selectedRevision, currentRevision, onViewCur
         <span className="text-muted-foreground">
           This is an earlier draft, kept as it was, so nothing here can be changed.
         </span>{' '}
-        <button
-          onClick={() => setShowExplanation(true)}
-          className="cursor-pointer text-muted-foreground underline underline-offset-2 hover:text-foreground"
-        >
-          What this is
-        </button>
+        <HelpLink topic="revisions">What this is</HelpLink>
       </p>
 
       {onViewCurrent && (
@@ -43,8 +35,6 @@ export function OldRevisionBanner({ selectedRevision, currentRevision, onViewCur
           </Button>
         </div>
       )}
-
-      <HelpCenter open={showExplanation} onOpenChange={setShowExplanation} topic="revisions" />
     </div>
   );
 }

--- a/frontend/components/results-v2/old-revision-banner.tsx
+++ b/frontend/components/results-v2/old-revision-banner.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { HelpCenter } from '@/components/help/help-center';
 import { Button } from '@/components/ui/button';
 import { History } from 'lucide-react';
+import { useState } from 'react';
 
 interface OldRevisionBannerProps {
   selectedRevision: number;
@@ -16,6 +18,8 @@ interface OldRevisionBannerProps {
  * notice would otherwise scroll away and take the explanation with it.
  */
 export function OldRevisionBanner({ selectedRevision, currentRevision, onViewCurrent }: OldRevisionBannerProps) {
+  const [showExplanation, setShowExplanation] = useState(false);
+
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-blue-50 px-3 py-2 dark:bg-blue-950/30">
       <History className="size-4 shrink-0 text-blue-700 dark:text-blue-400" />
@@ -23,7 +27,13 @@ export function OldRevisionBanner({ selectedRevision, currentRevision, onViewCur
         <strong className="font-medium">Viewing revision {selectedRevision}.</strong>{' '}
         <span className="text-muted-foreground">
           This is an earlier draft, kept as it was, so nothing here can be changed.
-        </span>
+        </span>{' '}
+        <button
+          onClick={() => setShowExplanation(true)}
+          className="cursor-pointer text-muted-foreground underline underline-offset-2 hover:text-foreground"
+        >
+          What this is
+        </button>
       </p>
 
       {onViewCurrent && (
@@ -33,6 +43,8 @@ export function OldRevisionBanner({ selectedRevision, currentRevision, onViewCur
           </Button>
         </div>
       )}
+
+      <HelpCenter open={showExplanation} onOpenChange={setShowExplanation} topic="revisions" />
     </div>
   );
 }

--- a/frontend/components/results-v2/old-revision-banner.tsx
+++ b/frontend/components/results-v2/old-revision-banner.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { History } from 'lucide-react';
+
+interface OldRevisionBannerProps {
+  selectedRevision: number;
+  currentRevision: number;
+  onViewCurrent?: () => void;
+}
+
+/**
+ * The strip that appears while an earlier revision is on screen. It sits in the
+ * chrome rather than at the top of the document, because everything below it
+ * belongs to that revision — its issues, its files, its results — and the
+ * notice would otherwise scroll away and take the explanation with it.
+ */
+export function OldRevisionBanner({ selectedRevision, currentRevision, onViewCurrent }: OldRevisionBannerProps) {
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-blue-50 px-3 py-2 dark:bg-blue-950/30">
+      <History className="size-4 shrink-0 text-blue-700 dark:text-blue-400" />
+      <p className="min-w-0 text-sm">
+        <strong className="font-medium">Viewing revision {selectedRevision}.</strong>{' '}
+        <span className="text-muted-foreground">
+          This is an earlier draft, kept as it was, so nothing here can be changed.
+        </span>
+      </p>
+
+      {onViewCurrent && (
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <Button size="xs" variant="outline" className="h-6" onClick={onViewCurrent}>
+            View revision {currentRevision}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/results-v2/panes.tsx
+++ b/frontend/components/results-v2/panes.tsx
@@ -57,7 +57,7 @@ export function Rail({ state, label, children }: { state: RailState; label: stri
 
   return (
     <Sheet open={state.isOpen} onOpenChange={(open) => !open && state.close()}>
-      <SheetContent side="left" showCloseButton={false} className="bg-sidebar w-80 gap-0 p-0 sm:max-w-sm">
+      <SheetContent side="left" showCloseButton={false} className="bg-sidebar w-full max-w-80 gap-0 p-0">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b px-4">
           <SheetTitle className="text-xs font-medium">{label}</SheetTitle>
           <SheetDescription className="sr-only">{label}</SheetDescription>
@@ -142,7 +142,9 @@ export function SidePane({ open, onClose, label, empty, className, children }: S
       {/* Its own titled bar rather than the sheet's floating close button: that
           button sits exactly where these panes put their own header content,
           and overlapped it. */}
-      <SheetContent side="right" showCloseButton={false} className="w-[26rem] gap-0 p-0 sm:max-w-md">
+      {/* Width capped by the viewport: a fixed 26rem runs off the left edge of a
+          phone, putting part of every detail pane out of reach. */}
+      <SheetContent side="right" showCloseButton={false} className="w-full max-w-[26rem] gap-0 p-0">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b px-4">
           <SheetTitle className="text-xs font-medium">{label}</SheetTitle>
           <SheetDescription className="sr-only">{label}</SheetDescription>

--- a/frontend/components/results-v2/panes.tsx
+++ b/frontend/components/results-v2/panes.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetClose, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { WIDE_ENOUGH_FOR_PANE, WIDE_ENOUGH_FOR_RAIL, useMediaQuery } from '@/lib/use-media-query';
+import { cn } from '@/lib/utils';
+import { PanelLeft, X } from 'lucide-react';
+import { ReactNode, useState } from 'react';
+
+export interface RailState {
+  /** There is room for the rail to sit beside the content. */
+  isWide: boolean;
+  isOpen: boolean;
+  toggle: () => void;
+  close: () => void;
+}
+
+/**
+ * Whether the rail is showing, and how it shows.
+ *
+ * Wide enough and it is a column that collapses to nothing; narrower and it is
+ * a sheet over the content. Two states rather than one, because the sensible
+ * default differs: a column starts open, an overlay starts closed.
+ */
+export function useRailState(): RailState {
+  const isWide = useMediaQuery(WIDE_ENOUGH_FOR_RAIL);
+  const [columnOpen, setColumnOpen] = useState(true);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  return {
+    isWide,
+    isOpen: isWide ? columnOpen : sheetOpen,
+    toggle: () => (isWide ? setColumnOpen((open) => !open) : setSheetOpen((open) => !open)),
+    close: () => setSheetOpen(false),
+  };
+}
+
+/**
+ * The left rail: a column beside the content, or a sheet over it. Rendered in
+ * one place or the other, never both, so anything stateful inside keeps its
+ * state instead of running twice.
+ */
+export function Rail({ state, label, children }: { state: RailState; label: string; children: ReactNode }) {
+  if (state.isWide) {
+    return (
+      <aside
+        className={cn(
+          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
+          state.isOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
+        )}
+      >
+        {children}
+      </aside>
+    );
+  }
+
+  return (
+    <Sheet open={state.isOpen} onOpenChange={(open) => !open && state.close()}>
+      <SheetContent side="left" showCloseButton={false} className="bg-sidebar w-80 gap-0 p-0 sm:max-w-sm">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b px-4">
+          <SheetTitle className="text-xs font-medium">{label}</SheetTitle>
+          <SheetDescription className="sr-only">{label}</SheetDescription>
+          <SheetClose asChild>
+            <Button variant="ghost" size="icon" className="ml-auto size-7" aria-label={`Close ${label.toLowerCase()}`}>
+              <X className="size-4" />
+            </Button>
+          </SheetClose>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/**
+ * The button that shows and hides the rail, in the tab's toolbar.
+ *
+ * Icon alone where the rail is a column — it is right there, and its heading
+ * says what it holds. Icon and label where it is a sheet, since nothing else
+ * on screen says what pressing this would bring out.
+ */
+export function RailToggle({ state, label }: { state: RailState; label: string }) {
+  const hint = `${state.isOpen && state.isWide ? 'Hide' : 'Show'} ${label.toLowerCase()}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size={state.isWide ? 'icon' : 'xs'}
+          className={cn('shrink-0', state.isWide && 'size-7')}
+          onClick={state.toggle}
+          aria-label={hint}
+          aria-pressed={state.isOpen}
+        >
+          <PanelLeft className={state.isWide ? 'size-4' : 'size-3.5'} />
+          {!state.isWide && label}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{hint}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+interface SidePaneProps {
+  /** Something is selected, or the reader asked for the pane. */
+  open: boolean;
+  onClose: () => void;
+  /** Names the sheet for screen readers when it opens over the content. */
+  label: string;
+  /** Shown in the column while nothing is selected. Never in the sheet. */
+  empty?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * The right-hand pane: a column beside the content where there is room, and a
+ * dismissible sheet over it where there is not. Below that width the pane only
+ * appears once the reader asks for it, by selecting a row or pressing the
+ * control that opens it.
+ */
+export function SidePane({ open, onClose, label, empty, className, children }: SidePaneProps) {
+  const isWide = useMediaQuery(WIDE_ENOUGH_FOR_PANE);
+
+  if (isWide) {
+    // Nothing to show and nothing to say in its place: take no width at all.
+    // The document explorer's margin mode relies on this — the issues are
+    // already beside the text, so an empty column would only squeeze it.
+    if (!open && !empty) return null;
+
+    return (
+      <aside className={cn('hidden w-[24rem] shrink-0 border-l lg:block xl:w-[26rem]', className)}>
+        {open ? children : empty}
+      </aside>
+    );
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={(next) => !next && onClose()}>
+      {/* Its own titled bar rather than the sheet's floating close button: that
+          button sits exactly where these panes put their own header content,
+          and overlapped it. */}
+      <SheetContent side="right" showCloseButton={false} className="w-[26rem] gap-0 p-0 sm:max-w-md">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b px-4">
+          <SheetTitle className="text-xs font-medium">{label}</SheetTitle>
+          <SheetDescription className="sr-only">{label}</SheetDescription>
+          <SheetClose asChild>
+            <Button variant="ghost" size="icon" className="ml-auto size-7" aria-label={`Close ${label.toLowerCase()}`}>
+              <X className="size-4" />
+            </Button>
+          </SheetClose>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/components/results-v2/peer-review-v2-panel.tsx
+++ b/frontend/components/results-v2/peer-review-v2-panel.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useProjectView } from '@/components/results/project-view-context';
+import { PeerReviewTabV2 } from './peer-review/peer-review-tab';
+
+/** Hash format the document explorer understands: `#L5` or `#L5-12`. */
+function lineRangeHash(lineRange?: [number, number]): string | undefined {
+  if (!lineRange) return undefined;
+  const [start, end] = lineRange;
+  return start === end ? `#L${start}` : `#L${start}-${end}`;
+}
+
+/** The v2 peer review tab as a tab panel, taking its project from the shell. */
+export function PeerReviewV2Panel() {
+  const { projectDetail, readOnly, onRevisionChange, onRevisionCreated, navigateToTab } = useProjectView();
+
+  return (
+    <PeerReviewTabV2
+      projectDetail={projectDetail}
+      readOnly={readOnly}
+      onRevisionChange={onRevisionChange}
+      onRevisionCreated={onRevisionCreated}
+      onNavigateToDocumentExplorer={(lineRange) => navigateToTab('document-explorer', lineRangeHash(lineRange))}
+    />
+  );
+}

--- a/frontend/components/results-v2/peer-review-v2-panel.tsx
+++ b/frontend/components/results-v2/peer-review-v2-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useProjectView } from '@/components/results/project-view-context';
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { PeerReviewTabV2 } from './peer-review/peer-review-tab';
 
 /** Hash format the document explorer understands: `#L5` or `#L5-12`. */
@@ -13,6 +14,23 @@ function lineRangeHash(lineRange?: [number, number]): string | undefined {
 /** The v2 peer review tab as a tab panel, taking its project from the shell. */
 export function PeerReviewV2Panel() {
   const { projectDetail, readOnly, onRevisionChange, onRevisionCreated, navigateToTab } = useProjectView();
+  // Peer Review is still alpha: the tab, and the route behind it, exist only
+  // for users who opted in.
+  const { showExperimentalFeatures, isLoading } = useExperimentalFeatures();
+
+  if (isLoading) return null;
+
+  if (!showExperimentalFeatures) {
+    // Reachable from a bookmark or a shared link, since the tab itself is hidden.
+    return (
+      <div className="flex h-full items-center justify-center p-8">
+        <p className="max-w-sm text-center text-sm leading-relaxed text-muted-foreground">
+          Peer Review is an alpha feature. Turn on <strong className="font-medium">Alpha features</strong> in your
+          profile menu to use it.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <PeerReviewTabV2

--- a/frontend/components/results-v2/peer-review/memos-pane.tsx
+++ b/frontend/components/results-v2/peer-review/memos-pane.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { formatFileSize } from '@/components/analysis-form/utils';
+import { PeerReviewFacts } from '@/components/results/tabs/peer-review/peer-review-derive';
+import { useRemoveFileMutation } from '@/components/results/tabs/reference-review/mutations';
+import { FileTypeIcon } from '@/components/shared/file-type-icon';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { FileDownloadLink } from '@/components/ui/file-download-link';
+import { FileListItem } from '@/lib/generated-api';
+import { Loader2, Trash2, Upload } from 'lucide-react';
+import { useState } from 'react';
+
+interface MemosPaneProps {
+  facts: PeerReviewFacts;
+  projectId: string;
+  readOnly: boolean;
+  onUploadMemos: () => void;
+}
+
+/**
+ * The reviewer memos every step reads from. A pane rather than a card above
+ * the steps: it is the input to all four of them, so it belongs beside the
+ * work rather than scrolling away above it.
+ */
+export function MemosPane({ facts, projectId, readOnly, onUploadMemos }: MemosPaneProps) {
+  const { activeMemos, reviewedRevision, staleMemoRevisions, memos } = facts;
+  const ignored = memos.filter((memo) => memo.revision !== reviewedRevision);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="bg-background/90 sticky top-0 z-10 flex h-10 shrink-0 items-center gap-2 border-b px-4 backdrop-blur">
+        <span className="text-xs font-medium">Reviewer memos</span>
+        <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{activeMemos.length}</span>
+        {!readOnly && (
+          <Button size="xs" variant="outline" className="ml-auto" onClick={onUploadMemos}>
+            <Upload className="size-3" />
+            Add
+          </Button>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4">
+        <section>
+          <h3 className="mb-2 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">
+            On revision {reviewedRevision}
+          </h3>
+          <ul className="space-y-1.5">
+            {activeMemos.map((memo) => (
+              <MemoRow key={memo.id} memo={memo} projectId={projectId} readOnly={readOnly} />
+            ))}
+          </ul>
+        </section>
+
+        {ignored.length > 0 && (
+          // `max()` is not "most recently uploaded": memos targeting an older
+          // revision than an existing batch are silently ignored by the agent.
+          // Unexplained, that behaviour is inexplicable — so say it, and list
+          // them here so it can be acted on without leaving the tab.
+          <section>
+            <h3 className="mb-2 font-mono text-[10px] tracking-wide text-amber-700 uppercase dark:text-amber-400">
+              Not being read
+            </h3>
+            <p className="mb-2 text-[11.5px] leading-relaxed text-muted-foreground">
+              {ignored.length} memo{ignored.length === 1 ? '' : 's'} on revision {staleMemoRevisions.join(', ')}{' '}
+              {ignored.length === 1 ? 'is' : 'are'} ignored — the steps read only revision {reviewedRevision}, the most
+              recent draft that has any. Remove {ignored.length === 1 ? 'it' : 'them'}, or upload again targeting
+              revision {reviewedRevision}.
+            </p>
+            <ul className="space-y-1.5 opacity-70">
+              {ignored.map((memo) => (
+                <MemoRow key={memo.id} memo={memo} projectId={projectId} readOnly={readOnly} showRevision />
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MemoRow({
+  memo,
+  projectId,
+  readOnly,
+  showRevision = false,
+}: {
+  memo: FileListItem;
+  projectId: string;
+  readOnly: boolean;
+  /** Ignored memos can span several revisions, so each says which it belongs to. */
+  showRevision?: boolean;
+}) {
+  const [removeOpen, setRemoveOpen] = useState(false);
+  const removeFile = useRemoveFileMutation(projectId, memo.id);
+
+  return (
+    <li className="flex items-center gap-2 rounded-md border px-2.5 py-2">
+      <FileTypeIcon fileType={memo.file_type} className="size-3.5 shrink-0 text-muted-foreground" />
+      <FileDownloadLink fileId={memo.id} className="text-primary min-w-0 flex-1 truncate text-[12.5px] hover:underline">
+        {memo.file_name || 'Unknown'}
+      </FileDownloadLink>
+      {showRevision && memo.revision != null && (
+        <span className="bg-muted shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          Rev {memo.revision}
+        </span>
+      )}
+      <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+        {formatFileSize(memo.file_size)}
+      </span>
+
+      {!readOnly && (
+        <>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-6 shrink-0"
+            disabled={removeFile.isPending}
+            onClick={() => setRemoveOpen(true)}
+            aria-label="Remove memo"
+          >
+            {removeFile.isPending ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <Trash2 className="size-3 text-muted-foreground" />
+            )}
+          </Button>
+
+          <AlertDialog open={removeOpen} onOpenChange={setRemoveOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Remove this reviewer memo?</AlertDialogTitle>
+                <AlertDialogDescription className="break-all">
+                  {memo.file_name} will be removed from the project. Steps you run afterwards will no longer read it.
+                  Reports already generated are unaffected.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={() => removeFile.mutate()}>Remove</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
+      )}
+    </li>
+  );
+}

--- a/frontend/components/results-v2/peer-review/peer-review-tab.tsx
+++ b/frontend/components/results-v2/peer-review/peer-review-tab.tsx
@@ -8,9 +8,10 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { SimpleDeepAgentResults } from '@/components/workflows/results/simple-deep-agent-results';
 import { FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
-import { cn } from '@/lib/utils';
-import { ClipboardCheck, History, ListChecks, Lock, MessagesSquare, PanelLeft, Upload } from 'lucide-react';
+import { WIDE_ENOUGH_FOR_PANE, useMediaQuery } from '@/lib/use-media-query';
+import { ClipboardCheck, History, ListChecks, Lock, MessagesSquare, Upload } from 'lucide-react';
 import { ReactNode, useState } from 'react';
+import { Rail, RailToggle, SidePane, useRailState } from '../panes';
 import { MemosPane } from './memos-pane';
 import { StepRail } from './step-rail';
 import { STEPS, StepId, readStepStates } from './steps';
@@ -40,7 +41,9 @@ export function PeerReviewTabV2({
   const { facts, planFallback, startStage, cancelRun, isStarting } = usePeerReviewState({ projectDetail });
   const { runs, currentRevision, reviewedRevision, hasRevisedDraft, isViewingOldRevision } = facts;
 
-  const [railOpen, setRailOpen] = useState(true);
+  const rail = useRailState();
+  const isWideEnoughForMemos = useMediaQuery(WIDE_ENOUGH_FOR_PANE);
+  const [memosOpen, setMemosOpen] = useState(false);
   const [memoUploadOpen, setMemoUploadOpen] = useState(false);
   const [revisionDialogOpen, setRevisionDialogOpen] = useState(false);
 
@@ -115,32 +118,20 @@ export function PeerReviewTabV2({
         hideRerunOption
       />
 
-      <aside
-        className={cn(
-          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
-          railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
-        )}
-      >
-        <StepRail states={states} activeStep={activeStep} onSelectStep={setActiveStep} />
-      </aside>
+      <Rail state={rail} label="Steps">
+        <StepRail
+          states={states}
+          activeStep={activeStep}
+          onSelectStep={(step) => {
+            setActiveStep(step);
+            rail.close();
+          }}
+        />
+      </Rail>
 
       <main className="flex min-w-0 flex-1 flex-col">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hidden size-7 xl:flex"
-                onClick={() => setRailOpen(!railOpen)}
-                aria-label={railOpen ? 'Hide steps' : 'Show steps'}
-                aria-pressed={railOpen}
-              >
-                <PanelLeft className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{railOpen ? 'Hide steps' : 'Show steps'}</TooltipContent>
-          </Tooltip>
+          <RailToggle state={rail} label="Steps" />
 
           <span className="min-w-0 truncate text-xs text-muted-foreground">
             Step {stepIndex + 1} of {STEPS.length}
@@ -159,6 +150,19 @@ export function PeerReviewTabV2({
               </>
             )}
             {!readOnly && !state.blockedReason && <ToolbarAction />}
+
+            {!isWideEnoughForMemos && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="xs" variant="outline" onClick={() => setMemosOpen(true)}>
+                    <MessagesSquare className="size-3" />
+                    Memos
+                    <span className="font-mono tabular-nums">{facts.activeMemos.length}</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>The reviewer memos every step reads from</TooltipContent>
+              </Tooltip>
+            )}
           </span>
         </div>
 
@@ -186,14 +190,21 @@ export function PeerReviewTabV2({
         </div>
       </main>
 
-      <aside className="hidden w-[22rem] shrink-0 border-l lg:block xl:w-[24rem]">
+      {/* Always a column where there is room; a sheet the reader opens where
+          there is not, since the memos are context rather than a selection. */}
+      <SidePane
+        open={isWideEnoughForMemos || memosOpen}
+        onClose={() => setMemosOpen(false)}
+        label="Reviewer memos"
+        className="w-[22rem] xl:w-[24rem]"
+      >
         <MemosPane
           facts={facts}
           projectId={projectId}
           readOnly={readOnly}
           onUploadMemos={() => setMemoUploadOpen(true)}
         />
-      </aside>
+      </SidePane>
     </div>
   );
 

--- a/frontend/components/results-v2/peer-review/peer-review-tab.tsx
+++ b/frontend/components/results-v2/peer-review/peer-review-tab.tsx
@@ -1,0 +1,437 @@
+'use client';
+
+import { ReplaceMainDocumentDialog } from '@/components/results/components/replace-main-document-dialog';
+import { PeerReviewStageAction } from '@/components/results/tabs/peer-review/peer-review-stage-card';
+import { usePeerReviewState } from '@/components/results/tabs/peer-review/use-peer-review-state';
+import { FileUploadDialog } from '@/components/results/tabs/reference-review/file-upload-dialog';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { SimpleDeepAgentResults } from '@/components/workflows/results/simple-deep-agent-results';
+import { FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import { ClipboardCheck, History, ListChecks, Lock, MessagesSquare, PanelLeft, Upload } from 'lucide-react';
+import { ReactNode, useState } from 'react';
+import { MemosPane } from './memos-pane';
+import { StepRail } from './step-rail';
+import { STEPS, StepId, readStepStates } from './steps';
+
+interface PeerReviewTabV2Props {
+  projectDetail: ProjectDetailed;
+  readOnly: boolean;
+  onRevisionChange?: (revision: number) => void;
+  onRevisionCreated?: () => void;
+  onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
+}
+
+/**
+ * Peer review in the v2 frame. The rail is a stepper rather than a filter, the
+ * pane holds one step at a time, and the memos every step reads from sit in
+ * the right pane — where they stay in view instead of scrolling away above the
+ * work, as the card above the steps used to.
+ */
+export function PeerReviewTabV2({
+  projectDetail,
+  readOnly,
+  onRevisionChange,
+  onRevisionCreated,
+  onNavigateToDocumentExplorer,
+}: PeerReviewTabV2Props) {
+  const projectId = projectDetail.project.id;
+  const { facts, planFallback, startStage, cancelRun, isStarting } = usePeerReviewState({ projectDetail });
+  const { runs, currentRevision, reviewedRevision, hasRevisedDraft, isViewingOldRevision } = facts;
+
+  const [railOpen, setRailOpen] = useState(true);
+  const [memoUploadOpen, setMemoUploadOpen] = useState(false);
+  const [revisionDialogOpen, setRevisionDialogOpen] = useState(false);
+
+  // The plan for the reviewed draft stays relevant once a newer revision
+  // exists, so fall back to the run on that revision rather than showing an
+  // empty first step.
+  const planRun = runs.plan ?? planFallback?.run;
+  const planRunRevision = runs.plan ? facts.viewedRevision : planFallback?.revision;
+  const planRunProject = runs.plan ? projectDetail : (planFallback?.projectDetail ?? projectDetail);
+  const states = readStepStates(facts, planRun);
+
+  // Land on the furthest step with something to show. Held in state rather than
+  // recomputed, so the project poll cannot move the selection out from under
+  // someone who is reading.
+  const [activeStep, setActiveStep] = useState<StepId>(() => {
+    if (runs.coverage) return 'coverage';
+    if (runs.memos || hasRevisedDraft) return 'respond';
+    if (states.plan.complete) return 'revise';
+    return 'plan';
+  });
+
+  const stepIndex = STEPS.findIndex((step) => step.id === activeStep);
+  const step = STEPS[stepIndex];
+  const state = states[activeStep];
+
+  const memoDialog = (
+    <FileUploadDialog
+      isOpen={memoUploadOpen}
+      projectId={projectId}
+      title="Upload reviewer memos"
+      description="Add the memos your peer reviewers returned. They are read against the draft the reviewers saw."
+      multiple
+      fileRole={FileRole.ReviewerMemo}
+      allowRevisionSelection
+      currentRevision={currentRevision}
+      onCancel={() => setMemoUploadOpen(false)}
+      onComplete={() => setMemoUploadOpen(false)}
+    />
+  );
+
+  if (reviewedRevision === null) {
+    return (
+      <div className="flex h-full items-center justify-center p-8">
+        <div className="max-w-md space-y-3 text-center">
+          <MessagesSquare className="mx-auto size-7 text-muted-foreground" />
+          <p className="text-sm font-medium">No reviewer memos yet</p>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Once your draft comes back from peer review, upload the reviewers&apos; memos here. Draft Detective turns
+            their points into a revision plan, then — after you upload your revised draft — drafts a response memo per
+            reviewer and a coverage report for a QA manager.
+          </p>
+          {!readOnly && (
+            <Button size="sm" className="mt-1" onClick={() => setMemoUploadOpen(true)}>
+              <Upload className="size-3.5" />
+              Upload reviewer memos
+            </Button>
+          )}
+        </div>
+        {memoDialog}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0">
+      {memoDialog}
+      <ReplaceMainDocumentDialog
+        isOpen={revisionDialogOpen}
+        projectId={projectId}
+        onClose={() => setRevisionDialogOpen(false)}
+        onRevisionCreated={onRevisionCreated}
+        hideRerunOption
+      />
+
+      <aside
+        className={cn(
+          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
+          railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
+        )}
+      >
+        <StepRail states={states} activeStep={activeStep} onSelectStep={setActiveStep} />
+      </aside>
+
+      <main className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hidden size-7 xl:flex"
+                onClick={() => setRailOpen(!railOpen)}
+                aria-label={railOpen ? 'Hide steps' : 'Show steps'}
+                aria-pressed={railOpen}
+              >
+                <PanelLeft className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{railOpen ? 'Hide steps' : 'Show steps'}</TooltipContent>
+          </Tooltip>
+
+          <span className="min-w-0 truncate text-xs text-muted-foreground">
+            Step {stepIndex + 1} of {STEPS.length}
+          </span>
+
+          <span className="ml-auto flex shrink-0 items-center gap-1.5">
+            {isViewingOldRevision && onRevisionChange && (
+              <>
+                <span className="text-xs text-muted-foreground">
+                  Viewing revision {facts.viewedRevision}; the steps run on revision {currentRevision}
+                </span>
+                <Button size="xs" variant="outline" onClick={() => onRevisionChange(currentRevision)}>
+                  <History className="size-3" />
+                  View current
+                </Button>
+              </>
+            )}
+            {!readOnly && !state.blockedReason && <ToolbarAction />}
+          </span>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-4xl px-6 py-5">
+            <header className="border-b pb-4">
+              <h1 className="text-base font-semibold tracking-tight">{step.title}</h1>
+              <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">{step.subtitle}</p>
+            </header>
+
+            <div className="pt-4">
+              {state.blockedReason ? (
+                <Blocked reason={state.blockedReason} />
+              ) : activeStep === 'plan' ? (
+                <PlanStep />
+              ) : activeStep === 'revise' ? (
+                <ReviseStep />
+              ) : activeStep === 'respond' ? (
+                <RespondStep />
+              ) : (
+                <CoverageStep />
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <aside className="hidden w-[22rem] shrink-0 border-l lg:block xl:w-[24rem]">
+        <MemosPane
+          facts={facts}
+          projectId={projectId}
+          readOnly={readOnly}
+          onUploadMemos={() => setMemoUploadOpen(true)}
+        />
+      </aside>
+    </div>
+  );
+
+  /**
+   * The current step's action. Only for steps that already produced something:
+   * a step with nothing yet carries its button in the call to action, where it
+   * sits under the description explaining what it will do.
+   */
+  function ToolbarAction() {
+    if (activeStep === 'plan' && planRun) {
+      return (
+        <PeerReviewStageAction
+          label="Generate planning summary"
+          reRunLabel={planFallback ? `Generate again for revision ${currentRevision}` : undefined}
+          run={planRun}
+          disabled={false}
+          isStarting={isStarting}
+          size="xs"
+          onStart={() => startStage([WorkflowRunType.RevisionPlanningSummary])}
+          onCancel={cancelRun}
+        />
+      );
+    }
+    if (activeStep === 'revise' && hasRevisedDraft) {
+      return (
+        <Button variant="outline" size="xs" onClick={() => setRevisionDialogOpen(true)}>
+          <Upload className="size-3" />
+          Create another revision
+        </Button>
+      );
+    }
+    if (activeStep === 'respond' && runs.memos) {
+      return (
+        <PeerReviewStageAction
+          label="Generate response memos"
+          run={runs.memos}
+          disabled={false}
+          isStarting={isStarting}
+          size="xs"
+          onStart={() => startStage([WorkflowRunType.ReviewerResponseMemos])}
+          onCancel={cancelRun}
+        />
+      );
+    }
+    if (activeStep === 'coverage' && runs.coverage) {
+      return (
+        <PeerReviewStageAction
+          label="Generate coverage report"
+          run={runs.coverage}
+          disabled={false}
+          isStarting={isStarting}
+          size="xs"
+          onStart={() => startStage([WorkflowRunType.ReviewerCoverageReport])}
+          onCancel={cancelRun}
+        />
+      );
+    }
+    return null;
+  }
+
+  function PlanStep() {
+    if (!planRun) {
+      return (
+        <StepCta
+          icon={ListChecks}
+          title="Turn the reviewers' memos into a revision plan"
+          description={`Reads the ${facts.activeMemos.length} memo${facts.activeMemos.length === 1 ? '' : 's'} on revision ${reviewedRevision} against that revision's draft, reproduces each memo verbatim, and adds a planning note under every point.`}
+          action={
+            !readOnly && (
+              <PeerReviewStageAction
+                label="Generate planning summary"
+                disabled={false}
+                isStarting={isStarting}
+                size="default"
+                onStart={() => startStage([WorkflowRunType.RevisionPlanningSummary])}
+                onCancel={cancelRun}
+              />
+            )
+          }
+        />
+      );
+    }
+
+    return (
+      <div className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Based on revision {planRunRevision} — the draft your reviewers read, and the {facts.activeMemos.length} memo
+          {facts.activeMemos.length === 1 ? '' : 's'} attached to it.
+          {planFallback && ' It still applies: those memos have not changed.'}
+        </p>
+        <Results>
+          <SimpleDeepAgentResults
+            project={planRunProject}
+            workflowDetail={planRun}
+            workflowName="Revision-Planning Summary"
+            onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+          />
+        </Results>
+      </div>
+    );
+  }
+
+  function ReviseStep() {
+    if (!hasRevisedDraft) {
+      return (
+        <StepCta
+          icon={Upload}
+          title="Upload the draft you revised"
+          description={`Revision ${reviewedRevision} is the draft your reviewers read. Uploading your revised version creates a new revision — revision ${reviewedRevision} and all its results are kept, and steps 3 and 4 compare the two.`}
+          action={
+            !readOnly && (
+              <Button onClick={() => setRevisionDialogOpen(true)}>
+                <Upload className="size-4" />
+                Upload revised draft
+              </Button>
+            )
+          }
+        />
+      );
+    }
+
+    return (
+      <p className="text-[13px] leading-relaxed text-muted-foreground">
+        Revision {currentRevision} is your revised draft. Revision {reviewedRevision} is kept as the draft the reviewers
+        read, and steps 3 and 4 compare the two.
+      </p>
+    );
+  }
+
+  function RespondStep() {
+    if (!runs.memos) {
+      return (
+        <StepCta
+          icon={MessagesSquare}
+          title="Draft a reply to every reviewer point"
+          description={`One response memo per reviewer. Compares revision ${currentRevision} against revision ${reviewedRevision} to state, for every point, what changed and where, or why it was not changed.`}
+          action={
+            !readOnly && (
+              <PeerReviewStageAction
+                label="Generate response memos"
+                disabled={false}
+                isStarting={isStarting}
+                size="default"
+                onStart={() => startStage([WorkflowRunType.ReviewerResponseMemos])}
+                onCancel={cancelRun}
+              />
+            )
+          }
+        />
+      );
+    }
+
+    return (
+      <div className="space-y-3">
+        <Results>
+          <SimpleDeepAgentResults
+            project={projectDetail}
+            workflowDetail={runs.memos}
+            workflowName="Reviewer Response Memos"
+            onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+          />
+        </Results>
+      </div>
+    );
+  }
+
+  function CoverageStep() {
+    if (!runs.coverage) {
+      return (
+        <StepCta
+          icon={ClipboardCheck}
+          title="Sign off on how responsive the revision was"
+          description="A single view for a QA manager: every reviewer point with a verdict (addressed, partially addressed, declined with rationale, or not addressed), a summary count table, and an overall responsiveness read."
+          action={
+            !readOnly && (
+              <PeerReviewStageAction
+                label="Generate coverage report"
+                disabled={false}
+                isStarting={isStarting}
+                size="default"
+                onStart={() => startStage([WorkflowRunType.ReviewerCoverageReport])}
+                onCancel={cancelRun}
+              />
+            )
+          }
+        />
+      );
+    }
+
+    return (
+      <div className="space-y-3">
+        <Results>
+          <SimpleDeepAgentResults
+            project={projectDetail}
+            workflowDetail={runs.coverage}
+            workflowName="Reviewer Coverage Report"
+            onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
+          />
+        </Results>
+      </div>
+    );
+  }
+}
+
+/** The result components are shared with v1, whose pages run a larger scale. */
+function Results({ children }: { children: ReactNode }) {
+  return <div className="text-scale-compact">{children}</div>;
+}
+
+function Blocked({ reason }: { reason: string }) {
+  return (
+    <div className="rounded-md border border-dashed px-4 py-8 text-center">
+      <Lock className="mx-auto size-4 text-muted-foreground" />
+      <p className="mt-2 text-sm font-medium">Not ready yet</p>
+      <p className="mx-auto mt-1 max-w-md text-[13px] leading-relaxed text-muted-foreground">{reason}</p>
+    </div>
+  );
+}
+
+function StepCta({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: {
+  icon: typeof ListChecks;
+  title: string;
+  description: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-md border border-dashed px-6 py-10 text-center">
+      <Icon className="size-7 text-muted-foreground" />
+      <div className="space-y-1.5">
+        <p className="text-sm font-medium">{title}</p>
+        <p className="mx-auto max-w-prose text-[13px] leading-relaxed text-muted-foreground">{description}</p>
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/frontend/components/results-v2/peer-review/step-rail.tsx
+++ b/frontend/components/results-v2/peer-review/step-rail.tsx
@@ -3,6 +3,7 @@
 import { HelpLink } from '@/components/help/help-link';
 import { StatusIndicator } from '@/components/ui/status-indicator';
 import { WorkflowRunStatus } from '@/lib/generated-api';
+import { RAIL_ITEM_ACTIVE, RAIL_ITEM_IDLE } from '@/lib/rail-style';
 import { cn } from '@/lib/utils';
 import { getDisplayStatus } from '@/lib/workflow-state';
 import { Check } from 'lucide-react';
@@ -36,7 +37,7 @@ export function StepRail({ states, activeStep, onSelectStep }: StepRailProps) {
                   aria-current={active ? 'step' : undefined}
                   className={cn(
                     'flex w-full cursor-pointer gap-2.5 rounded-md px-2 py-2 text-left transition-colors',
-                    active ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
+                    active ? RAIL_ITEM_ACTIVE : RAIL_ITEM_IDLE,
                   )}
                 >
                   <StepMarker index={index + 1} complete={state.complete} blocked={state.blockedReason !== null} />

--- a/frontend/components/results-v2/peer-review/step-rail.tsx
+++ b/frontend/components/results-v2/peer-review/step-rail.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { HelpLink } from '@/components/help/help-link';
 import { StatusIndicator } from '@/components/ui/status-indicator';
 import { WorkflowRunStatus } from '@/lib/generated-api';
 import { cn } from '@/lib/utils';
@@ -64,7 +65,8 @@ export function StepRail({ states, activeStep, onSelectStep }: StepRailProps) {
 
       <p className="shrink-0 border-t px-5 py-4 text-xs leading-relaxed text-muted-foreground">
         Reviewer memos are documents peer reviewers wrote about your draft. These four steps read them, help you plan
-        and write the revision, and then report how fully each point was addressed.
+        and write the revision, and then report how fully each point was addressed.{' '}
+        <HelpLink topic="peer-review">More details</HelpLink>
       </p>
     </div>
   );

--- a/frontend/components/results-v2/peer-review/step-rail.tsx
+++ b/frontend/components/results-v2/peer-review/step-rail.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { StatusIndicator } from '@/components/ui/status-indicator';
+import { WorkflowRunStatus } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import { getDisplayStatus } from '@/lib/workflow-state';
+import { Check } from 'lucide-react';
+import { STEPS, StepId, StepState } from './steps';
+
+interface StepRailProps {
+  states: Record<StepId, StepState>;
+  activeStep: StepId;
+  onSelectStep: (step: StepId) => void;
+}
+
+/**
+ * The four steps as a stepper. Peer review is the one tab that is a sequence
+ * rather than a set, so the rail numbers its rows and marks the ones already
+ * done — where the other tabs' rails just list what exists.
+ */
+export function StepRail({ states, activeStep, onSelectStep }: StepRailProps) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <h2 className="px-2 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">Steps</h2>
+
+        <ol className="mt-2 space-y-px">
+          {STEPS.map((step, index) => {
+            const state = states[step.id];
+            const active = activeStep === step.id;
+            return (
+              <li key={step.id}>
+                <button
+                  onClick={() => onSelectStep(step.id)}
+                  aria-current={active ? 'step' : undefined}
+                  className={cn(
+                    'flex w-full cursor-pointer gap-2.5 rounded-md px-2 py-2 text-left transition-colors',
+                    active ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
+                  )}
+                >
+                  <StepMarker index={index + 1} complete={state.complete} blocked={state.blockedReason !== null} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-[13px] leading-tight font-medium">{step.title}</span>
+                    <span className="mt-1 block">
+                      {/* A run's own status wins. The upload step has no run, so
+                          its completion has to come from the facts instead. */}
+                      {state.run ? (
+                        <StatusIndicator status={getDisplayStatus(state.run)} />
+                      ) : state.complete ? (
+                        <StatusIndicator status={WorkflowRunStatus.Completed} />
+                      ) : (
+                        <span className="text-[11px] text-muted-foreground">
+                          {state.blockedReason ? 'Not ready' : 'Ready to run'}
+                        </span>
+                      )}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      <p className="shrink-0 border-t px-5 py-4 text-xs leading-relaxed text-muted-foreground">
+        Reviewer memos are documents peer reviewers wrote about your draft. These four steps read them, help you plan
+        and write the revision, and then report how fully each point was addressed.
+      </p>
+    </div>
+  );
+}
+
+function StepMarker({ index, complete, blocked }: { index: number; complete: boolean; blocked: boolean }) {
+  if (complete) {
+    return (
+      <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full bg-green-600 dark:bg-green-500">
+        <Check className="size-2.5 text-white" strokeWidth={3} />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border text-[9px] font-medium',
+        blocked ? 'border-muted-foreground/30 text-muted-foreground' : 'border-primary text-primary',
+      )}
+    >
+      {index}
+    </span>
+  );
+}

--- a/frontend/components/results-v2/peer-review/steps.ts
+++ b/frontend/components/results-v2/peer-review/steps.ts
@@ -1,0 +1,69 @@
+import { PeerReviewFacts } from '@/components/results/tabs/peer-review/peer-review-derive';
+import { WorkflowRunDetail, WorkflowRunStatus } from '@/lib/generated-api';
+import { getDisplayStatus } from '@/lib/workflow-state';
+
+export type StepId = 'plan' | 'revise' | 'respond' | 'coverage';
+
+export interface StepDefinition {
+  id: StepId;
+  title: string;
+  /** One line on what this step produces. */
+  subtitle: string;
+}
+
+/** The sequence, in the order it has to happen. */
+export const STEPS: StepDefinition[] = [
+  {
+    id: 'plan',
+    title: 'Plan the revision',
+    subtitle: 'Reads the reviewer memos and prepares a document on how to address each point they raise.',
+  },
+  {
+    id: 'revise',
+    title: 'Upload your revised draft',
+    subtitle:
+      'Adds your revised draft as a new revision, so the later steps can compare it against the one the reviewers read.',
+  },
+  {
+    id: 'respond',
+    title: 'Respond to the reviewers',
+    subtitle:
+      'Writes one response memo per reviewer, answering each of their points with what changed and where, or why it did not.',
+  },
+  {
+    id: 'coverage',
+    title: 'QA coverage report',
+    subtitle:
+      'Gives every reviewer point a verdict — addressed, partly, declined, or not — and an overall read for sign-off.',
+  },
+];
+
+export const isComplete = (run?: WorkflowRunDetail) => !!run && getDisplayStatus(run) === WorkflowRunStatus.Completed;
+
+export interface StepState {
+  complete: boolean;
+  blockedReason: string | null;
+  /** The run behind this step, absent for the one the author does by hand. */
+  run?: WorkflowRunDetail;
+}
+
+/**
+ * What each step's marker and status line report. Kept in one function so the
+ * rail and the panel cannot disagree about whether a step is done.
+ */
+export function readStepStates(facts: PeerReviewFacts, planRun?: WorkflowRunDetail): Record<StepId, StepState> {
+  return {
+    plan: { complete: isComplete(planRun), blockedReason: facts.planBlockedReason, run: planRun },
+    revise: { complete: facts.hasRevisedDraft, blockedReason: facts.reviseBlockedReason },
+    respond: {
+      complete: isComplete(facts.runs.memos),
+      blockedReason: facts.comparisonBlockedReason,
+      run: facts.runs.memos,
+    },
+    coverage: {
+      complete: isComplete(facts.runs.coverage),
+      blockedReason: facts.comparisonBlockedReason,
+      run: facts.runs.coverage,
+    },
+  };
+}

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { AnalysisOptionsMenu } from '@/components/results/components/analysis-options-menu';
+import { TabType } from '@/components/results/constants';
+import { ProjectViewProvider } from '@/components/results/project-view-context';
+import {
+  derivePeerReviewFacts,
+  peerReviewNeedsAttention,
+} from '@/components/results/tabs/peer-review/peer-review-derive';
+import { UnmatchedReferencesApproveDialog } from '@/components/results/tabs/reference-review/unmatched-references-approve-dialog';
+import { useReferenceApprovalFlow } from '@/components/results/tabs/reference-review/use-reference-approval-flow';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { EditableTitle } from '@/components/ui/editable-title';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ProjectFeedbackProvider } from '@/lib/contexts/project-feedback-context';
+import { ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { getWorkflowRunByType } from '@/lib/workflow-state';
+import { BookOpen, Loader2 } from 'lucide-react';
+import { ReactNode, useMemo } from 'react';
+import { AppBar } from './app-bar';
+
+interface ProjectShellV2Props {
+  projectDetail: ProjectDetailed;
+  activeTab: TabType;
+  onTabChange: (tab: TabType, hash?: string) => void;
+  readOnly?: boolean;
+  onTitleSave?: (newTitle: string) => Promise<void>;
+  isTitleSaving?: boolean;
+  needsReferenceReview?: boolean;
+  selectedRevision?: number;
+  onRevisionChange?: (revision: number) => void;
+  onRevisionCreated?: () => void;
+  children: ReactNode;
+}
+
+/**
+ * Workbench chrome: one row for the application, one for the project, and the
+ * rest of the viewport for the tab. Replaces both ApplicationShell's nav and the
+ * stacked title block, which together cost about 160px before any content.
+ *
+ * The authors line is deliberately gone — it is in the document itself.
+ */
+export function ProjectShellV2({
+  projectDetail,
+  activeTab,
+  onTabChange,
+  readOnly = false,
+  onTitleSave,
+  isTitleSaving = false,
+  needsReferenceReview = false,
+  selectedRevision,
+  onRevisionChange,
+  onRevisionCreated,
+  children,
+}: ProjectShellV2Props) {
+  const results = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
+  const { isWorkflowTypeVisible } = useWorkflowTypes();
+
+  const referenceExtraction = getWorkflowRunByType(results, WorkflowRunType.ReferenceExtraction);
+  const referenceApproval = useReferenceApprovalFlow(projectDetail, projectDetail.project.id);
+
+  const peerReviewFacts = derivePeerReviewFacts(projectDetail);
+  const peerReviewAttention = peerReviewNeedsAttention(peerReviewFacts, readOnly);
+
+  const navigateToTab = (tab: TabType, hash?: string) => onTabChange(tab, hash);
+
+  return (
+    <ProjectFeedbackProvider
+      projectId={readOnly ? undefined : projectDetail.project.id}
+      feedbackVisibility={readOnly ? null : (projectDetail.project.feedback_visibility ?? null)}
+    >
+      <ProjectViewProvider
+        value={{
+          projectDetail,
+          readOnly,
+          selectedRevision,
+          onRevisionChange,
+          onRevisionCreated,
+          navigateToTab,
+        }}
+      >
+        <div className="bg-background text-foreground flex h-dvh flex-col">
+          <AppBar />
+
+          {/* This project: what you are looking at, and the ways into it. */}
+          <header className="flex h-12 shrink-0 items-center gap-3 border-b px-3">
+            <div className="flex min-w-0 max-w-md flex-1 items-center">
+              {!readOnly && onTitleSave ? (
+                <EditableTitle
+                  title={projectDetail.project.title}
+                  titleClassName="text-sm font-semibold truncate"
+                  className="min-w-0"
+                  onSave={onTitleSave}
+                  isLoading={isTitleSaving}
+                />
+              ) : (
+                <h1 className="truncate text-sm font-semibold">{projectDetail.project.title}</h1>
+              )}
+            </div>
+
+            <Tabs
+              value={activeTab}
+              onValueChange={(value) => onTabChange(value as TabType)}
+              className="hidden shrink-0 lg:block"
+            >
+              <TabsList>
+                <TabsTrigger value="document-explorer">Document Explorer</TabsTrigger>
+                <TabsTrigger value="references" className="relative">
+                  References
+                  <Badge className="h-4.5 min-w-4.5 rounded-full" variant="secondary">
+                    {referenceExtraction?.state?.extracted_references?.length || 0}
+                  </Badge>
+                  {needsReferenceReview && (
+                    <span className="ring-background absolute -top-1 -right-1 size-2.5 rounded-full bg-amber-500 ring-2" />
+                  )}
+                </TabsTrigger>
+                <TabsTrigger value="files">
+                  Files
+                  <Badge className="h-4.5 min-w-4.5 rounded-full" variant="secondary">
+                    {projectDetail.files?.length ?? 0}
+                  </Badge>
+                </TabsTrigger>
+                <TabsTrigger value="analyses">
+                  Assessments
+                  <Badge className="h-4.5 min-w-4.5 rounded-full" variant="secondary">
+                    {results.filter((r) => isWorkflowTypeVisible(r.run.type)).length}
+                  </Badge>
+                </TabsTrigger>
+                <TabsTrigger value="peer-review" className="relative">
+                  Peer Review
+                  {peerReviewFacts.memos.length > 0 && (
+                    <Badge className="h-4.5 min-w-4.5 rounded-full" variant="secondary">
+                      {peerReviewFacts.memos.length}
+                    </Badge>
+                  )}
+                  {peerReviewAttention && (
+                    <span className="ring-background absolute -top-1 -right-1 size-2.5 rounded-full bg-amber-500 ring-2" />
+                  )}
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+
+            {/* Share badge, revision switcher, Download DOCX and the overflow menu. */}
+            <div className="ml-auto flex shrink-0 items-center gap-2">
+              {readOnly && (
+                <Badge variant="secondary" className="h-7 text-xs">
+                  Read-only view
+                </Badge>
+              )}
+              <AnalysisOptionsMenu
+                project={projectDetail.project}
+                results={results}
+                readOnly={readOnly}
+                selectedRevision={selectedRevision}
+                onRevisionChange={onRevisionChange}
+                onRevisionCreated={onRevisionCreated}
+                downloadLabel="Export"
+              />
+            </div>
+          </header>
+
+          {needsReferenceReview && (
+            <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-amber-50 px-3 py-2 dark:bg-amber-950/30">
+              <BookOpen className="size-4 shrink-0 text-amber-700 dark:text-amber-400" />
+              <p className="min-w-0 text-sm">
+                <strong className="font-medium">Reference review required.</strong>{' '}
+                <span className="text-muted-foreground">
+                  Upload source documents or fetch them from the web, then approve to start the assessment.
+                </span>
+              </p>
+              <div className="ml-auto flex shrink-0 items-center gap-2">
+                <Button size="sm" variant="outline" className="h-7" onClick={() => onTabChange('references')}>
+                  Review references
+                </Button>
+                <Button
+                  size="sm"
+                  className="h-7"
+                  onClick={referenceApproval.handleApprove}
+                  disabled={referenceApproval.isApproveDisabled}
+                >
+                  {referenceApproval.showApproveButtonSpinner && (
+                    <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                  )}
+                  {referenceApproval.approveButtonText}
+                </Button>
+              </div>
+              <UnmatchedReferencesApproveDialog
+                open={referenceApproval.showUnmatchedWarning}
+                onOpenChange={referenceApproval.setShowUnmatchedWarning}
+                unmatchedCount={referenceApproval.unmatchedCount}
+                onConfirmApprove={referenceApproval.handleConfirmApprove}
+              />
+            </div>
+          )}
+
+          <div className="min-h-0 flex-1">
+            {activeTab === 'document-explorer' ? (
+              children
+            ) : (
+              /* Placeholder framing for tabs that have not been redesigned yet:
+                 they were built for a scrolling page inside a max-width column. */
+              <div className="h-full overflow-y-auto">
+                <div className="mx-auto h-full max-w-7xl p-4">{children}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      </ProjectViewProvider>
+    </ProjectFeedbackProvider>
+  );
+}

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -7,19 +7,16 @@ import {
   derivePeerReviewFacts,
   peerReviewNeedsAttention,
 } from '@/components/results/tabs/peer-review/peer-review-derive';
-import { UnmatchedReferencesApproveDialog } from '@/components/results/tabs/reference-review/unmatched-references-approve-dialog';
-import { useReferenceApprovalFlow } from '@/components/results/tabs/reference-review/use-reference-approval-flow';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { EditableTitle } from '@/components/ui/editable-title';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ProjectFeedbackProvider } from '@/lib/contexts/project-feedback-context';
 import { ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
-import { BookOpen, Loader2 } from 'lucide-react';
 import { ReactNode, useMemo } from 'react';
 import { AppBar } from './app-bar';
+import { ProjectTab, ProjectTabs } from './project-tabs';
+import { ReferenceReviewBanner } from './reference-review-banner';
 
 interface ProjectShellV2Props {
   projectDetail: ProjectDetailed;
@@ -59,10 +56,40 @@ export function ProjectShellV2({
   const { isWorkflowTypeVisible } = useWorkflowTypes();
 
   const referenceExtraction = getWorkflowRunByType(results, WorkflowRunType.ReferenceExtraction);
-  const referenceApproval = useReferenceApprovalFlow(projectDetail, projectDetail.project.id);
 
   const peerReviewFacts = derivePeerReviewFacts(projectDetail);
   const peerReviewAttention = peerReviewNeedsAttention(peerReviewFacts, readOnly);
+
+  const tabs: ProjectTab[] = [
+    { id: 'document-explorer', label: 'Document Explorer' },
+    {
+      id: 'references',
+      label: 'References',
+      count: referenceExtraction?.state?.extracted_references?.length || 0,
+      attention: needsReferenceReview,
+    },
+    { id: 'files', label: 'Files', count: projectDetail.files?.length ?? 0 },
+    { id: 'analyses', label: 'Assessments', count: results.filter((r) => isWorkflowTypeVisible(r.run.type)).length },
+    {
+      id: 'peer-review',
+      label: 'Peer Review',
+      count: peerReviewFacts.memos.length > 0 ? peerReviewFacts.memos.length : undefined,
+      attention: peerReviewAttention,
+    },
+  ];
+
+  const titleNode =
+    !readOnly && onTitleSave ? (
+      <EditableTitle
+        title={projectDetail.project.title}
+        titleClassName="text-sm font-semibold truncate min-w-0"
+        className="min-w-0"
+        onSave={onTitleSave}
+        isLoading={isTitleSaving}
+      />
+    ) : (
+      <h1 className="truncate text-sm font-semibold">{projectDetail.project.title}</h1>
+    );
 
   const navigateToTab = (tab: TabType, hash?: string) => onTabChange(tab, hash);
 
@@ -82,67 +109,14 @@ export function ProjectShellV2({
         }}
       >
         <div className="bg-background text-foreground flex h-dvh flex-col">
-          <AppBar />
+          <AppBar title={titleNode} />
 
-          {/* This project: what you are looking at, and the ways into it. */}
+          {/* This project: the ways in on the left, what you can do with it on
+              the right. The title names the project a row above. */}
           <header className="flex h-12 shrink-0 items-center gap-3 border-b px-3">
-            <div className="flex min-w-0 max-w-md flex-1 items-center">
-              {!readOnly && onTitleSave ? (
-                <EditableTitle
-                  title={projectDetail.project.title}
-                  titleClassName="text-sm font-semibold truncate"
-                  className="min-w-0"
-                  onSave={onTitleSave}
-                  isLoading={isTitleSaving}
-                />
-              ) : (
-                <h1 className="truncate text-sm font-semibold">{projectDetail.project.title}</h1>
-              )}
-            </div>
+            <ProjectTabs tabs={tabs} activeTab={activeTab} onTabChange={onTabChange} />
 
-            <Tabs
-              value={activeTab}
-              onValueChange={(value) => onTabChange(value as TabType)}
-              className="hidden shrink-0 lg:block"
-            >
-              <TabsList>
-                <TabsTrigger value="document-explorer">Document Explorer</TabsTrigger>
-                <TabsTrigger value="references" className="relative">
-                  References
-                  <Badge className="h-4.5 min-w-4.5 rounded-full" variant="secondary">
-                    {referenceExtraction?.state?.extracted_references?.length || 0}
-                  </Badge>
-                  {needsReferenceReview && (
-                    <span className="ring-background absolute -top-1 -right-1 size-2.5 rounded-full bg-amber-500 ring-2" />
-                  )}
-                </TabsTrigger>
-                <TabsTrigger value="files">
-                  Files
-                  <Badge className="h-4.5 min-w-4.5 rounded-full" variant="secondary">
-                    {projectDetail.files?.length ?? 0}
-                  </Badge>
-                </TabsTrigger>
-                <TabsTrigger value="analyses">
-                  Assessments
-                  <Badge className="h-4.5 min-w-4.5 rounded-full" variant="secondary">
-                    {results.filter((r) => isWorkflowTypeVisible(r.run.type)).length}
-                  </Badge>
-                </TabsTrigger>
-                <TabsTrigger value="peer-review" className="relative">
-                  Peer Review
-                  {peerReviewFacts.memos.length > 0 && (
-                    <Badge className="h-4.5 min-w-4.5 rounded-full" variant="secondary">
-                      {peerReviewFacts.memos.length}
-                    </Badge>
-                  )}
-                  {peerReviewAttention && (
-                    <span className="ring-background absolute -top-1 -right-1 size-2.5 rounded-full bg-amber-500 ring-2" />
-                  )}
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-
-            {/* Share badge, revision switcher, Download DOCX and the overflow menu. */}
+            {/* Share badge, revision switcher, Export and the overflow menu. */}
             <div className="ml-auto flex shrink-0 items-center gap-2">
               {readOnly && (
                 <Badge variant="secondary" className="h-7 text-xs">
@@ -162,37 +136,7 @@ export function ProjectShellV2({
           </header>
 
           {needsReferenceReview && (
-            <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-amber-50 px-3 py-2 dark:bg-amber-950/30">
-              <BookOpen className="size-4 shrink-0 text-amber-700 dark:text-amber-400" />
-              <p className="min-w-0 text-sm">
-                <strong className="font-medium">Reference review required.</strong>{' '}
-                <span className="text-muted-foreground">
-                  Upload source documents or fetch them from the web, then approve to start the assessment.
-                </span>
-              </p>
-              <div className="ml-auto flex shrink-0 items-center gap-2">
-                <Button size="sm" variant="outline" className="h-7" onClick={() => onTabChange('references')}>
-                  Review references
-                </Button>
-                <Button
-                  size="sm"
-                  className="h-7"
-                  onClick={referenceApproval.handleApprove}
-                  disabled={referenceApproval.isApproveDisabled}
-                >
-                  {referenceApproval.showApproveButtonSpinner && (
-                    <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
-                  )}
-                  {referenceApproval.approveButtonText}
-                </Button>
-              </div>
-              <UnmatchedReferencesApproveDialog
-                open={referenceApproval.showUnmatchedWarning}
-                onOpenChange={referenceApproval.setShowUnmatchedWarning}
-                unmatchedCount={referenceApproval.unmatchedCount}
-                onConfirmApprove={referenceApproval.handleConfirmApprove}
-              />
-            </div>
+            <ReferenceReviewBanner projectDetail={projectDetail} onReviewReferences={() => onTabChange('references')} />
           )}
 
           <div className="min-h-0 flex-1">

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -18,6 +18,7 @@ import { ReactNode, useMemo } from 'react';
 import { AppBar } from './app-bar';
 import { NewAssessmentButton } from './new-assessment-button';
 import { OldRevisionBanner } from './old-revision-banner';
+import { PageTitle } from '@/components/shared/page-title';
 import { ProjectTab, ProjectTabs } from './project-tabs';
 import { ReferenceReviewBanner } from './reference-review-banner';
 
@@ -112,6 +113,8 @@ export function ProjectShellV2({
       projectId={readOnly ? undefined : projectDetail.project.id}
       feedbackVisibility={readOnly ? null : (projectDetail.project.feedback_visibility ?? null)}
     >
+      <PageTitle title={projectDetail.project.title} />
+
       <ProjectViewProvider
         value={{
           projectDetail,

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -19,7 +19,7 @@ import { ProjectTab, ProjectTabs } from './project-tabs';
 import { ReferenceReviewBanner } from './reference-review-banner';
 
 /** Tabs redesigned for the v2 frame, which manage their own scrolling. */
-const FULL_BLEED_TABS = new Set<TabType>(['document-explorer', 'references', 'files']);
+const FULL_BLEED_TABS = new Set<TabType>(['document-explorer', 'references', 'files', 'analyses']);
 
 interface ProjectShellV2Props {
   projectDetail: ProjectDetailed;

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -18,6 +18,9 @@ import { AppBar } from './app-bar';
 import { ProjectTab, ProjectTabs } from './project-tabs';
 import { ReferenceReviewBanner } from './reference-review-banner';
 
+/** Tabs redesigned for the v2 frame, which manage their own scrolling. */
+const FULL_BLEED_TABS = new Set<TabType>(['document-explorer', 'references']);
+
 interface ProjectShellV2Props {
   projectDetail: ProjectDetailed;
   activeTab: TabType;
@@ -140,7 +143,7 @@ export function ProjectShellV2({
           )}
 
           <div className="min-h-0 flex-1">
-            {activeTab === 'document-explorer' ? (
+            {FULL_BLEED_TABS.has(activeTab) ? (
               children
             ) : (
               /* Placeholder framing for tabs that have not been redesigned yet:

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -15,6 +15,7 @@ import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
 import { ReactNode, useMemo } from 'react';
 import { AppBar } from './app-bar';
+import { NewAssessmentButton } from './new-assessment-button';
 import { ProjectTab, ProjectTabs } from './project-tabs';
 import { ReferenceReviewBanner } from './reference-review-banner';
 
@@ -127,6 +128,7 @@ export function ProjectShellV2({
                   Read-only view
                 </Badge>
               )}
+              {!readOnly && <NewAssessmentButton projectId={projectDetail.project.id} />}
               <AnalysisOptionsMenu
                 project={projectDetail.project}
                 results={results}
@@ -135,6 +137,7 @@ export function ProjectShellV2({
                 onRevisionChange={onRevisionChange}
                 onRevisionCreated={onRevisionCreated}
                 downloadLabel="Export"
+                downloadVariant="outline"
               />
             </div>
           </header>

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -19,7 +19,8 @@ import { ProjectTab, ProjectTabs } from './project-tabs';
 import { ReferenceReviewBanner } from './reference-review-banner';
 
 /** Tabs redesigned for the v2 frame, which manage their own scrolling. */
-const FULL_BLEED_TABS = new Set<TabType>(['document-explorer', 'references', 'files', 'analyses']);
+/** Every redesigned tab manages its own scrolling; only Summary still does not. */
+const FULL_BLEED_TABS = new Set<TabType>(['document-explorer', 'references', 'files', 'analyses', 'peer-review']);
 
 interface ProjectShellV2Props {
   projectDetail: ProjectDetailed;

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -19,7 +19,7 @@ import { ProjectTab, ProjectTabs } from './project-tabs';
 import { ReferenceReviewBanner } from './reference-review-banner';
 
 /** Tabs redesigned for the v2 frame, which manage their own scrolling. */
-const FULL_BLEED_TABS = new Set<TabType>(['document-explorer', 'references']);
+const FULL_BLEED_TABS = new Set<TabType>(['document-explorer', 'references', 'files']);
 
 interface ProjectShellV2Props {
   projectDetail: ProjectDetailed;

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -17,6 +17,7 @@ import { getWorkflowRunByType } from '@/lib/workflow-state';
 import { ReactNode, useMemo } from 'react';
 import { AppBar } from './app-bar';
 import { NewAssessmentButton } from './new-assessment-button';
+import { OldRevisionBanner } from './old-revision-banner';
 import { ProjectTab, ProjectTabs } from './project-tabs';
 import { ReferenceReviewBanner } from './reference-review-banner';
 
@@ -61,6 +62,7 @@ export function ProjectShellV2({
   const results = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
   const { isWorkflowTypeVisible } = useWorkflowTypes();
 
+  const currentRevision = projectDetail.project.current_revision ?? 1;
   const referenceExtraction = getWorkflowRunByType(results, WorkflowRunType.ReferenceExtraction);
 
   const { showExperimentalFeatures } = useExperimentalFeatures();
@@ -152,6 +154,16 @@ export function ProjectShellV2({
 
           {needsReferenceReview && (
             <ReferenceReviewBanner projectDetail={projectDetail} onReviewReferences={() => onTabChange('references')} />
+          )}
+
+          {/* An older revision governs every tab, not just the document, so the
+              notice belongs to the view rather than to the reader. */}
+          {selectedRevision != null && selectedRevision < currentRevision && (
+            <OldRevisionBanner
+              selectedRevision={selectedRevision}
+              currentRevision={currentRevision}
+              onViewCurrent={onRevisionChange ? () => onRevisionChange(currentRevision) : undefined}
+            />
           )}
 
           <div className="min-h-0 flex-1">

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/results/tabs/peer-review/peer-review-derive';
 import { Badge } from '@/components/ui/badge';
 import { EditableTitle } from '@/components/ui/editable-title';
+import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { ProjectFeedbackProvider } from '@/lib/contexts/project-feedback-context';
 import { ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
@@ -62,6 +63,7 @@ export function ProjectShellV2({
 
   const referenceExtraction = getWorkflowRunByType(results, WorkflowRunType.ReferenceExtraction);
 
+  const { showExperimentalFeatures } = useExperimentalFeatures();
   const peerReviewFacts = derivePeerReviewFacts(projectDetail);
   const peerReviewAttention = peerReviewNeedsAttention(peerReviewFacts, readOnly);
 
@@ -75,12 +77,17 @@ export function ProjectShellV2({
     },
     { id: 'files', label: 'Files', count: projectDetail.files?.length ?? 0 },
     { id: 'analyses', label: 'Assessments', count: results.filter((r) => isWorkflowTypeVisible(r.run.type)).length },
-    {
-      id: 'peer-review',
-      label: 'Peer Review',
-      count: peerReviewFacts.memos.length > 0 ? peerReviewFacts.memos.length : undefined,
-      attention: peerReviewAttention,
-    },
+    // Peer Review is still alpha, so it only exists for users who opted in.
+    ...(showExperimentalFeatures
+      ? [
+          {
+            id: 'peer-review' as const,
+            label: 'Peer Review',
+            count: peerReviewFacts.memos.length > 0 ? peerReviewFacts.memos.length : undefined,
+            attention: peerReviewAttention,
+          },
+        ]
+      : []),
   ];
 
   const titleNode =

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -145,6 +145,7 @@ export function ProjectShellV2({
                 onRevisionCreated={onRevisionCreated}
                 downloadLabel="Export"
                 downloadVariant="outline"
+                compact
               />
             </div>
           </header>

--- a/frontend/components/results-v2/project-tabs.tsx
+++ b/frontend/components/results-v2/project-tabs.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { TabType } from '@/components/results/constants';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
+import { Check, ChevronDown } from 'lucide-react';
 
 export interface ProjectTab {
   id: TabType;
@@ -24,42 +32,86 @@ interface ProjectTabsProps {
  * explaining: a segmented control floating mid-row read as one more toolbar
  * widget, while a rule that touches the panel edge reads as the panel's own
  * label.
+ *
+ * Five tabs will not fit a narrow header, so below that width they collapse
+ * into a menu naming the one you are on. Both are rendered and one is hidden
+ * by CSS: neither holds state, so there is nothing for two copies to disagree
+ * about, and the layout never flashes while a query resolves.
  */
 export function ProjectTabs({ tabs, activeTab, onTabChange }: ProjectTabsProps) {
+  const active = tabs.find((tab) => tab.id === activeTab) ?? tabs[0];
+
   return (
-    <nav className="hidden h-full shrink-0 items-center lg:flex" aria-label="Project sections">
-      {tabs.map((tab) => {
-        const active = tab.id === activeTab;
-        return (
-          <button
-            key={tab.id}
-            onClick={() => onTabChange(tab.id)}
-            aria-current={active ? 'page' : undefined}
-            className={cn(
-              'relative flex h-full cursor-pointer items-center gap-1.5 px-3 text-[13px] transition-colors',
-              // -bottom-px lands the marker on the header's own border, tying
-              // the tab to the content underneath it.
-              'after:bg-primary after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:transition-opacity',
-              active
-                ? 'text-foreground font-medium after:opacity-100'
-                : 'text-muted-foreground hover:text-foreground after:opacity-0',
-            )}
-          >
+    <>
+      <ProjectTabsMenu tabs={tabs} activeTab={activeTab} activeLabel={active?.label} onTabChange={onTabChange} />
+      <nav className="hidden h-full shrink-0 items-center lg:flex" aria-label="Project sections">
+        {tabs.map((tab) => {
+          const active = tab.id === activeTab;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => onTabChange(tab.id)}
+              aria-current={active ? 'page' : undefined}
+              className={cn(
+                'relative flex h-full cursor-pointer items-center gap-1.5 px-3 text-[13px] transition-colors',
+                // -bottom-px lands the marker on the header's own border, tying
+                // the tab to the content underneath it.
+                'after:bg-primary after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:transition-opacity',
+                active
+                  ? 'text-foreground font-medium after:opacity-100'
+                  : 'text-muted-foreground hover:text-foreground after:opacity-0',
+              )}
+            >
+              {tab.label}
+              {tab.count !== undefined && (
+                <span
+                  className={cn(
+                    'font-mono text-[11px] tabular-nums',
+                    active ? 'text-muted-foreground' : 'text-muted-foreground/70',
+                  )}
+                >
+                  {tab.count}
+                </span>
+              )}
+              {tab.attention && <span className="size-1.5 shrink-0 rounded-full bg-amber-500" />}
+            </button>
+          );
+        })}
+      </nav>
+    </>
+  );
+}
+
+/** The same tabs as a menu, for headers too narrow to lay them out in a row. */
+function ProjectTabsMenu({ tabs, activeTab, activeLabel, onTabChange }: ProjectTabsProps & { activeLabel?: string }) {
+  const needsAttention = tabs.some((tab) => tab.attention && tab.id !== activeTab);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-8 shrink-0 px-2 text-[13px] font-medium lg:hidden">
+          {activeLabel}
+          {/* Something elsewhere is waiting; the strip would have shown its own
+              dot, and folding the tabs away must not fold that away with them. */}
+          {needsAttention && <span className="size-1.5 shrink-0 rounded-full bg-amber-500" />}
+          <ChevronDown className="text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" className="w-56">
+        {tabs.map((tab) => (
+          <DropdownMenuItem key={tab.id} onSelect={() => onTabChange(tab.id)}>
             {tab.label}
-            {tab.count !== undefined && (
-              <span
-                className={cn(
-                  'font-mono text-[11px] tabular-nums',
-                  active ? 'text-muted-foreground' : 'text-muted-foreground/70',
-                )}
-              >
-                {tab.count}
-              </span>
-            )}
             {tab.attention && <span className="size-1.5 shrink-0 rounded-full bg-amber-500" />}
-          </button>
-        );
-      })}
-    </nav>
+            <span className="ml-auto flex items-center gap-2">
+              {tab.count !== undefined && (
+                <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{tab.count}</span>
+              )}
+              {tab.id === activeTab && <Check className="size-3.5" />}
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/components/results-v2/project-tabs.tsx
+++ b/frontend/components/results-v2/project-tabs.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { TabType } from '@/components/results/constants';
+import { cn } from '@/lib/utils';
+
+export interface ProjectTab {
+  id: TabType;
+  label: string;
+  /** Shown beside the label; omitted when there is nothing to count. */
+  count?: number;
+  /** Amber dot: this tab is waiting on the reader. */
+  attention?: boolean;
+}
+
+interface ProjectTabsProps {
+  tabs: ProjectTab[];
+  activeTab: TabType;
+  onTabChange: (tab: TabType) => void;
+}
+
+/**
+ * The project's tab strip, sitting at the left of the header row with its
+ * active marker riding the row's bottom border. The marker is what does the
+ * explaining: a segmented control floating mid-row read as one more toolbar
+ * widget, while a rule that touches the panel edge reads as the panel's own
+ * label.
+ */
+export function ProjectTabs({ tabs, activeTab, onTabChange }: ProjectTabsProps) {
+  return (
+    <nav className="hidden h-full shrink-0 items-center lg:flex" aria-label="Project sections">
+      {tabs.map((tab) => {
+        const active = tab.id === activeTab;
+        return (
+          <button
+            key={tab.id}
+            onClick={() => onTabChange(tab.id)}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'relative flex h-full cursor-pointer items-center gap-1.5 px-3 text-[13px] transition-colors',
+              // -bottom-px lands the marker on the header's own border, tying
+              // the tab to the content underneath it.
+              'after:bg-primary after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:transition-opacity',
+              active
+                ? 'text-foreground font-medium after:opacity-100'
+                : 'text-muted-foreground hover:text-foreground after:opacity-0',
+            )}
+          >
+            {tab.label}
+            {tab.count !== undefined && (
+              <span
+                className={cn(
+                  'font-mono text-[11px] tabular-nums',
+                  active ? 'text-muted-foreground' : 'text-muted-foreground/70',
+                )}
+              >
+                {tab.count}
+              </span>
+            )}
+            {tab.attention && <span className="size-1.5 shrink-0 rounded-full bg-amber-500" />}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/components/results-v2/project-tabs.tsx
+++ b/frontend/components/results-v2/project-tabs.tsx
@@ -89,8 +89,15 @@ function ProjectTabsMenu({ tabs, activeTab, activeLabel, onTabChange }: ProjectT
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="h-8 shrink-0 px-2 text-[13px] font-medium lg:hidden">
-          {activeLabel}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 max-w-64 min-w-0 flex-1 justify-start px-2 text-[13px] font-medium lg:hidden"
+        >
+          {/* Takes the room that is going spare and gives it back when the
+              project's actions need it: "Document Explorer" is wide enough to
+              push them off a phone screen on its own. */}
+          <span className="truncate">{activeLabel}</span>
           {/* Something elsewhere is waiting; the strip would have shown its own
               dot, and folding the tabs away must not fold that away with them. */}
           {needsAttention && <span className="size-1.5 shrink-0 rounded-full bg-amber-500" />}

--- a/frontend/components/results-v2/reference-review-banner.tsx
+++ b/frontend/components/results-v2/reference-review-banner.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { ProjectDetailed } from '@/lib/generated-api';
 import { BookOpen, Loader2 } from 'lucide-react';
 import { useState } from 'react';
-import { ReferenceReviewExplainer } from '@/components/results/tabs/reference-review/reference-review-explainer';
+import { HelpCenter } from '@/components/help/help-center';
 
 interface ReferenceReviewBannerProps {
   projectDetail: ProjectDetailed;
@@ -56,9 +56,10 @@ export function ReferenceReviewBanner({ projectDetail, onReviewReferences }: Ref
         onConfirmApprove={approval.handleConfirmApprove}
       />
 
-      <ReferenceReviewExplainer
+      <HelpCenter
         open={showExplanation}
         onOpenChange={setShowExplanation}
+        topic="source-files"
         onReviewReferences={() => {
           setShowExplanation(false);
           onReviewReferences();

--- a/frontend/components/results-v2/reference-review-banner.tsx
+++ b/frontend/components/results-v2/reference-review-banner.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { UnmatchedReferencesApproveDialog } from '@/components/results/tabs/reference-review/unmatched-references-approve-dialog';
+import { useReferenceApprovalFlow } from '@/components/results/tabs/reference-review/use-reference-approval-flow';
+import { Button } from '@/components/ui/button';
+import { ProjectDetailed } from '@/lib/generated-api';
+import { BookOpen, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { ReferenceReviewExplainer } from '@/components/results/tabs/reference-review/reference-review-explainer';
+
+interface ReferenceReviewBannerProps {
+  projectDetail: ProjectDetailed;
+  onReviewReferences: () => void;
+}
+
+/**
+ * The strip that appears while Claim Reference Validation is waiting to be let
+ * through. It names the assessment rather than saying "review required",
+ * because the reason a project stalls here is not obvious from the tabs: every
+ * other assessment reads the document alone and keeps producing results.
+ */
+export function ReferenceReviewBanner({ projectDetail, onReviewReferences }: ReferenceReviewBannerProps) {
+  const approval = useReferenceApprovalFlow(projectDetail, projectDetail.project.id);
+  const [showExplanation, setShowExplanation] = useState(false);
+
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-amber-50 px-3 py-2 dark:bg-amber-950/30">
+      <BookOpen className="size-4 shrink-0 text-amber-700 dark:text-amber-400" />
+      <p className="min-w-0 text-sm">
+        <strong className="font-medium">Reference review required.</strong>{' '}
+        <span className="text-muted-foreground">
+          Claim Reference Validation reads each citation against the source it cites, and needs those sources first.
+        </span>{' '}
+        <button
+          onClick={() => setShowExplanation(true)}
+          className="cursor-pointer text-muted-foreground underline underline-offset-2 hover:text-foreground"
+        >
+          Why this is needed
+        </button>
+      </p>
+
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        <Button size="xs" variant="outline" className="h-6" onClick={onReviewReferences}>
+          Review references
+        </Button>
+        <Button size="xs" className="h-6" onClick={approval.handleApprove} disabled={approval.isApproveDisabled}>
+          {approval.showApproveButtonSpinner && <Loader2 className="size-3 animate-spin" aria-hidden />}
+          {approval.approveButtonText}
+        </Button>
+      </div>
+
+      <UnmatchedReferencesApproveDialog
+        open={approval.showUnmatchedWarning}
+        onOpenChange={approval.setShowUnmatchedWarning}
+        unmatchedCount={approval.unmatchedCount}
+        onConfirmApprove={approval.handleConfirmApprove}
+      />
+
+      <ReferenceReviewExplainer
+        open={showExplanation}
+        onOpenChange={setShowExplanation}
+        onReviewReferences={() => {
+          setShowExplanation(false);
+          onReviewReferences();
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/components/results-v2/reference-review-banner.tsx
+++ b/frontend/components/results-v2/reference-review-banner.tsx
@@ -5,8 +5,7 @@ import { useReferenceApprovalFlow } from '@/components/results/tabs/reference-re
 import { Button } from '@/components/ui/button';
 import { ProjectDetailed } from '@/lib/generated-api';
 import { BookOpen, Loader2 } from 'lucide-react';
-import { useState } from 'react';
-import { HelpCenter } from '@/components/help/help-center';
+import { HelpLink } from '@/components/help/help-link';
 
 interface ReferenceReviewBannerProps {
   projectDetail: ProjectDetailed;
@@ -21,7 +20,6 @@ interface ReferenceReviewBannerProps {
  */
 export function ReferenceReviewBanner({ projectDetail, onReviewReferences }: ReferenceReviewBannerProps) {
   const approval = useReferenceApprovalFlow(projectDetail, projectDetail.project.id);
-  const [showExplanation, setShowExplanation] = useState(false);
 
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-amber-50 px-3 py-2 dark:bg-amber-950/30">
@@ -31,12 +29,9 @@ export function ReferenceReviewBanner({ projectDetail, onReviewReferences }: Ref
         <span className="text-muted-foreground">
           Claim Reference Validation reads each citation against the source it cites, and needs those sources first.
         </span>{' '}
-        <button
-          onClick={() => setShowExplanation(true)}
-          className="cursor-pointer text-muted-foreground underline underline-offset-2 hover:text-foreground"
-        >
+        <HelpLink topic="source-files" onReviewReferences={onReviewReferences}>
           Why this is needed
-        </button>
+        </HelpLink>
       </p>
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
@@ -54,16 +49,6 @@ export function ReferenceReviewBanner({ projectDetail, onReviewReferences }: Ref
         onOpenChange={approval.setShowUnmatchedWarning}
         unmatchedCount={approval.unmatchedCount}
         onConfirmApprove={approval.handleConfirmApprove}
-      />
-
-      <HelpCenter
-        open={showExplanation}
-        onOpenChange={setShowExplanation}
-        topic="source-files"
-        onReviewReferences={() => {
-          setShowExplanation(false);
-          onReviewReferences();
-        }}
       />
     </div>
   );

--- a/frontend/components/results-v2/references-v2-panel.tsx
+++ b/frontend/components/results-v2/references-v2-panel.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useProjectView } from '@/components/results/project-view-context';
+import { ReferencesTabV2 } from './references/references-tab';
+
+/** The v2 references tab as a tab panel, taking its project from the shell. */
+export function ReferencesV2Panel() {
+  const { projectDetail, readOnly } = useProjectView();
+
+  return <ReferencesTabV2 projectDetail={projectDetail} readOnly={readOnly} />;
+}

--- a/frontend/components/results-v2/references/fetch-outcome.ts
+++ b/frontend/components/results-v2/references/fetch-outcome.ts
@@ -1,0 +1,36 @@
+import { ReferenceFetchConclusion, ReferenceFetchResult, ReferenceFetchStatus } from '@/lib/generated-api';
+import { formatReferenceError } from '@/lib/utils';
+
+const CONCLUSION: Record<ReferenceFetchConclusion, { label: string; className: string }> = {
+  [ReferenceFetchConclusion.SourceFound]: { label: 'Source found', className: 'text-green-700 dark:text-green-400' },
+  [ReferenceFetchConclusion.SourceFoundButNotAccessible]: {
+    label: 'Found, but not readable',
+    className: 'text-amber-700 dark:text-amber-400',
+  },
+  [ReferenceFetchConclusion.SourceNotFound]: { label: 'Not found on the web', className: 'text-muted-foreground' },
+};
+
+/**
+ * Reads a web fetch's result into the parts the detail pane shows: what came of
+ * it, why, and where it looked. Null while the fetch is still running, or when
+ * the workflow reported nothing to say.
+ */
+export function readFetchOutcome(fetchResult: ReferenceFetchResult) {
+  if (fetchResult.status === ReferenceFetchStatus.Pending) return null;
+
+  const failed = fetchResult.status === ReferenceFetchStatus.Error || fetchResult.error != null;
+  const conclusion = fetchResult.result?.final_conclusion;
+  const outcome = failed
+    ? { label: 'Fetch failed', className: 'text-red-700 dark:text-red-400' }
+    : conclusion
+      ? CONCLUSION[conclusion]
+      : null;
+  if (!outcome) return null;
+
+  return {
+    outcome,
+    detail: failed ? formatReferenceError(fetchResult.error) : fetchResult.result?.inaccessibility_reason,
+    reasoning: fetchResult.result?.reasoning,
+    sourceUrl: fetchResult.result?.source_url,
+  };
+}

--- a/frontend/components/results-v2/references/reference-detail.tsx
+++ b/frontend/components/results-v2/references/reference-detail.tsx
@@ -101,6 +101,10 @@ export function ReferenceDetail({ reference, projectId, readOnly, disabled, onEx
       <WorkflowConfigDialog
         isOpen={fetchDialogOpen}
         type={WorkflowRunType.ReferenceDownloader}
+        title="Fetch this source from the web"
+        description="Draft Detective searches for this reference and downloads the full text if it finds one it can read."
+        helpTopic="source-files"
+        submitLabel="Fetch source"
         projectId={projectId}
         onConfirm={() =>
           fetchFromWeb.mutate(undefined, {

--- a/frontend/components/results-v2/references/reference-detail.tsx
+++ b/frontend/components/results-v2/references/reference-detail.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { Markdown } from '@/components/markdown';
+import { FileUploadDialog } from '@/components/results/tabs/reference-review/file-upload-dialog';
+import { useFetchFromWebMutation, useRemoveFileMutation } from '@/components/results/tabs/reference-review/mutations';
+import { ReferenceReviewItem, ReferenceReviewStatus } from '@/components/results/tabs/reference-review/types';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { FileDownloadLink } from '@/components/ui/file-download-link';
+import { WorkflowConfigDialog } from '@/components/workflows/workflow-config-dialog';
+import { MatchSource, WorkflowRunType } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  Download,
+  FileText,
+  FileX,
+  GlobeIcon,
+  Loader2,
+  LucideIcon,
+  Sparkles,
+  Trash2,
+  Upload,
+  User,
+} from 'lucide-react';
+import { ReactNode, useEffect, useState } from 'react';
+import { readFetchOutcome } from './fetch-outcome';
+import { STATUS } from './status';
+
+const SOURCE: Record<MatchSource, { icon: LucideIcon; label: string }> = {
+  [MatchSource.ManualUpload]: { icon: User, label: 'Uploaded by someone on the project' },
+  [MatchSource.AutoMatched]: { icon: Sparkles, label: 'Matched from your supporting documents' },
+  [MatchSource.AutoFetched]: { icon: GlobeIcon, label: 'Downloaded from the web' },
+};
+
+interface ReferenceDetailProps {
+  reference: ReferenceReviewItem;
+  projectId: string;
+  readOnly: boolean;
+  /** Files are being processed project-wide, so edits here would race. */
+  disabled: boolean;
+  /** Opens the shared explanation of why source files are wanted. */
+  onExplain: () => void;
+}
+
+/**
+ * Everything about one reference that is not the citation itself: which source
+ * file stands behind it, where that file came from, how to change it, and what
+ * the web fetch found. The list keeps only what you scan; this keeps what you
+ * act on, so a row does not have to carry six controls.
+ */
+export function ReferenceDetail({ reference, projectId, readOnly, disabled, onExplain }: ReferenceDetailProps) {
+  const { id, index, text, status, matchedFile, source, fetchResult } = reference;
+  const [uploadMode, setUploadMode] = useState<'upload' | 'replace' | null>(null);
+  const [fetchDialogOpen, setFetchDialogOpen] = useState(false);
+  const [removeOpen, setRemoveOpen] = useState(false);
+  // The backend only reports 'fetching' once the workflow starts, a round trip
+  // away; without this the button snaps back to idle in between.
+  const [fetchInitiated, setFetchInitiated] = useState(false);
+
+  const removeFile = useRemoveFileMutation(projectId, matchedFile?.id);
+  const fetchFromWeb = useFetchFromWebMutation(projectId, id, text);
+
+  const isFetching = fetchFromWeb.isPending || (fetchInitiated && status !== 'fetching');
+  const busy = removeFile.isPending || isFetching || uploadMode !== null;
+  const actionsDisabled = busy || status === 'fetching' || disabled;
+  const displayStatus: ReferenceReviewStatus = isFetching ? 'fetching' : status;
+  const fetchRead = fetchResult ? readFetchOutcome(fetchResult) : null;
+
+  useEffect(() => {
+    if (fetchInitiated && (status === 'fetching' || status === 'matched')) setFetchInitiated(false);
+  }, [fetchInitiated, status]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <FileUploadDialog
+        isOpen={uploadMode !== null}
+        title={uploadMode === 'replace' ? 'Replace source file' : 'Provide source file'}
+        description={
+          uploadMode === 'replace'
+            ? 'Upload a new document to take the place of the current one. We process it and match it to this reference.'
+            : 'Upload the document this reference cites. We process it and match it to this reference.'
+        }
+        multiple={false}
+        projectId={projectId}
+        referenceId={id}
+        onCancel={() => setUploadMode(null)}
+        onComplete={() => setUploadMode(null)}
+      />
+
+      <WorkflowConfigDialog
+        isOpen={fetchDialogOpen}
+        type={WorkflowRunType.ReferenceDownloader}
+        projectId={projectId}
+        onConfirm={() =>
+          fetchFromWeb.mutate(undefined, {
+            onSuccess: () => {
+              setFetchDialogOpen(false);
+              setFetchInitiated(true);
+            },
+          })
+        }
+        onCancel={() => setFetchDialogOpen(false)}
+      />
+
+      <AlertDialog open={removeOpen} onOpenChange={setRemoveOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this source file?</AlertDialogTitle>
+            <AlertDialogDescription className="break-all">
+              {matchedFile?.name} will no longer be matched to this reference, and assessments that read sources will
+              skip it.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => removeFile.mutate()}>Remove</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <div className="bg-background/90 sticky top-0 z-10 flex h-10 shrink-0 items-center gap-2 border-b px-4 backdrop-blur">
+        <span className={cn('text-xs font-medium', STATUS[displayStatus].text)}>
+          {displayStatus === 'fetching' ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Loader2 className="size-3.5 animate-spin" />
+              {STATUS.fetching.label}
+            </span>
+          ) : (
+            STATUS[displayStatus].label
+          )}
+        </span>
+        <span className="ml-auto font-mono text-[11px] tabular-nums text-muted-foreground">Reference {index + 1}</span>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-4 py-4">
+        <Section title="Source file">
+          {matchedFile ? (
+            <div className="space-y-2">
+              <div className="rounded-md border p-2.5">
+                <FileDownloadLink
+                  fileId={matchedFile.id}
+                  className="group flex min-w-0 items-start gap-2 text-[12.5px]"
+                >
+                  <FileText className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1">
+                    <span className="text-primary block break-all group-hover:underline">{matchedFile.name}</span>
+                    <span className="text-[11px] text-muted-foreground">{matchedFile.size}</span>
+                  </span>
+                  <Download className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                </FileDownloadLink>
+                {source && <SourceLine source={source} />}
+              </div>
+
+              {!readOnly && (
+                <div className="flex flex-wrap gap-1.5">
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={actionsDisabled}
+                    onClick={() => setUploadMode('replace')}
+                  >
+                    <Upload className="size-3" />
+                    Replace
+                  </Button>
+                  <Button size="xs" variant="outline" disabled={actionsDisabled} onClick={() => setRemoveOpen(true)}>
+                    {removeFile.isPending ? <Loader2 className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
+                    Remove
+                  </Button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <p className={cn('flex items-start gap-2 text-[12.5px]', STATUS.unmatched.text)}>
+                <FileX className="mt-0.5 size-3.5 shrink-0" />
+                <span>
+                  {displayStatus === 'fetching'
+                    ? 'We are searching the web for a copy of this source.'
+                    : 'Source file has not been provided for this reference yet.'}{' '}
+                  <button
+                    onClick={onExplain}
+                    className="cursor-pointer text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                  >
+                    What is this?
+                  </button>
+                </span>
+              </p>
+
+              {!readOnly && (
+                <div className="flex flex-wrap gap-1.5">
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={actionsDisabled}
+                    onClick={() => setFetchDialogOpen(true)}
+                  >
+                    {isFetching ? <Loader2 className="size-3 animate-spin" /> : <GlobeIcon className="size-3" />}
+                    Fetch from the web
+                  </Button>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={actionsDisabled}
+                    onClick={() => setUploadMode('upload')}
+                  >
+                    <Upload className="size-3" />
+                    Upload
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </Section>
+
+        {fetchRead && (
+          <Section title="Web fetch">
+            <div className="space-y-1.5 text-[12.5px] leading-relaxed">
+              <p className={cn('font-medium', fetchRead.outcome.className)}>{fetchRead.outcome.label}</p>
+              {fetchRead.detail && <p className="text-foreground/80">{fetchRead.detail}</p>}
+              {fetchRead.sourceUrl && (
+                <p className="min-w-0">
+                  <span className="mr-1.5 font-mono text-[10px] text-muted-foreground uppercase">Source</span>
+                  <a
+                    href={fetchRead.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary break-all hover:underline"
+                  >
+                    {fetchRead.sourceUrl}
+                  </a>
+                </p>
+              )}
+              {fetchRead.reasoning && (
+                <details className="group">
+                  <summary className="inline-flex cursor-pointer list-none items-center gap-0.5 text-[11px] font-medium text-muted-foreground hover:text-foreground">
+                    <ChevronRightIcon className="size-3 group-open:hidden" />
+                    <ChevronDownIcon className="hidden size-3 group-open:inline" />
+                    <span className="group-open:hidden">How we looked</span>
+                    <span className="hidden group-open:inline">Hide how we looked</span>
+                  </summary>
+                  <div className="bg-muted/50 text-foreground/80 mt-1.5 rounded-md border p-2.5 text-[11.5px] leading-relaxed [&_p]:mb-1 [&_p:last-child]:mb-0">
+                    <Markdown>{fetchRead.reasoning}</Markdown>
+                  </div>
+                </details>
+              )}
+            </div>
+          </Section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SourceLine({ source }: { source: MatchSource }) {
+  const { icon: Icon, label } = SOURCE[source];
+  return (
+    <p className="mt-2 flex items-center gap-1.5 border-t pt-2 text-[11px] text-muted-foreground">
+      <Icon className="size-3 shrink-0" />
+      {label}
+    </p>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-2 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">{title}</h3>
+      {children}
+    </section>
+  );
+}

--- a/frontend/components/results-v2/references/reference-detail.tsx
+++ b/frontend/components/results-v2/references/reference-detail.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { FileDownloadLink } from '@/components/ui/file-download-link';
+import { HelpLink } from '@/components/help/help-link';
 import { WorkflowConfigDialog } from '@/components/workflows/workflow-config-dialog';
 import { MatchSource, WorkflowRunType } from '@/lib/generated-api';
 import { cn } from '@/lib/utils';
@@ -50,7 +51,6 @@ interface ReferenceDetailProps {
   /** Files are being processed project-wide, so edits here would race. */
   disabled: boolean;
   /** Opens the shared explanation of why source files are wanted. */
-  onExplain: () => void;
 }
 
 /**
@@ -59,7 +59,7 @@ interface ReferenceDetailProps {
  * the web fetch found. The list keeps only what you scan; this keeps what you
  * act on, so a row does not have to carry six controls.
  */
-export function ReferenceDetail({ reference, projectId, readOnly, disabled, onExplain }: ReferenceDetailProps) {
+export function ReferenceDetail({ reference, projectId, readOnly, disabled }: ReferenceDetailProps) {
   const { id, index, text, status, matchedFile, source, fetchResult } = reference;
   const [uploadMode, setUploadMode] = useState<'upload' | 'replace' | null>(null);
   const [fetchDialogOpen, setFetchDialogOpen] = useState(false);
@@ -192,12 +192,7 @@ export function ReferenceDetail({ reference, projectId, readOnly, disabled, onEx
                   {displayStatus === 'fetching'
                     ? 'We are searching the web for a copy of this source.'
                     : 'Source file has not been provided for this reference yet.'}{' '}
-                  <button
-                    onClick={onExplain}
-                    className="cursor-pointer text-muted-foreground underline underline-offset-2 hover:text-foreground"
-                  >
-                    What is this?
-                  </button>
+                  <HelpLink topic="source-files">What is this?</HelpLink>
                 </span>
               </p>
 

--- a/frontend/components/results-v2/references/reference-row.tsx
+++ b/frontend/components/results-v2/references/reference-row.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Markdown } from '@/components/markdown';
+import { ReferenceReviewItem } from '@/components/results/tabs/reference-review/types';
+import { cn } from '@/lib/utils';
+import { FileText, FileX, Loader2 } from 'lucide-react';
+import { STATUS } from './status';
+
+interface ReferenceRowProps {
+  reference: ReferenceReviewItem;
+  active: boolean;
+  onSelect: () => void;
+}
+
+/**
+ * One row of the bibliography: the citation, and whether a source file stands
+ * behind it. Nothing else — the file's provenance and the controls that change
+ * it live in the detail pane, so scanning fifty references stays scanning.
+ */
+export function ReferenceRow({ reference, active, onSelect }: ReferenceRowProps) {
+  const { index, text, status, matchedFile } = reference;
+
+  return (
+    // A div rather than a button: the citation renders as markdown, and block
+    // elements are not allowed inside a button.
+    <div
+      id={`reference-${index}`}
+      role="button"
+      tabIndex={0}
+      aria-pressed={active}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      className={cn(
+        'relative flex cursor-pointer gap-3 px-4 py-3 text-left transition-colors',
+        // A bar on the edge rather than a heavier tint: the row is what the
+        // detail pane is describing, so it has to be findable at a glance.
+        active
+          ? 'bg-accent before:bg-primary before:absolute before:inset-y-0 before:left-0 before:w-0.5'
+          : 'hover:bg-accent/40',
+      )}
+    >
+      <span className="w-8 shrink-0 pt-0.5 text-right font-mono text-[11px] tabular-nums text-muted-foreground">
+        {index + 1}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="max-w-4xl text-[13.5px] leading-relaxed [&_p]:mb-0">
+          <Markdown>{text}</Markdown>
+        </div>
+
+        <p className="mt-1.5 flex min-w-0 items-center gap-1.5 text-[11px]">
+          {status === 'fetching' ? (
+            <>
+              <Loader2 className={cn('size-3 shrink-0 animate-spin', STATUS.fetching.text)} />
+              <span className={STATUS.fetching.text}>{STATUS.fetching.label}</span>
+            </>
+          ) : matchedFile ? (
+            <>
+              <FileText className={cn('size-3 shrink-0', STATUS.matched.text)} />
+              <span className={cn('shrink-0 font-medium', STATUS.matched.text)}>{STATUS.matched.label}:</span>
+              <span className={cn('truncate', STATUS.matched.text)}>{matchedFile.name}</span>
+            </>
+          ) : (
+            <>
+              <FileX className={cn('size-3 shrink-0', STATUS.unmatched.text)} />
+              <span className={cn('font-medium', STATUS.unmatched.text)}>{STATUS.unmatched.label}</span>
+            </>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/references/reference-row.tsx
+++ b/frontend/components/results-v2/references/reference-row.tsx
@@ -30,6 +30,10 @@ export function ReferenceRow({ reference, active, onSelect }: ReferenceRowProps)
       aria-pressed={active}
       onClick={onSelect}
       onKeyDown={(event) => {
+        // Only when the row itself has focus. The citation renders as markdown
+        // and its DOI links are focusable, and swallowing their Enter would
+        // select the row instead of following the link.
+        if (event.target !== event.currentTarget) return;
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
           onSelect();

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -4,7 +4,7 @@ import { CopyReferencesDialog } from '@/components/references/copy-references-di
 import { useFetchAllFromWebMutation } from '@/components/results/tabs/reference-review/mutations';
 import { useReferenceReviewReferences } from '@/components/results/tabs/reference-review/queries';
 import { ReferenceReviewStatus } from '@/components/results/tabs/reference-review/types';
-import { HelpCenter } from '@/components/help/help-center';
+import { HelpLink } from '@/components/help/help-link';
 import { UnmatchedReferencesApproveDialog } from '@/components/results/tabs/reference-review/unmatched-references-approve-dialog';
 import { useReferenceApprovalFlow } from '@/components/results/tabs/reference-review/use-reference-approval-flow';
 import { useScrollToReference } from '@/components/results/tabs/reference-review/use-scroll-to-reference';
@@ -53,7 +53,6 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
   const [copyOpen, setCopyOpen] = useState(false);
   const [fetchAllOpen, setFetchAllOpen] = useState(false);
   const [batchUploadOpen, setBatchUploadOpen] = useState(false);
-  const [explainOpen, setExplainOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   useScrollToReference();
@@ -135,7 +134,6 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
         open={copyOpen}
         onOpenChange={setCopyOpen}
       />
-      <HelpCenter open={explainOpen} onOpenChange={setExplainOpen} topic="source-files" />
       <UnmatchedReferencesApproveDialog
         open={approval.showUnmatchedWarning}
         onOpenChange={approval.setShowUnmatchedWarning}
@@ -151,7 +149,6 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
             rail.close();
           }}
           counts={counts}
-          onExplain={() => setExplainOpen(true)}
         />
       </Rail>
 
@@ -328,7 +325,6 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
               projectId={projectId}
               readOnly={readOnly}
               disabled={approval.isProcessingFiles}
-              onExplain={() => setExplainOpen(true)}
             />
           )}
         </SidePane>
@@ -348,12 +344,10 @@ function LensRail({
   lens,
   onLensChange,
   counts,
-  onExplain,
 }: {
   lens: Lens;
   onLensChange: (lens: Lens) => void;
   counts: Record<'all' | 'unmatched' | 'matched' | 'fetching' | 'withFile', number>;
-  onExplain: () => void;
 }) {
   return (
     <div className="flex h-full flex-col">
@@ -390,10 +384,7 @@ function LensRail({
 
       <p className="shrink-0 border-t px-5 py-4 text-xs leading-relaxed text-muted-foreground">
         Some assessments — Claim Reference Validation among them — read the original source documents behind your
-        bibliographic references.{' '}
-        <button onClick={onExplain} className="cursor-pointer underline underline-offset-2 hover:text-foreground">
-          More details
-        </button>
+        bibliographic references. <HelpLink topic="source-files">More details</HelpLink>
       </p>
     </div>
   );

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -79,6 +79,14 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
     [references],
   );
 
+  // What the zip will actually hold. Counting matched references instead reports
+  // a different number: a source can sit in the project without any reference
+  // claiming it, and the download asks the API for the role, not for the matches.
+  const sourceFileCount = useMemo(
+    () => (projectDetail.files ?? []).filter((file) => file.role === FileRole.Support).length,
+    [projectDetail.files],
+  );
+
   const shown = useMemo(() => {
     const query = search.trim().toLowerCase();
     return references.filter((reference) => {
@@ -221,9 +229,11 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
                     <Copy className="size-4" />
                     Copy all references
                   </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => downloadAll()} disabled={counts.withFile === 0 || isDownloading}>
+                  <DropdownMenuItem onSelect={() => downloadAll()} disabled={sourceFileCount === 0 || isDownloading}>
                     {isDownloading ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
-                    {isDownloading ? 'Preparing zip…' : `Download ${counts.withFile} source files (.zip)`}
+                    {isDownloading
+                      ? 'Preparing zip…'
+                      : `Download ${sourceFileCount} source file${sourceFileCount === 1 ? '' : 's'} (.zip)`}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -113,6 +113,10 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
       <WorkflowConfigDialog
         isOpen={fetchAllOpen}
         type={WorkflowRunType.ReferenceDownloader}
+        title="Fetch source files from the web"
+        description="Draft Detective searches for each reference without a source file and downloads the full text when it finds one it can read."
+        helpTopic="source-files"
+        submitLabel="Fetch sources"
         projectId={projectId}
         onConfirm={handleFetchAllConfirm}
         onCancel={() => setFetchAllOpen(false)}

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -20,6 +20,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { WorkflowConfigDialog } from '@/components/workflows/workflow-config-dialog';
 import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
 import { FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { RAIL_ITEM_ACTIVE, RAIL_ITEM_IDLE } from '@/lib/rail-style';
 import { cn } from '@/lib/utils';
 import { getWorkflowRunByType, isWorkflowProcessing } from '@/lib/workflow-state';
 import { Copy, Download, FileText, GlobeIcon, Loader2, MoreHorizontal, Search, Upload } from 'lucide-react';
@@ -186,6 +187,7 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
                   <Button
                     size="xs"
                     variant="outline"
+                    aria-label="Fetch all missing"
                     disabled={isFetchingAll || isProcessingFiles || counts.unmatched === 0}
                     onClick={() => setFetchAllOpen(true)}
                   >
@@ -206,6 +208,7 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
                   <Button
                     size="xs"
                     variant="outline"
+                    aria-label="Upload sources"
                     disabled={isProcessingFiles}
                     onClick={() => setBatchUploadOpen(true)}
                   >
@@ -383,7 +386,7 @@ function LensRail({
                 aria-pressed={lens === entry.id}
                 className={cn(
                   'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
-                  lens === entry.id ? 'bg-accent text-accent-foreground font-medium' : 'hover:bg-accent/60',
+                  lens === entry.id ? RAIL_ITEM_ACTIVE : RAIL_ITEM_IDLE,
                 )}
               >
                 <span className="flex-1 truncate">{entry.label}</span>

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -4,7 +4,7 @@ import { CopyReferencesDialog } from '@/components/references/copy-references-di
 import { useFetchAllFromWebMutation } from '@/components/results/tabs/reference-review/mutations';
 import { useReferenceReviewReferences } from '@/components/results/tabs/reference-review/queries';
 import { ReferenceReviewStatus } from '@/components/results/tabs/reference-review/types';
-import { ReferenceReviewExplainer } from '@/components/results/tabs/reference-review/reference-review-explainer';
+import { HelpCenter } from '@/components/help/help-center';
 import { UnmatchedReferencesApproveDialog } from '@/components/results/tabs/reference-review/unmatched-references-approve-dialog';
 import { useReferenceApprovalFlow } from '@/components/results/tabs/reference-review/use-reference-approval-flow';
 import { useScrollToReference } from '@/components/results/tabs/reference-review/use-scroll-to-reference';
@@ -131,7 +131,7 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
         open={copyOpen}
         onOpenChange={setCopyOpen}
       />
-      <ReferenceReviewExplainer open={explainOpen} onOpenChange={setExplainOpen} />
+      <HelpCenter open={explainOpen} onOpenChange={setExplainOpen} topic="source-files" />
       <UnmatchedReferencesApproveDialog
         open={approval.showUnmatchedWarning}
         onOpenChange={approval.setShowUnmatchedWarning}

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -1,0 +1,399 @@
+'use client';
+
+import { CopyReferencesDialog } from '@/components/references/copy-references-dialog';
+import { useFetchAllFromWebMutation } from '@/components/results/tabs/reference-review/mutations';
+import { useReferenceReviewReferences } from '@/components/results/tabs/reference-review/queries';
+import { ReferenceReviewStatus } from '@/components/results/tabs/reference-review/types';
+import { ReferenceReviewExplainer } from '@/components/results/tabs/reference-review/reference-review-explainer';
+import { UnmatchedReferencesApproveDialog } from '@/components/results/tabs/reference-review/unmatched-references-approve-dialog';
+import { useReferenceApprovalFlow } from '@/components/results/tabs/reference-review/use-reference-approval-flow';
+import { useScrollToReference } from '@/components/results/tabs/reference-review/use-scroll-to-reference';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { WorkflowConfigDialog } from '@/components/workflows/workflow-config-dialog';
+import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
+import { FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import { getWorkflowRunByType, isWorkflowProcessing } from '@/lib/workflow-state';
+import { Copy, Download, FileText, GlobeIcon, Loader2, MoreHorizontal, PanelLeft, Search, Upload } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { FileUploadDialog } from '@/components/results/tabs/reference-review/file-upload-dialog';
+import { ReferenceDetail } from './reference-detail';
+import { ReferenceRow } from './reference-row';
+
+type Lens = 'all' | ReferenceReviewStatus;
+
+interface ReferencesTabV2Props {
+  projectDetail: ProjectDetailed;
+  readOnly: boolean;
+}
+
+/**
+ * The references tab in the v2 frame: a rail that narrows the list, a toolbar
+ * that acts on all of it, and one flat row per reference. The right-hand
+ * evidence pane the mock carried is gone — reference validation reports its
+ * findings as issues in the document explorer, so a second place to read them
+ * would only be a second place to keep in sync.
+ */
+export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Props) {
+  const projectId = projectDetail.project.id;
+  const workflowRuns = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
+
+  const [railOpen, setRailOpen] = useState(true);
+  const [lens, setLens] = useState<Lens>('all');
+  const [search, setSearch] = useState('');
+  const [copyOpen, setCopyOpen] = useState(false);
+  const [fetchAllOpen, setFetchAllOpen] = useState(false);
+  const [batchUploadOpen, setBatchUploadOpen] = useState(false);
+  const [explainOpen, setExplainOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useScrollToReference();
+
+  const references = useReferenceReviewReferences(projectDetail);
+  const approval = useReferenceApprovalFlow(projectDetail, projectId);
+  const fetchAll = useFetchAllFromWebMutation(projectId);
+  const { downloadAll, isDownloading } = useDownloadAllProjectFiles(projectId, [FileRole.Support]);
+
+  const referenceExtraction = getWorkflowRunByType(workflowRuns, WorkflowRunType.ReferenceExtraction);
+  const referenceDownloader = getWorkflowRunByType(workflowRuns, WorkflowRunType.ReferenceDownloader);
+  const isExtracting = isWorkflowProcessing(referenceExtraction);
+  const isFetchingAll = fetchAll.isPending || isWorkflowProcessing(referenceDownloader);
+  const isProcessingFiles = approval.isProcessingFiles;
+
+  const counts = useMemo(
+    () => ({
+      all: references.length,
+      unmatched: references.filter((r) => r.status === 'unmatched').length,
+      matched: references.filter((r) => r.status === 'matched').length,
+      fetching: references.filter((r) => r.status === 'fetching').length,
+      withFile: references.filter((r) => r.matchedFile).length,
+    }),
+    [references],
+  );
+
+  const shown = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return references.filter((reference) => {
+      if (lens !== 'all' && reference.status !== lens) return false;
+      if (!query) return true;
+      return (
+        reference.text?.toLowerCase().includes(query) || !!reference.matchedFile?.name.toLowerCase().includes(query)
+      );
+    });
+  }, [references, lens, search]);
+
+  const filtered = lens !== 'all' || search.trim() !== '';
+  // Looked up in the filtered list, not all of them: a pane describing a row
+  // the filter has hidden is a pane pointing at nothing. The id is kept, so
+  // clearing the filter brings the selection back.
+  const selected = shown.find((reference) => reference.id === selectedId) ?? null;
+
+  if (isExtracting) {
+    return <ExtractingState />;
+  }
+
+  const handleFetchAllConfirm = () => {
+    const unmatched = references
+      .filter((reference) => reference.status === 'unmatched')
+      .map((reference) => ({ reference_id: reference.id, text: reference.text }));
+    fetchAll.mutate({ references: unmatched }, { onSuccess: () => setFetchAllOpen(false) });
+  };
+
+  return (
+    <div className="flex h-full min-h-0">
+      <WorkflowConfigDialog
+        isOpen={fetchAllOpen}
+        type={WorkflowRunType.ReferenceDownloader}
+        projectId={projectId}
+        onConfirm={handleFetchAllConfirm}
+        onCancel={() => setFetchAllOpen(false)}
+      />
+      <FileUploadDialog
+        isOpen={batchUploadOpen}
+        title="Upload source documents"
+        description="Upload as many sources as you like. We process each one and match it to the reference it belongs to."
+        multiple
+        projectId={projectId}
+        onCancel={() => setBatchUploadOpen(false)}
+        onComplete={() => setBatchUploadOpen(false)}
+      />
+      <CopyReferencesDialog
+        references={references.map((reference) => reference.text)}
+        open={copyOpen}
+        onOpenChange={setCopyOpen}
+      />
+      <ReferenceReviewExplainer open={explainOpen} onOpenChange={setExplainOpen} />
+      <UnmatchedReferencesApproveDialog
+        open={approval.showUnmatchedWarning}
+        onOpenChange={approval.setShowUnmatchedWarning}
+        unmatchedCount={approval.unmatchedCount}
+        onConfirmApprove={approval.handleConfirmApprove}
+      />
+
+      <aside
+        className={cn(
+          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
+          railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
+        )}
+      >
+        <LensRail lens={lens} onLensChange={setLens} counts={counts} onExplain={() => setExplainOpen(true)} />
+      </aside>
+
+      <main className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="hidden size-7 xl:flex"
+            onClick={() => setRailOpen(!railOpen)}
+            aria-label={railOpen ? 'Hide filters' : 'Show filters'}
+            aria-pressed={railOpen}
+          >
+            <PanelLeft className="size-4" />
+          </Button>
+
+          <span className="shrink-0 truncate text-xs text-muted-foreground">
+            {filtered ? `${shown.length} of ${counts.all} references` : `${counts.all} references`}
+          </span>
+
+          <div className="relative ml-2 hidden max-w-64 min-w-0 flex-1 sm:block">
+            <Search className="absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search references and files"
+              className="h-7 pl-7 text-xs"
+            />
+          </div>
+
+          {!readOnly && (
+            <div className="ml-auto flex shrink-0 items-center gap-1.5">
+              <Button
+                size="xs"
+                variant="outline"
+                disabled={isFetchingAll || isProcessingFiles || counts.unmatched === 0}
+                onClick={() => setFetchAllOpen(true)}
+              >
+                {isFetchingAll ? <Loader2 className="size-3 animate-spin" /> : <GlobeIcon className="size-3" />}
+                Fetch all missing
+              </Button>
+              <Button size="xs" variant="outline" disabled={isProcessingFiles} onClick={() => setBatchUploadOpen(true)}>
+                <Upload className="size-3" />
+                Upload sources
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button size="icon" variant="ghost" className="size-7" aria-label="More reference actions">
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onSelect={() => setCopyOpen(true)}>
+                    <Copy className="size-4" />
+                    Copy all references
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => downloadAll()} disabled={counts.withFile === 0 || isDownloading}>
+                    {isDownloading ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+                    {isDownloading ? 'Preparing zip…' : `Download ${counts.withFile} source files (.zip)`}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+        </div>
+
+        {isProcessingFiles && (
+          <div className="flex shrink-0 items-center gap-2 border-b bg-blue-50 px-4 py-2 text-xs dark:bg-blue-950/30">
+            <Loader2 className="size-3.5 shrink-0 animate-spin text-blue-700 dark:text-blue-400" />
+            <span>
+              <strong className="font-medium">Processing your source files.</strong>{' '}
+              <span className="text-muted-foreground">
+                We are indexing them and matching them to references — usually a minute or two.
+              </span>
+            </span>
+          </div>
+        )}
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {references.length === 0 ? (
+            <EmptyState />
+          ) : shown.length === 0 ? (
+            <div className="space-y-1 py-12 text-center text-sm text-muted-foreground">
+              <p>No references match this view.</p>
+              <Button
+                variant="link"
+                size="sm"
+                className="text-xs"
+                onClick={() => {
+                  setLens('all');
+                  setSearch('');
+                }}
+              >
+                Clear filters
+              </Button>
+            </div>
+          ) : (
+            <div className="divide-y">
+              {shown.map((reference) => (
+                <ReferenceRow
+                  key={reference.id}
+                  reference={reference}
+                  active={reference.id === selectedId}
+                  onSelect={() => setSelectedId(reference.id)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {approval.hasPendingApproval && !readOnly && (
+          <div className="flex shrink-0 flex-wrap items-center gap-3 border-t px-4 py-2.5">
+            <span className="min-w-0 text-sm">
+              {counts.unmatched > 0 ? (
+                <>
+                  <strong className="font-medium">
+                    {counts.unmatched} reference{counts.unmatched === 1 ? ' has' : 's have'} no source file provided.
+                  </strong>{' '}
+                  <span className="text-muted-foreground">
+                    Claim Reference Validation will mark {counts.unmatched === 1 ? 'its claims' : 'their claims'}{' '}
+                    unverifiable.
+                  </span>
+                </>
+              ) : (
+                <span className="text-muted-foreground">Every reference has its source file. Ready when you are.</span>
+              )}
+            </span>
+            <Button
+              size="sm"
+              className="ml-auto h-7"
+              onClick={approval.handleApprove}
+              disabled={approval.isApproveDisabled}
+            >
+              {approval.showApproveButtonSpinner && <Loader2 className="size-3 animate-spin" />}
+              {approval.approveButtonText}
+            </Button>
+          </div>
+        )}
+      </main>
+
+      {references.length > 0 && (
+        <aside className="hidden w-[24rem] shrink-0 border-l lg:block xl:w-[26rem]">
+          {selected ? (
+            <ReferenceDetail
+              key={selected.id}
+              reference={selected}
+              projectId={projectId}
+              readOnly={readOnly}
+              disabled={approval.isProcessingFiles}
+              onExplain={() => setExplainOpen(true)}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center p-8">
+              <p className="max-w-56 text-center text-xs leading-relaxed text-muted-foreground">
+                Select a reference to see more details, provide or replace a source file.
+              </p>
+            </div>
+          )}
+        </aside>
+      )}
+    </div>
+  );
+}
+
+const LENSES: { id: Lens; label: string; countKey: 'all' | 'unmatched' | 'matched' | 'fetching' }[] = [
+  { id: 'all', label: 'All references', countKey: 'all' },
+  { id: 'unmatched', label: 'Source file not provided', countKey: 'unmatched' },
+  { id: 'matched', label: 'Source file provided', countKey: 'matched' },
+  { id: 'fetching', label: 'Fetching', countKey: 'fetching' },
+];
+
+function LensRail({
+  lens,
+  onLensChange,
+  counts,
+  onExplain,
+}: {
+  lens: Lens;
+  onLensChange: (lens: Lens) => void;
+  counts: Record<'all' | 'unmatched' | 'matched' | 'fetching' | 'withFile', number>;
+  onExplain: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <div className="flex items-center justify-between px-2">
+          <h2 className="font-mono text-[10px] tracking-wide text-muted-foreground uppercase">Filter references</h2>
+          {lens !== 'all' && (
+            <Button variant="link" size="sm" className="h-auto p-0 text-xs" onClick={() => onLensChange('all')}>
+              Clear
+            </Button>
+          )}
+        </div>
+        <div className="mt-2 space-y-px">
+          {LENSES.map((entry) => {
+            const count = counts[entry.countKey];
+            if (entry.id === 'fetching' && count === 0) return null;
+            return (
+              <button
+                key={entry.id}
+                onClick={() => onLensChange(entry.id)}
+                aria-pressed={lens === entry.id}
+                className={cn(
+                  'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+                  lens === entry.id ? 'bg-accent text-accent-foreground font-medium' : 'hover:bg-accent/60',
+                )}
+              >
+                <span className="flex-1 truncate">{entry.label}</span>
+                <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="shrink-0 border-t px-5 py-4 text-xs leading-relaxed text-muted-foreground">
+        Some assessments — Claim Reference Validation among them — read the original source documents behind your
+        bibliographic references.{' '}
+        <button onClick={onExplain} className="cursor-pointer underline underline-offset-2 hover:text-foreground">
+          More details
+        </button>
+      </p>
+    </div>
+  );
+}
+
+function ExtractingState() {
+  return (
+    <div className="flex h-full items-center justify-center p-8">
+      <div className="max-w-sm space-y-2 text-center">
+        <Loader2 className="text-primary mx-auto size-7 animate-spin" />
+        <p className="text-sm font-medium">Finding references in your document</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Usually two to ten minutes, depending on how long the document is. You can leave this page — we keep working.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex h-full items-center justify-center p-8">
+      <div className="max-w-sm space-y-2 text-center">
+        <FileText className="mx-auto size-7 text-muted-foreground" />
+        <p className="text-sm font-medium">No references found</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          We did not find a bibliography in this document. Assessments that read sources have nothing to check against.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -22,9 +22,10 @@ import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-fil
 import { FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { cn } from '@/lib/utils';
 import { getWorkflowRunByType, isWorkflowProcessing } from '@/lib/workflow-state';
-import { Copy, Download, FileText, GlobeIcon, Loader2, MoreHorizontal, PanelLeft, Search, Upload } from 'lucide-react';
+import { Copy, Download, FileText, GlobeIcon, Loader2, MoreHorizontal, Search, Upload } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { FileUploadDialog } from '@/components/results/tabs/reference-review/file-upload-dialog';
+import { Rail, RailToggle, SidePane, useRailState } from '../panes';
 import { ReferenceDetail } from './reference-detail';
 import { ReferenceRow } from './reference-row';
 
@@ -46,7 +47,7 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
   const projectId = projectDetail.project.id;
   const workflowRuns = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
 
-  const [railOpen, setRailOpen] = useState(true);
+  const rail = useRailState();
   const [lens, setLens] = useState<Lens>('all');
   const [search, setSearch] = useState('');
   const [copyOpen, setCopyOpen] = useState(false);
@@ -138,32 +139,21 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
         onConfirmApprove={approval.handleConfirmApprove}
       />
 
-      <aside
-        className={cn(
-          'bg-sidebar hidden shrink-0 border-r transition-[width] xl:block',
-          railOpen ? 'w-72' : 'w-0 overflow-hidden border-r-0',
-        )}
-      >
-        <LensRail lens={lens} onLensChange={setLens} counts={counts} onExplain={() => setExplainOpen(true)} />
-      </aside>
+      <Rail state={rail} label="Filters">
+        <LensRail
+          lens={lens}
+          onLensChange={(next) => {
+            setLens(next);
+            rail.close();
+          }}
+          counts={counts}
+          onExplain={() => setExplainOpen(true)}
+        />
+      </Rail>
 
       <main className="flex min-w-0 flex-1 flex-col">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hidden size-7 xl:flex"
-                onClick={() => setRailOpen(!railOpen)}
-                aria-label={railOpen ? 'Hide filters' : 'Show filters'}
-                aria-pressed={railOpen}
-              >
-                <PanelLeft className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{railOpen ? 'Hide filters' : 'Show filters'}</TooltipContent>
-          </Tooltip>
+          <RailToggle state={rail} label="Filters" />
 
           <span className="shrink-0 truncate text-xs text-muted-foreground">
             {filtered ? `${shown.length} of ${counts.all} references` : `${counts.all} references`}
@@ -315,8 +305,19 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
       </main>
 
       {references.length > 0 && (
-        <aside className="hidden w-[24rem] shrink-0 border-l lg:block xl:w-[26rem]">
-          {selected ? (
+        <SidePane
+          open={selected !== null}
+          onClose={() => setSelectedId(null)}
+          label="Reference details"
+          empty={
+            <div className="flex h-full items-center justify-center p-8">
+              <p className="max-w-56 text-center text-xs leading-relaxed text-muted-foreground">
+                Select a reference to see more details, provide or replace a source file.
+              </p>
+            </div>
+          }
+        >
+          {selected && (
             <ReferenceDetail
               key={selected.id}
               reference={selected}
@@ -325,14 +326,8 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
               disabled={approval.isProcessingFiles}
               onExplain={() => setExplainOpen(true)}
             />
-          ) : (
-            <div className="flex h-full items-center justify-center p-8">
-              <p className="max-w-56 text-center text-xs leading-relaxed text-muted-foreground">
-                Select a reference to see more details, provide or replace a source file.
-              </p>
-            </div>
           )}
-        </aside>
+        </SidePane>
       )}
     </div>
   );

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { WorkflowConfigDialog } from '@/components/workflows/workflow-config-dialog';
 import { useDownloadAllProjectFiles } from '@/hooks/use-download-all-project-files';
 import { FileRole, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
@@ -148,16 +149,21 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
 
       <main className="flex min-w-0 flex-1 flex-col">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="hidden size-7 xl:flex"
-            onClick={() => setRailOpen(!railOpen)}
-            aria-label={railOpen ? 'Hide filters' : 'Show filters'}
-            aria-pressed={railOpen}
-          >
-            <PanelLeft className="size-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hidden size-7 xl:flex"
+                onClick={() => setRailOpen(!railOpen)}
+                aria-label={railOpen ? 'Hide filters' : 'Show filters'}
+                aria-pressed={railOpen}
+              >
+                <PanelLeft className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{railOpen ? 'Hide filters' : 'Show filters'}</TooltipContent>
+          </Tooltip>
 
           <span className="shrink-0 truncate text-xs text-muted-foreground">
             {filtered ? `${shown.length} of ${counts.all} references` : `${counts.all} references`}
@@ -176,25 +182,49 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
 
           {!readOnly && (
             <div className="ml-auto flex shrink-0 items-center gap-1.5">
-              <Button
-                size="xs"
-                variant="outline"
-                disabled={isFetchingAll || isProcessingFiles || counts.unmatched === 0}
-                onClick={() => setFetchAllOpen(true)}
-              >
-                {isFetchingAll ? <Loader2 className="size-3 animate-spin" /> : <GlobeIcon className="size-3" />}
-                Fetch all missing
-              </Button>
-              <Button size="xs" variant="outline" disabled={isProcessingFiles} onClick={() => setBatchUploadOpen(true)}>
-                <Upload className="size-3" />
-                Upload sources
-              </Button>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button size="icon" variant="ghost" className="size-7" aria-label="More reference actions">
-                    <MoreHorizontal className="size-4" />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={isFetchingAll || isProcessingFiles || counts.unmatched === 0}
+                    onClick={() => setFetchAllOpen(true)}
+                  >
+                    {isFetchingAll ? <Loader2 className="size-3 animate-spin" /> : <GlobeIcon className="size-3" />}
+                    Fetch all missing
                   </Button>
-                </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {counts.unmatched === 0
+                    ? 'Every reference already has a source file'
+                    : 'Search the web for the source files not provided yet'}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={isProcessingFiles}
+                    onClick={() => setBatchUploadOpen(true)}
+                  >
+                    <Upload className="size-3" />
+                    Upload sources
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Upload source files, and we match each one to its reference</TooltipContent>
+              </Tooltip>
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <Button size="icon" variant="ghost" className="size-7" aria-label="More reference actions">
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>More options</TooltipContent>
+                </Tooltip>
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem onSelect={() => setCopyOpen(true)}>
                     <Copy className="size-4" />

--- a/frontend/components/results-v2/references/references-tab.tsx
+++ b/frontend/components/results-v2/references/references-tab.tsx
@@ -190,7 +190,9 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
                     onClick={() => setFetchAllOpen(true)}
                   >
                     {isFetchingAll ? <Loader2 className="size-3 animate-spin" /> : <GlobeIcon className="size-3" />}
-                    Fetch all missing
+                    {/* Labels give way below sm: this row needs 430px of them,
+                        which is wider than the phone it sits on. */}
+                    <span className="hidden sm:inline">Fetch all missing</span>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
@@ -208,7 +210,7 @@ export function ReferencesTabV2({ projectDetail, readOnly }: ReferencesTabV2Prop
                     onClick={() => setBatchUploadOpen(true)}
                   >
                     <Upload className="size-3" />
-                    Upload sources
+                    <span className="hidden sm:inline">Upload sources</span>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Upload source files, and we match each one to its reference</TooltipContent>

--- a/frontend/components/results-v2/references/status.ts
+++ b/frontend/components/results-v2/references/status.ts
@@ -1,0 +1,27 @@
+import { ReferenceReviewStatus } from '@/components/results/tabs/reference-review/types';
+
+/**
+ * The one place the two states are named. "Provided" rather than "available",
+ * because whether we hold the file is the result of someone supplying it — by
+ * uploading, or by letting us fetch it.
+ */
+export const STATUS: Record<ReferenceReviewStatus, { label: string; short: string; text: string }> = {
+  matched: {
+    label: 'Source file provided',
+    short: 'Provided',
+    text: 'text-green-700 dark:text-green-400',
+  },
+  unmatched: {
+    // Amber, the app's colour for "waiting on you": these are the rows the
+    // reader is here to act on, and they have to be findable down a list of
+    // fifty that otherwise all look alike.
+    label: 'Source file not provided',
+    short: 'Not provided',
+    text: 'text-amber-700 dark:text-amber-400',
+  },
+  fetching: {
+    label: 'Looking for a source file',
+    short: 'Fetching',
+    text: 'text-blue-700 dark:text-blue-400',
+  },
+};

--- a/frontend/components/results-v2/use-project-shell-state.ts
+++ b/frontend/components/results-v2/use-project-shell-state.ts
@@ -53,9 +53,12 @@ export function useProjectShellState(projectId: string) {
       });
     },
     onSuccess: (updatedProject) => {
-      queryClient.setQueryData(['project', projectId], (curr: ProjectDetailed | undefined) =>
+      // The details query is keyed per revision (['project', id, revision]), so patch every
+      // cached revision instead of an exact key that would never match.
+      queryClient.setQueriesData({ queryKey: ['project', projectId] }, (curr: ProjectDetailed | undefined) =>
         curr ? { ...curr, project: updatedProject } : curr,
       );
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
       toast.success('Title updated successfully');
     },
     onError: (mutationError) => {

--- a/frontend/components/results-v2/use-project-shell-state.ts
+++ b/frontend/components/results-v2/use-project-shell-state.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useWorkflowProgressToast } from '@/hooks/use-workflow-progress-toast';
+import { getErrorMessage } from '@/lib/api-error';
+import { AccessLevel, ProjectDetailed, updateProjectEndpointApiProjectProjectIdPatch } from '@/lib/generated-api';
+import { useProjectDetails } from '@/lib/hooks/use-project-details';
+import { isAnyWorkflowProcessing, needsHumanApproval } from '@/lib/workflow-state';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Everything the project chrome needs that is not chrome: the project itself,
+ * which revision is being viewed, and saving the title.
+ *
+ * This mirrors the production `[projectId]/layout.tsx`, deliberately rather than
+ * being shared with it — the v2 tree is meant to be deletable, and the
+ * production layout should not have to care that it exists. Fold the two
+ * together when v2 replaces it.
+ */
+export function useProjectShellState(projectId: string) {
+  const queryClient = useQueryClient();
+
+  // null means "follow the latest revision"
+  const [selectedRevision, setSelectedRevision] = useState<number | null>(null);
+
+  const { project, workflowDetails, isLoading, error } = useProjectDetails(projectId, selectedRevision);
+
+  const currentRevision = project?.project?.current_revision ?? 1;
+  const effectiveRevision = selectedRevision ?? currentRevision;
+
+  const handleRevisionChange = useCallback((rev: number) => {
+    setSelectedRevision(rev);
+  }, []);
+
+  // After a new revision is created, drop back to "follow latest" so the view and
+  // switcher move to the newly created revision.
+  const handleRevisionCreated = useCallback(() => {
+    setSelectedRevision(null);
+  }, []);
+
+  const isProcessing = isAnyWorkflowProcessing(workflowDetails);
+  const awaitingHumanApproval = needsHumanApproval(workflowDetails);
+  // HumanApproval stays Pending/Running until the user approves, which keeps
+  // isProcessing true even though the pipeline is intentionally paused.
+  useWorkflowProgressToast(projectId, isProcessing && !awaitingHumanApproval);
+
+  const updateTitleMutation = useMutation({
+    mutationFn: async (newTitle: string) => {
+      return await updateProjectEndpointApiProjectProjectIdPatch({
+        path: { project_id: projectId },
+        body: { title: newTitle },
+      });
+    },
+    onSuccess: (updatedProject) => {
+      queryClient.setQueryData(['project', projectId], (curr: ProjectDetailed | undefined) =>
+        curr ? { ...curr, project: updatedProject } : curr,
+      );
+      toast.success('Title updated successfully');
+    },
+    onError: (mutationError) => {
+      toast.error(`Failed to update title: ${getErrorMessage(mutationError, 'Unknown error')}`);
+    },
+  });
+
+  const handleTitleSave = useCallback(
+    async (newTitle: string) => {
+      await updateTitleMutation.mutateAsync(newTitle);
+    },
+    [updateTitleMutation],
+  );
+
+  const isReadOnly = project ? project.access_level !== AccessLevel.Write : false;
+  const isViewingOldRevision = effectiveRevision < currentRevision;
+
+  return {
+    project,
+    workflowDetails,
+    isLoading,
+    error,
+    effectiveRevision,
+    handleRevisionChange,
+    handleRevisionCreated,
+    handleTitleSave,
+    isTitleSaving: updateTitleMutation.isPending,
+    readOnly: isReadOnly || isViewingOldRevision,
+    isReadOnly,
+    isViewingOldRevision,
+  };
+}

--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -21,6 +21,7 @@ import {
   WorkflowRunType,
 } from '@/lib/generated-api';
 import { useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
+import { cn } from '@/lib/utils';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
 import { getErrorMessage } from '@/lib/api-error';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -47,6 +48,11 @@ export interface AnalysisOptionsMenuProps {
   downloadLabel?: string;
   /** Drops the download button to secondary where another action leads the row. */
   downloadVariant?: 'default' | 'outline';
+  /**
+   * Labels give way to icons on narrow screens. For headers that carry other
+   * controls beside this one and would otherwise run off a phone screen.
+   */
+  compact?: boolean;
 }
 
 export function AnalysisOptionsMenu({
@@ -58,6 +64,7 @@ export function AnalysisOptionsMenu({
   onRevisionCreated,
   downloadLabel = 'Download DOCX',
   downloadVariant = 'default',
+  compact = false,
 }: AnalysisOptionsMenuProps) {
   const { filter } = useDocumentExplorerStore();
   const router = useRouter();
@@ -182,9 +189,12 @@ export function AnalysisOptionsMenu({
                   size="xs"
                   onClick={handleDownloadClick}
                   disabled={!hasDocx || isDownloading}
+                  aria-label={downloadLabel}
                 >
                   <Download />
-                  {isDownloading ? 'Downloading...' : downloadLabel}
+                  <span className={cn(compact && 'hidden sm:inline')}>
+                    {isDownloading ? 'Downloading...' : downloadLabel}
+                  </span>
                 </Button>
               </span>
             </TooltipTrigger>
@@ -202,6 +212,7 @@ export function AnalysisOptionsMenu({
               selectedRevision={selectedRevision}
               onRevisionChange={onRevisionChange}
               onCreateRevision={readOnly ? undefined : () => setIsReplaceDialogOpen(true)}
+              compact={compact}
             />
           )}
         </div>

--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -23,7 +24,8 @@ import { useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
 import { getErrorMessage } from '@/lib/api-error';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Download, EllipsisVerticalIcon, Link, Pencil, Plus } from 'lucide-react';
+import { ArrowLeftRight, Download, EllipsisVerticalIcon, Link, Pencil, Plus } from 'lucide-react';
+import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { downloadDocxFile, DocxType, useDownloadDocx } from './use-download-docx';
@@ -58,7 +60,19 @@ export function AnalysisOptionsMenu({
   downloadVariant = 'default',
 }: AnalysisOptionsMenuProps) {
   const { filter } = useDocumentExplorerStore();
+  const router = useRouter();
+  const pathname = usePathname();
   const projectId = project.id;
+
+  // The two layouts are the same routes under a /v2 prefix, so switching is
+  // adding or dropping it. Only offered on the project routes: the share view
+  // has no v2 counterpart.
+  const isNewLayout = pathname.startsWith('/v2/projects/');
+  const layoutSwitchPath = isNewLayout
+    ? pathname.slice('/v2'.length)
+    : pathname.startsWith('/projects/')
+      ? `/v2${pathname}`
+      : null;
   const share = useShareStatus(projectId, !readOnly);
   const shareContext = useShare();
   const queryClient = useQueryClient();
@@ -229,6 +243,23 @@ export function AnalysisOptionsMenu({
               >
                 {share.isEnabled ? 'Manage share link' : 'Share this assessment'}
               </MenuItemWithTooltip>
+
+              {layoutSwitchPath && (
+                <>
+                  <DropdownMenuSeparator />
+                  <MenuItemWithTooltip
+                    icon={ArrowLeftRight}
+                    onClick={() => router.push(`${layoutSwitchPath}${window.location.hash}`)}
+                    tooltip={
+                      isNewLayout
+                        ? 'Return to the layout the rest of the app uses.'
+                        : 'The same project in the redesigned layout. Nothing changes about your data.'
+                    }
+                  >
+                    {isNewLayout ? 'Back to the classic layout' : 'Try the new layout'}
+                  </MenuItemWithTooltip>
+                </>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -217,7 +217,10 @@ export function AnalysisOptionsMenu({
           )}
         </div>
 
-        {!readOnly && (
+        {/* The menu also carries the way back to the other layout, which a
+            read-only reader needs as much as an owner does — so it opens for
+            them too, holding only that entry. */}
+        {(!readOnly || layoutSwitchPath) && (
           <DropdownMenu>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -231,33 +234,37 @@ export function AnalysisOptionsMenu({
             </Tooltip>
 
             <DropdownMenuContent className="w-56">
-              <MenuItemWithTooltip
-                icon={Pencil}
-                onClick={() => setIsEditDialogOpen(true)}
-                tooltip="Edit project details"
-              >
-                Edit project details
-              </MenuItemWithTooltip>
+              {!readOnly && (
+                <>
+                  <MenuItemWithTooltip
+                    icon={Pencil}
+                    onClick={() => setIsEditDialogOpen(true)}
+                    tooltip="Edit project details"
+                  >
+                    Edit project details
+                  </MenuItemWithTooltip>
 
-              <MenuItemWithTooltip
-                icon={Plus}
-                onClick={() => setIsReplaceDialogOpen(true)}
-                tooltip="Upload a new version of the main document as a new revision. Previous revisions, their reviewer memos, and results are kept."
-              >
-                Create new revision
-              </MenuItemWithTooltip>
+                  <MenuItemWithTooltip
+                    icon={Plus}
+                    onClick={() => setIsReplaceDialogOpen(true)}
+                    tooltip="Upload a new version of the main document as a new revision. Previous revisions, their reviewer memos, and results are kept."
+                  >
+                    Create new revision
+                  </MenuItemWithTooltip>
 
-              <MenuItemWithTooltip
-                icon={Link}
-                onClick={() => share.setIsDialogOpen(true)}
-                tooltip={share.isEnabled ? 'View or copy the share link' : 'Create a public link'}
-              >
-                {share.isEnabled ? 'Manage share link' : 'Share this assessment'}
-              </MenuItemWithTooltip>
+                  <MenuItemWithTooltip
+                    icon={Link}
+                    onClick={() => share.setIsDialogOpen(true)}
+                    tooltip={share.isEnabled ? 'View or copy the share link' : 'Create a public link'}
+                  >
+                    {share.isEnabled ? 'Manage share link' : 'Share this assessment'}
+                  </MenuItemWithTooltip>
+                </>
+              )}
 
               {layoutSwitchPath && (
                 <>
-                  <DropdownMenuSeparator />
+                  {!readOnly && <DropdownMenuSeparator />}
                   <MenuItemWithTooltip
                     icon={ArrowLeftRight}
                     onClick={() => router.push(`${layoutSwitchPath}${window.location.hash}`)}

--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -43,6 +43,8 @@ export interface AnalysisOptionsMenuProps {
   onRevisionCreated?: () => void;
   /** Label for the download button. */
   downloadLabel?: string;
+  /** Drops the download button to secondary where another action leads the row. */
+  downloadVariant?: 'default' | 'outline';
 }
 
 export function AnalysisOptionsMenu({
@@ -53,6 +55,7 @@ export function AnalysisOptionsMenu({
   onRevisionChange,
   onRevisionCreated,
   downloadLabel = 'Download DOCX',
+  downloadVariant = 'default',
 }: AnalysisOptionsMenuProps) {
   const { filter } = useDocumentExplorerStore();
   const projectId = project.id;
@@ -156,21 +159,16 @@ export function AnalysisOptionsMenu({
         <div className="flex items-center gap-2">
           {!readOnly && <ShareStatusBadge isEnabled={share.isEnabled} onClick={() => share.setIsDialogOpen(true)} />}
 
-          {selectedRevision && onRevisionChange && (
-            <RevisionSwitcher
-              currentRevision={project.current_revision ?? 1}
-              totalRevisions={project.current_revision ?? 1}
-              selectedRevision={selectedRevision}
-              onRevisionChange={onRevisionChange}
-              onCreateRevision={readOnly ? undefined : () => setIsReplaceDialogOpen(true)}
-            />
-          )}
-
           <Tooltip>
             <TooltipTrigger asChild>
               {/* Wrapper span so the tooltip still fires while the button is disabled */}
               <span tabIndex={0}>
-                <Button variant="default" size="xs" onClick={handleDownloadClick} disabled={!hasDocx || isDownloading}>
+                <Button
+                  variant={downloadVariant}
+                  size="xs"
+                  onClick={handleDownloadClick}
+                  disabled={!hasDocx || isDownloading}
+                >
                   <Download />
                   {isDownloading ? 'Downloading...' : downloadLabel}
                 </Button>
@@ -182,6 +180,16 @@ export function AnalysisOptionsMenu({
                 : 'DOCX export is only available when the source document is a Word file (.docx or .doc)'}
             </TooltipContent>
           </Tooltip>
+
+          {selectedRevision && onRevisionChange && (
+            <RevisionSwitcher
+              currentRevision={project.current_revision ?? 1}
+              totalRevisions={project.current_revision ?? 1}
+              selectedRevision={selectedRevision}
+              onRevisionChange={onRevisionChange}
+              onCreateRevision={readOnly ? undefined : () => setIsReplaceDialogOpen(true)}
+            />
+          )}
         </div>
 
         {!readOnly && (

--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -41,6 +41,8 @@ export interface AnalysisOptionsMenuProps {
   selectedRevision?: number;
   onRevisionChange?: (revision: number) => void;
   onRevisionCreated?: () => void;
+  /** Label for the download button. */
+  downloadLabel?: string;
 }
 
 export function AnalysisOptionsMenu({
@@ -50,6 +52,7 @@ export function AnalysisOptionsMenu({
   selectedRevision,
   onRevisionChange,
   onRevisionCreated,
+  downloadLabel = 'Download DOCX',
 }: AnalysisOptionsMenuProps) {
   const { filter } = useDocumentExplorerStore();
   const projectId = project.id;
@@ -169,7 +172,7 @@ export function AnalysisOptionsMenu({
               <span tabIndex={0}>
                 <Button variant="default" size="xs" onClick={handleDownloadClick} disabled={!hasDocx || isDownloading}>
                   <Download />
-                  {isDownloading ? 'Downloading...' : 'Download DOCX'}
+                  {isDownloading ? 'Downloading...' : downloadLabel}
                 </Button>
               </span>
             </TooltipTrigger>

--- a/frontend/components/results/components/document-issue-card.tsx
+++ b/frontend/components/results/components/document-issue-card.tsx
@@ -70,7 +70,8 @@ export const severityColorMap: Record<
   },
 };
 
-function IssueFeedbackButtons({ issueId }: { issueId: string }) {
+/** Thumbs up/down with the "what could be improved" popover. Shared with the v2 margin note. */
+export function IssueFeedbackButtons({ issueId }: { issueId: string }) {
   const { feedback, submitFeedback, isSubmitting } = useIssueFeedbackFromContext(issueId);
   const [feedbackText, setFeedbackText] = useState('');
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);

--- a/frontend/components/results/components/replace-main-document-dialog.tsx
+++ b/frontend/components/results/components/replace-main-document-dialog.tsx
@@ -160,7 +160,7 @@ export function ReplaceMainDocumentDialog({
         }
         return 'Uploading document...';
       case 'starting-workflows':
-        return 'Starting assessment workflows...';
+        return 'Starting assessments...';
       default:
         return '';
     }

--- a/frontend/components/results/components/replace-main-document-dialog.tsx
+++ b/frontend/components/results/components/replace-main-document-dialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { HelpLink } from '@/components/help/help-link';
 import { Label } from '@/components/ui/label';
 import { FileUpload } from '@/components/ui/file-upload';
 import { FileListItem } from '@/components/analysis-form/file-list-item';
@@ -172,7 +173,8 @@ export function ReplaceMainDocumentDialog({
           <DialogTitle>Create a new revision</DialogTitle>
           <DialogDescription>
             A revision is a version of the main document. Uploading a new version here creates a new revision and makes
-            it the current one. Your previous revisions, with all their related results, are kept and stay available..
+            it the current one. Your previous revisions, with all their related results, are kept and stay available.{' '}
+            <HelpLink topic="revisions">More about revisions</HelpLink>
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/components/results/components/revision-switcher.tsx
+++ b/frontend/components/results/components/revision-switcher.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { HelpCircle, Plus } from 'lucide-react';
-
-// Sentinel value for the "Create new revision..." action so it can live inside
-// the same Select without being mistaken for a revision number.
-const CREATE_REVISION_VALUE = '__create_revision__';
+import { Check, ChevronDown, Plus } from 'lucide-react';
 
 interface RevisionSwitcherProps {
   currentRevision: number;
@@ -17,6 +20,13 @@ interface RevisionSwitcherProps {
   onCreateRevision?: () => void;
 }
 
+/**
+ * Which revision of the main document is on screen.
+ *
+ * A menu rather than a select: it sits in a row of buttons, and a select's
+ * trigger reads as a form field among them. It is also not really a form
+ * field — one of its entries uploads a document rather than choosing a value.
+ */
 export function RevisionSwitcher({
   currentRevision,
   totalRevisions,
@@ -24,55 +34,46 @@ export function RevisionSwitcher({
   onRevisionChange,
   onCreateRevision,
 }: RevisionSwitcherProps) {
-  const handleChange = (value: string) => {
-    if (value === CREATE_REVISION_VALUE) {
-      onCreateRevision?.();
-      return;
-    }
-    onRevisionChange(Number(value));
-  };
+  const revisions = Array.from({ length: totalRevisions }, (_, index) => totalRevisions - index);
 
   return (
-    <Select value={String(selectedRevision)} onValueChange={handleChange}>
-      <SelectTrigger className="h-7 w-auto gap-1 text-xs">
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         {/* The trigger names the revision only; which one is current is a
             distinction that matters while choosing, not while reading. */}
-        <SelectValue>Revision {selectedRevision}</SelectValue>
-      </SelectTrigger>
-      <SelectContent>
-        {Array.from({ length: totalRevisions }, (_, i) => totalRevisions - i).map((rev) => (
-          <SelectItem key={rev} value={String(rev)}>
-            Revision {rev}
-            {rev === currentRevision ? ' (current)' : ''}
-          </SelectItem>
+        <Button variant="outline" size="xs">
+          Revision {selectedRevision}
+          <ChevronDown className="text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end">
+        {revisions.map((revision) => (
+          <DropdownMenuItem key={revision} onSelect={() => onRevisionChange(revision)}>
+            Revision {revision}
+            {revision === currentRevision && <span className="text-muted-foreground">(current)</span>}
+            {revision === selectedRevision && <Check className="ml-auto size-3.5" />}
+          </DropdownMenuItem>
         ))}
+
         {onCreateRevision && (
           <>
-            <SelectSeparator />
-            <SelectItem value={CREATE_REVISION_VALUE}>
-              <span className="flex items-center gap-1.5 text-muted-foreground text-xs">
-                <Plus className="size-3.5" />
-                Create new revision...
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      className="inline-flex"
-                      onPointerDown={(e) => e.stopPropagation()}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <HelpCircle className="size-3.5" />
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-xs">
-                    A revision is a version of the main document. Creating one uploads a new version and makes it
-                    current; earlier revisions and their results are kept.
-                  </TooltipContent>
-                </Tooltip>
-              </span>
-            </SelectItem>
+            <DropdownMenuSeparator />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuItem onSelect={onCreateRevision}>
+                  <Plus />
+                  Create new revision...
+                </DropdownMenuItem>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                A revision is a version of the main document. Creating one uploads a new version and makes it current;
+                earlier revisions and their results are kept.
+              </TooltipContent>
+            </Tooltip>
           </>
         )}
-      </SelectContent>
-    </Select>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/components/results/components/revision-switcher.tsx
+++ b/frontend/components/results/components/revision-switcher.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import { Check, ChevronDown, Plus } from 'lucide-react';
 
 interface RevisionSwitcherProps {
@@ -18,6 +19,8 @@ interface RevisionSwitcherProps {
   onRevisionChange: (revision: number) => void;
   /** Opens the dialog for uploading a new revision of the main document. */
   onCreateRevision?: () => void;
+  /** Abbreviates the trigger on narrow screens, for headers short of room. */
+  compact?: boolean;
 }
 
 /**
@@ -33,6 +36,7 @@ export function RevisionSwitcher({
   selectedRevision,
   onRevisionChange,
   onCreateRevision,
+  compact = false,
 }: RevisionSwitcherProps) {
   const revisions = Array.from({ length: totalRevisions }, (_, index) => totalRevisions - index);
 
@@ -41,8 +45,11 @@ export function RevisionSwitcher({
       <DropdownMenuTrigger asChild>
         {/* The trigger names the revision only; which one is current is a
             distinction that matters while choosing, not while reading. */}
-        <Button variant="outline" size="xs">
-          Revision {selectedRevision}
+        <Button variant="outline" size="xs" aria-label={`Revision ${selectedRevision}`}>
+          {/* Compact drops to "Rev 1" on a phone: the number is the part that
+              has to survive, and the row has no width for the rest. */}
+          {compact && <span className="sm:hidden">Rev {selectedRevision}</span>}
+          <span className={cn(compact && 'hidden sm:inline')}>Revision {selectedRevision}</span>
           <ChevronDown className="text-muted-foreground" />
         </Button>
       </DropdownMenuTrigger>

--- a/frontend/components/results/components/revision-switcher.tsx
+++ b/frontend/components/results/components/revision-switcher.tsx
@@ -35,7 +35,9 @@ export function RevisionSwitcher({
   return (
     <Select value={String(selectedRevision)} onValueChange={handleChange}>
       <SelectTrigger className="h-7 w-auto gap-1 text-xs">
-        <SelectValue />
+        {/* The trigger names the revision only; which one is current is a
+            distinction that matters while choosing, not while reading. */}
+        <SelectValue>Revision {selectedRevision}</SelectValue>
       </SelectTrigger>
       <SelectContent>
         {Array.from({ length: totalRevisions }, (_, i) => totalRevisions - i).map((rev) => (

--- a/frontend/components/results/components/revision-switcher.tsx
+++ b/frontend/components/results/components/revision-switcher.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { HelpCenter } from '@/components/help/help-center';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -10,7 +11,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import { Check, ChevronDown, Plus } from 'lucide-react';
+import { useState } from 'react';
+import { Check, ChevronDown, CircleHelp, Plus } from 'lucide-react';
 
 interface RevisionSwitcherProps {
   currentRevision: number;
@@ -39,33 +41,35 @@ export function RevisionSwitcher({
   compact = false,
 }: RevisionSwitcherProps) {
   const revisions = Array.from({ length: totalRevisions }, (_, index) => totalRevisions - index);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        {/* The trigger names the revision only; which one is current is a
-            distinction that matters while choosing, not while reading. */}
-        <Button variant="outline" size="xs" aria-label={`Revision ${selectedRevision}`}>
-          {/* Compact drops to "Rev 1" on a phone: the number is the part that
-              has to survive, and the row has no width for the rest. */}
-          {compact && <span className="sm:hidden">Rev {selectedRevision}</span>}
-          <span className={cn(compact && 'hidden sm:inline')}>Revision {selectedRevision}</span>
-          <ChevronDown className="text-muted-foreground" />
-        </Button>
-      </DropdownMenuTrigger>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          {/* The trigger names the revision only; which one is current is a
+              distinction that matters while choosing, not while reading. */}
+          <Button variant="outline" size="xs" aria-label={`Revision ${selectedRevision}`}>
+            {/* Compact drops to "Rev 1" on a phone: the number is the part that
+                has to survive, and the row has no width for the rest. */}
+            {compact && <span className="sm:hidden">Rev {selectedRevision}</span>}
+            <span className={cn(compact && 'hidden sm:inline')}>Revision {selectedRevision}</span>
+            <ChevronDown className="text-muted-foreground" />
+          </Button>
+        </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="end">
-        {revisions.map((revision) => (
-          <DropdownMenuItem key={revision} onSelect={() => onRevisionChange(revision)}>
-            Revision {revision}
-            {revision === currentRevision && <span className="text-muted-foreground">(current)</span>}
-            {revision === selectedRevision && <Check className="ml-auto size-3.5" />}
-          </DropdownMenuItem>
-        ))}
+        <DropdownMenuContent align="end">
+          {revisions.map((revision) => (
+            <DropdownMenuItem key={revision} onSelect={() => onRevisionChange(revision)}>
+              Revision {revision}
+              {revision === currentRevision && <span className="text-muted-foreground">(current)</span>}
+              {revision === selectedRevision && <Check className="ml-auto size-3.5" />}
+            </DropdownMenuItem>
+          ))}
 
-        {onCreateRevision && (
-          <>
-            <DropdownMenuSeparator />
+          <DropdownMenuSeparator />
+
+          {onCreateRevision && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <DropdownMenuItem onSelect={onCreateRevision}>
@@ -78,9 +82,18 @@ export function RevisionSwitcher({
                 earlier revisions and their results are kept.
               </TooltipContent>
             </Tooltip>
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          )}
+
+          <DropdownMenuItem onSelect={() => setHelpOpen(true)}>
+            <CircleHelp />
+            About revisions
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Outside the menu: Radix unmounts its content on close, which would take
+          the dialog with it the moment the item that opens it is chosen. */}
+      <HelpCenter open={helpOpen} onOpenChange={setHelpOpen} topic="revisions" />
+    </>
   );
 }

--- a/frontend/components/results/project-results-shell.tsx
+++ b/frontend/components/results/project-results-shell.tsx
@@ -13,11 +13,12 @@ import { cn } from '@/lib/utils';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
 import { format } from 'date-fns';
 import { BookOpen, Loader2 } from 'lucide-react';
-import { ReactNode, useMemo } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { AnalysisOptionsMenu } from './components/analysis-options-menu';
 import { TabType } from './constants';
 import { ProjectViewProvider } from './project-view-context';
 import { derivePeerReviewFacts, peerReviewNeedsAttention } from './tabs/peer-review/peer-review-derive';
+import { ReferenceReviewExplainer } from './tabs/reference-review/reference-review-explainer';
 import { UnmatchedReferencesApproveDialog } from './tabs/reference-review/unmatched-references-approve-dialog';
 import { useReferenceApprovalFlow } from './tabs/reference-review/use-reference-approval-flow';
 
@@ -72,6 +73,7 @@ export function ProjectResultsShell({
   const { showExperimentalFeatures } = useExperimentalFeatures();
 
   const referenceApproval = useReferenceApprovalFlow(projectDetail, projectDetail.project.id);
+  const [showExplanation, setShowExplanation] = useState(false);
 
   // Find the main document summary from the summaries list
   const mainFileId = documentProcessing?.state?.file?.file_id;
@@ -124,9 +126,14 @@ export function ProjectResultsShell({
             <Callout variant="warning" icon={BookOpen} title="Reference review required">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <p className="text-sm min-w-0">
-                  Go to the <strong>References tab</strong> to upload source documents or fetch them from the web. When
-                  you&apos;re ready, use <strong>Approve and start assessment</strong> here or at the bottom of that
-                  tab.
+                  Claim Reference Validation reads each citation against the source it cites, and needs those sources
+                  first.{' '}
+                  <button
+                    onClick={() => setShowExplanation(true)}
+                    className="cursor-pointer underline underline-offset-2"
+                  >
+                    Why this is needed
+                  </button>
                 </p>
                 <div className="flex shrink-0 flex-wrap items-center gap-2">
                   <Button size="sm" variant="outline" onClick={() => onTabChange('references')}>
@@ -149,6 +156,14 @@ export function ProjectResultsShell({
                 onOpenChange={referenceApproval.setShowUnmatchedWarning}
                 unmatchedCount={referenceApproval.unmatchedCount}
                 onConfirmApprove={referenceApproval.handleConfirmApprove}
+              />
+              <ReferenceReviewExplainer
+                open={showExplanation}
+                onOpenChange={setShowExplanation}
+                onReviewReferences={() => {
+                  setShowExplanation(false);
+                  onTabChange('references');
+                }}
               />
             </Callout>
           )}

--- a/frontend/components/results/project-results-shell.tsx
+++ b/frontend/components/results/project-results-shell.tsx
@@ -18,7 +18,7 @@ import { AnalysisOptionsMenu } from './components/analysis-options-menu';
 import { TabType } from './constants';
 import { ProjectViewProvider } from './project-view-context';
 import { derivePeerReviewFacts, peerReviewNeedsAttention } from './tabs/peer-review/peer-review-derive';
-import { ReferenceReviewExplainer } from './tabs/reference-review/reference-review-explainer';
+import { HelpCenter } from '@/components/help/help-center';
 import { UnmatchedReferencesApproveDialog } from './tabs/reference-review/unmatched-references-approve-dialog';
 import { useReferenceApprovalFlow } from './tabs/reference-review/use-reference-approval-flow';
 
@@ -157,9 +157,10 @@ export function ProjectResultsShell({
                 unmatchedCount={referenceApproval.unmatchedCount}
                 onConfirmApprove={referenceApproval.handleConfirmApprove}
               />
-              <ReferenceReviewExplainer
+              <HelpCenter
                 open={showExplanation}
                 onOpenChange={setShowExplanation}
+                topic="source-files"
                 onReviewReferences={() => {
                   setShowExplanation(false);
                   onTabChange('references');

--- a/frontend/components/results/project-results-shell.tsx
+++ b/frontend/components/results/project-results-shell.tsx
@@ -18,6 +18,7 @@ import { AnalysisOptionsMenu } from './components/analysis-options-menu';
 import { TabType } from './constants';
 import { ProjectViewProvider } from './project-view-context';
 import { derivePeerReviewFacts, peerReviewNeedsAttention } from './tabs/peer-review/peer-review-derive';
+import { PageTitle } from '@/components/shared/page-title';
 import { HelpCenter } from '@/components/help/help-center';
 import { UnmatchedReferencesApproveDialog } from './tabs/reference-review/unmatched-references-approve-dialog';
 import { useReferenceApprovalFlow } from './tabs/reference-review/use-reference-approval-flow';
@@ -100,6 +101,8 @@ export function ProjectResultsShell({
       projectId={readOnly ? undefined : projectDetail.project.id}
       feedbackVisibility={readOnly ? null : (projectDetail.project.feedback_visibility ?? null)}
     >
+      <PageTitle title={projectDetail.project.title} />
+
       <ProjectViewProvider value={projectView}>
         <div className="space-y-3">
           {/* Header */}

--- a/frontend/components/results/tabs/analyses-tab.tsx
+++ b/frontend/components/results/tabs/analyses-tab.tsx
@@ -72,11 +72,11 @@ export function AnalysesTab({
       });
     },
     onSuccess: () => {
-      toast.success('Workflows started');
+      toast.success('Assessments started');
       queryClient.invalidateQueries({ queryKey: ['project', projectId] });
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, 'Failed to start workflows'));
+      toast.error(getErrorMessage(error, 'Failed to start assessments'));
     },
   });
 

--- a/frontend/components/results/tabs/files-tab.tsx
+++ b/frontend/components/results/tabs/files-tab.tsx
@@ -177,7 +177,8 @@ export function FilesTab({ projectDetail, readOnly = false, onRevisionCreated }:
   const currentRevision = projectDetail.project.current_revision ?? 1;
   const allFiles = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
   // Supporting candidates are a staging role the reference downloader uses
-  // while it works, not files the project holds, so the tab does not list them.
+  // while it works, not files the project holds. The API already excludes them
+  // from projectDetail.files; this only guards against that changing.
   const files = useMemo(() => allFiles.filter((file) => file.role !== FileRole.SupportingCandidate), [allFiles]);
   const workflowDetails = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
   const [searchQuery, setSearchQuery] = useState('');

--- a/frontend/components/results/tabs/files-tab.tsx
+++ b/frontend/components/results/tabs/files-tab.tsx
@@ -175,7 +175,10 @@ function FileTableRow({ file, projectId, currentRevision, matchedReference, onRe
 export function FilesTab({ projectDetail, readOnly = false, onRevisionCreated }: FilesTabProps) {
   const projectId = projectDetail.project.id;
   const currentRevision = projectDetail.project.current_revision ?? 1;
-  const files = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
+  const allFiles = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
+  // Supporting candidates are a staging role the reference downloader uses
+  // while it works, not files the project holds, so the tab does not list them.
+  const files = useMemo(() => allFiles.filter((file) => file.role !== FileRole.SupportingCandidate), [allFiles]);
   const workflowDetails = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
   const [searchQuery, setSearchQuery] = useState('');
   const [isReplaceDialogOpen, setIsReplaceDialogOpen] = useState(false);
@@ -192,8 +195,12 @@ export function FilesTab({ projectDetail, readOnly = false, onRevisionCreated }:
   // Compose references from extraction and file matching states
   const composedReferences = useMemo(
     () =>
-      composeReferences(referenceExtraction?.state?.extracted_references, referenceFileMatching?.state?.matches, files),
-    [referenceExtraction?.state?.extracted_references, referenceFileMatching?.state?.matches, files],
+      composeReferences(
+        referenceExtraction?.state?.extracted_references,
+        referenceFileMatching?.state?.matches,
+        allFiles,
+      ),
+    [referenceExtraction?.state?.extracted_references, referenceFileMatching?.state?.matches, allFiles],
   );
 
   // Build a map of file_id to matched references once

--- a/frontend/components/results/tabs/peer-review/peer-review-stage-card.tsx
+++ b/frontend/components/results/tabs/peer-review/peer-review-stage-card.tsx
@@ -157,7 +157,7 @@ interface StageActionProps {
   isStarting: boolean;
   variant?: 'default' | 'outline';
   /** CTA buttons render at the default size; toolbar ones stay small. */
-  size?: 'sm' | 'default';
+  size?: 'xs' | 'sm' | 'default';
   onStart: () => void;
   onCancel: (runId: string) => void;
 }
@@ -183,9 +183,9 @@ export function PeerReviewStageAction({
   if (run && isWorkflowProcessing(run)) {
     return (
       <Button variant="outline" size={size} onClick={() => onCancel(run.run.id)}>
-        <Loader2 className="size-4 animate-spin" />
+        <Loader2 className={size === 'xs' ? 'size-3 animate-spin' : 'size-4 animate-spin'} />
         Running
-        <X className="size-4" />
+        <X className={size === 'xs' ? 'size-3' : 'size-4'} />
       </Button>
     );
   }
@@ -193,7 +193,7 @@ export function PeerReviewStageAction({
   const hasResult = !!run;
   return (
     <Button variant={hasResult ? 'outline' : variant} size={size} disabled={disabled || isStarting} onClick={onStart}>
-      {isStarting && <Loader2 className="size-4 animate-spin" />}
+      {isStarting && <Loader2 className={size === 'xs' ? 'size-3 animate-spin' : 'size-4 animate-spin'} />}
       {hasResult ? (reRunLabel ?? 'Re-run') : label}
     </Button>
   );

--- a/frontend/components/results/tabs/reference-review/file-upload-dialog.tsx
+++ b/frontend/components/results/tabs/reference-review/file-upload-dialog.tsx
@@ -90,7 +90,9 @@ export function FileUploadDialog({
   // Reference matching only applies to supporting documents (that aren't
   // already tied to a specific reference); other roles skip it.
   const activeSkipMatching = activeRole !== FileRole.Support;
-  const activeSuccessMessage = isMemoUpload ? 'Reviewer memos uploaded.' : 'Files uploaded. Matching workflow started.';
+  const activeSuccessMessage = isMemoUpload
+    ? 'Reviewer memos uploaded.'
+    : 'Files uploaded. Matching them to your references.';
   // Only memos carry a revision; sending one for any other role is a 400.
   const activeRevision = isMemoUpload ? selectedRevision : undefined;
   // Shown even when there is only one revision: memos are always bound to a
@@ -126,7 +128,7 @@ export function FileUploadDialog({
       queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       toast.success(activeSuccessMessage);
     } catch (error) {
-      toast.error(getErrorMessage(error, 'Failed to start file matching workflow'));
+      toast.error(getErrorMessage(error, 'Failed to match the files to your references'));
     } finally {
       setIsStartingWorkflow(false);
       onComplete?.();
@@ -209,7 +211,7 @@ export function FileUploadDialog({
               <DialogTitle>{isStartingWorkflow ? 'Starting file matching...' : 'Uploading files'}</DialogTitle>
               <DialogDescription>
                 {isStartingWorkflow
-                  ? 'Starting the file matching workflow to match uploaded files to references.'
+                  ? 'Matching the uploaded files to your references.'
                   : 'Your files are being uploaded. You can cancel at any time.'}
               </DialogDescription>
             </DialogHeader>

--- a/frontend/components/results/tabs/reference-review/file-upload-dialog.tsx
+++ b/frontend/components/results/tabs/reference-review/file-upload-dialog.tsx
@@ -15,6 +15,7 @@ import { Label } from '@/components/ui/label';
 import { FileUpload } from '@/components/ui/file-upload';
 import { RadioGroup, RadioGroupItemWithDescription } from '@/components/ui/radio-group-with-description';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { HelpLink } from '@/components/help/help-link';
 import { FileListItem } from '@/components/analysis-form/file-list-item';
 import { UploadProgressList } from '@/components/ui/upload-progress-list';
 import { useUpload } from '@/lib/hooks/upload';
@@ -258,6 +259,7 @@ export function FileUploadDialog({
                       label="Supporting document"
                       description="Reference material cited by the document. Supporting files are matched against the document's references."
                       disabled={isUploading}
+                      help={<HelpLink topic="source-files">What a source file is used for</HelpLink>}
                     />
                     <RadioGroupItemWithDescription
                       id={FileRole.ReviewerMemo}
@@ -265,6 +267,7 @@ export function FileUploadDialog({
                       label="Reviewer memo"
                       description="Peer-review feedback on a specific draft. Used by the Peer Review assessments."
                       disabled={isUploading}
+                      help={<HelpLink topic="peer-review">What peer review does with these</HelpLink>}
                     />
                   </RadioGroup>
                 </div>

--- a/frontend/components/results/tabs/reference-review/reference-card.tsx
+++ b/frontend/components/results/tabs/reference-review/reference-card.tsx
@@ -188,6 +188,10 @@ export function ReferenceCard({ reference, projectId, readOnly, disabled = false
       <WorkflowConfigDialog
         isOpen={isFetchDialogOpen}
         type={WorkflowRunType.ReferenceDownloader}
+        title="Fetch this source from the web"
+        description="Draft Detective searches for this reference and downloads the full text if it finds one it can read."
+        helpTopic="source-files"
+        submitLabel="Fetch source"
         projectId={projectId}
         onConfirm={handleFetchFromWebConfirm}
         onCancel={() => setIsFetchDialogOpen(false)}

--- a/frontend/components/results/tabs/reference-review/reference-review-explainer.tsx
+++ b/frontend/components/results/tabs/reference-review/reference-review-explainer.tsx
@@ -77,7 +77,8 @@ const OUTCOMES: Verdict[] = [
 interface ReferenceReviewExplainerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onReviewReferences: () => void;
+  /** Omitted when the reader is already on the References tab. */
+  onReviewReferences?: () => void;
 }
 
 export function ReferenceReviewExplainer({ open, onOpenChange, onReviewReferences }: ReferenceReviewExplainerProps) {
@@ -157,7 +158,7 @@ export function ReferenceReviewExplainer({ open, onOpenChange, onReviewReference
           <DialogClose asChild>
             <Button variant="outline">Close</Button>
           </DialogClose>
-          <Button onClick={onReviewReferences}>Review references</Button>
+          {onReviewReferences && <Button onClick={onReviewReferences}>Review references</Button>}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/components/results/tabs/reference-review/reference-review-explainer.tsx
+++ b/frontend/components/results/tabs/reference-review/reference-review-explainer.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { SeverityEnum } from '@/lib/generated-api';
+import { SEVERITY } from '@/lib/severity-style';
+import { cn } from '@/lib/utils';
+import { ArrowRight, FileText, FileX2, Globe, LucideIcon, Upload } from 'lucide-react';
+import { ReactNode } from 'react';
+
+interface Verdict {
+  severity: SeverityEnum;
+  label: string;
+  gloss: string;
+}
+
+interface Trace {
+  /** The sentence without its citation, which is rendered separately. */
+  claim: string;
+  /** The in-text citation, highlighted in the claim and naming the reference. */
+  citation: string;
+  reference: string;
+  /** The matched source document, or null when the reference has none yet. */
+  source: string | null;
+  verdict: Verdict;
+}
+
+/**
+ * Two worked examples, identical but for the last link in the chain. Side by
+ * side they make the point the prose cannot: the source document is the only
+ * thing standing between a citation and a real verdict.
+ *
+ * The references are invented. A fabricated claim hung on a real paper would
+ * read as a finding about that paper.
+ */
+const TRACES: Trace[] = [
+  {
+    claim: 'Training compute for frontier models has doubled roughly every six months since 2020',
+    citation: '(Sandoval & Okoye, 2023)',
+    reference: 'Sandoval, R., & Okoye, T. (2023). Compute trends in large-scale training.',
+    source: 'sandoval-2023.pdf',
+    verdict: {
+      severity: SeverityEnum.None,
+      label: 'Supported',
+      gloss: 'The source reports the same doubling time.',
+    },
+  },
+  {
+    claim: 'Grid-scale storage now covers 40% of peak demand across three EU member states',
+    citation: '(Lindqvist, 2022)',
+    reference: 'Lindqvist, A. (2022). European storage deployment review.',
+    source: null,
+    verdict: {
+      severity: SeverityEnum.Medium,
+      label: 'Unverifiable',
+      gloss: 'With nothing to read, the claim goes unchecked.',
+    },
+  },
+];
+
+/** The full result vocabulary, in the colours the margin and issue list use. */
+const OUTCOMES: Verdict[] = [
+  { severity: SeverityEnum.None, label: 'Supported', gloss: 'The source backs the claim.' },
+  { severity: SeverityEnum.Medium, label: 'Partially supported', gloss: 'It backs part of it.' },
+  { severity: SeverityEnum.High, label: 'Unsupported', gloss: 'It does not back the claim.' },
+  { severity: SeverityEnum.Medium, label: 'Unverifiable', gloss: 'There was nothing to check against.' },
+];
+
+interface ReferenceReviewExplainerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onReviewReferences: () => void;
+}
+
+export function ReferenceReviewExplainer({ open, onOpenChange, onReviewReferences }: ReferenceReviewExplainerProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Why Claim Reference Validation needs your sources</DialogTitle>
+          <DialogDescription>
+            This assessment reads your citations against the documents they cite. It waits here until you tell it the
+            sources are ready.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[65vh] space-y-5 overflow-y-auto text-sm">
+          <section>
+            <SectionTitle>The chain it follows</SectionTitle>
+            <div className="space-y-2">
+              {TRACES.map((trace) => (
+                <TraceCard key={trace.citation} trace={trace} />
+              ))}
+            </div>
+            <p className="text-foreground/80 mt-2 leading-relaxed">
+              Both citations are perfectly good. Only one can be checked, because{' '}
+              <strong className="text-foreground font-medium">
+                a bibliography entry names a source, it does not contain one
+              </strong>
+              .
+            </p>
+          </section>
+
+          <section>
+            <SectionTitle>What comes back</SectionTitle>
+            <ul className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
+              {OUTCOMES.map((outcome) => (
+                <li key={outcome.label} className="flex items-baseline gap-2">
+                  <span className={cn('mt-1.5 block size-1.5 shrink-0 rounded-full', SEVERITY[outcome.severity].dot)} />
+                  <span className="min-w-0 text-xs leading-snug">
+                    <strong className="font-medium">{outcome.label}</strong>{' '}
+                    <span className="text-muted-foreground">{outcome.gloss}</span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <SectionTitle>What to do</SectionTitle>
+            <p className="text-foreground/80 leading-relaxed">
+              On the References tab, every reference we extracted is listed with the source matched to it. There are two
+              ways to close a gap.
+            </p>
+            <div className="mt-2 grid gap-2 sm:grid-cols-2">
+              <Route icon={Globe} title="Fetch from the web">
+                Draft Detective searches the web for the reference and downloads the full text when it finds one it can
+                read.
+              </Route>
+              <Route icon={Upload} title="Upload it yourself">
+                Plenty of sources are private, paywalled, or closed to automated downloads. Add the file and we match it
+                to the reference.
+              </Route>
+            </div>
+            <p className="text-foreground/80 mt-2 leading-relaxed">
+              Then choose <strong className="text-foreground font-medium">Approve and Start Analysis</strong>. Approving
+              with gaps is fine: those claims come back{' '}
+              <strong className="text-foreground font-medium">unverifiable instead of checked</strong>, and everything
+              else runs normally.
+            </p>
+            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+              Nothing else is waiting on this. Your other assessments work from the document alone, and their results
+              are already coming in.
+            </p>
+          </section>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Close</Button>
+          </DialogClose>
+          <Button onClick={onReviewReferences}>Review references</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TraceCard({ trace }: { trace: Trace }) {
+  const style = SEVERITY[trace.verdict.severity];
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <div className="grid items-start gap-x-3 gap-y-3 p-3 sm:grid-cols-[1fr_auto_1fr_auto_9.5rem]">
+        <Cell label="Claim in your document">
+          <span className="italic">
+            “{trace.claim}{' '}
+            {/* Marked the way the document itself marks flagged text, so the
+                citation reads as the hinge between claim and reference. */}
+            <span className="text-foreground font-medium not-italic underline decoration-dotted decoration-muted-foreground/60 underline-offset-2">
+              {trace.citation}
+            </span>
+            .”
+          </span>
+        </Cell>
+        <Arrow />
+        <Cell label="Reference it points to">{trace.reference}</Cell>
+        <Arrow />
+        <Cell label="Source document">
+          {trace.source ? (
+            <span className="inline-flex items-center gap-1.5">
+              <FileText className="size-3 shrink-0" />
+              <span className="truncate font-mono text-[11px]">{trace.source}</span>
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 text-amber-700 dark:text-amber-400">
+              <FileX2 className="size-3 shrink-0" />
+              Not provided yet
+            </span>
+          )}
+        </Cell>
+      </div>
+
+      <div className={cn('flex flex-wrap items-center gap-x-2 gap-y-0.5 border-t px-3 py-1.5', style.wash)}>
+        <span className={cn('block size-1.5 shrink-0 rounded-full', style.dot)} />
+        <span className={cn('font-mono text-[10px] tracking-wide uppercase', style.text)}>{trace.verdict.label}</span>
+        <span className="text-foreground/80 text-xs">{trace.verdict.gloss}</span>
+      </div>
+    </div>
+  );
+}
+
+function Cell({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <p className="mb-0.5 font-mono text-[9.5px] tracking-wide text-muted-foreground uppercase">{label}</p>
+      <p className="text-xs leading-snug">{children}</p>
+    </div>
+  );
+}
+
+/** Points right across the columns, down between them once they stack. */
+function Arrow() {
+  return <ArrowRight className="mt-4 hidden size-3.5 shrink-0 text-muted-foreground sm:block" aria-hidden />;
+}
+
+/** One of the two ways to give a reference its source. */
+function Route({ icon: Icon, title, children }: { icon: LucideIcon; title: string; children: ReactNode }) {
+  return (
+    <div className="rounded-md border p-2.5">
+      <p className="mb-1 flex items-center gap-1.5 text-xs font-medium">
+        <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        {title}
+      </p>
+      <p className="text-xs leading-relaxed text-muted-foreground">{children}</p>
+    </div>
+  );
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return <h3 className="mb-1.5 font-mono text-[10px] tracking-wide text-muted-foreground uppercase">{children}</h3>;
+}

--- a/frontend/components/results/tabs/reference-review/reference-review-tab.tsx
+++ b/frontend/components/results/tabs/reference-review/reference-review-tab.tsx
@@ -93,6 +93,10 @@ export function ReferenceReviewTab({ projectId, readOnly = false }: ReferenceRev
       <WorkflowConfigDialog
         isOpen={isConfigDialogOpen}
         type={WorkflowRunType.ReferenceDownloader}
+        title="Fetch source files from the web"
+        description="Draft Detective searches for each reference without a source file and downloads the full text when it finds one it can read."
+        helpTopic="source-files"
+        submitLabel="Fetch sources"
         projectId={projectId}
         onConfirm={handleConfirm}
         onCancel={() => setIsConfigDialogOpen(false)}

--- a/frontend/components/results/tabs/use-workflow-selection.ts
+++ b/frontend/components/results/tabs/use-workflow-selection.ts
@@ -7,11 +7,24 @@ interface UseWorkflowSelectionParams {
   projectId: string;
   workflowDetails: WorkflowRunDetail[];
   shareToken?: string | null;
+  /**
+   * Shown until the reader picks one. Views that put the assessment list in a
+   * rail pass the first entry, so the pane opens on something rather than on a
+   * prompt to click the thing already in front of you.
+   */
+  defaultWorkflowType?: WorkflowRunType | null;
 }
 
-export function useWorkflowSelection({ projectId, workflowDetails, shareToken }: UseWorkflowSelectionParams) {
-  const [selectedWorkflowType, setSelectedWorkflowType] = useState<WorkflowRunType | null>(null);
+export function useWorkflowSelection({
+  projectId,
+  workflowDetails,
+  shareToken,
+  defaultWorkflowType = null,
+}: UseWorkflowSelectionParams) {
+  const [pickedWorkflowType, setPickedWorkflowType] = useState<WorkflowRunType | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+
+  const selectedWorkflowType = pickedWorkflowType ?? defaultWorkflowType;
 
   const mainRequestWorkflow = selectedWorkflowType
     ? workflowDetails.find((w) => w.run.type === selectedWorkflowType)
@@ -50,7 +63,7 @@ export function useWorkflowSelection({ projectId, workflowDetails, shareToken }:
   }, [selectedWorkflowType, selectedRunId, historyData, mainRequestWorkflow]);
 
   const handleSelectWorkflowType = (workflowType: WorkflowRunType) => {
-    setSelectedWorkflowType(workflowType);
+    setPickedWorkflowType(workflowType);
     setSelectedRunId(null);
   };
 

--- a/frontend/components/shared/page-title.tsx
+++ b/frontend/components/shared/page-title.tsx
@@ -1,15 +1,35 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+const DEFAULT_TITLE = 'Draft Detective';
+
 /**
  * Names the browser tab after what is on screen.
  *
- * A rendered `<title>` rather than route metadata: these pages are client
- * components whose subject arrives from a query, which `generateMetadata` on
- * the server has no way to read. React hoists this into the head, and the last
- * one rendered wins over the app-wide default.
+ * Route metadata cannot do it: these pages are client components whose subject
+ * arrives from a query, which `generateMetadata` on the server has no way to
+ * read. Nor can a rendered `<title>` — React hoists one into the head, but the
+ * App Router rewrites the head on every client navigation and drops it, taking
+ * the app-wide default with it, so switching tabs left the tab unnamed.
+ *
+ * Setting `document.title` is a side effect on something React does not own, so
+ * an effect is the right tool here rather than the exception. It is keyed on the
+ * path as well as the title: the shell stays mounted across tab switches, and
+ * the title has to be written again after each one rewrites the head.
  */
 export function PageTitle({ title }: { title: string }) {
-  const trimmed = title.trim();
+  const pathname = usePathname();
 
-  return <title>{trimmed ? `${trimmed} · Draft Detective` : 'Draft Detective'}</title>;
+  useEffect(() => {
+    const trimmed = title.trim();
+    document.title = trimmed ? `${trimmed} · ${DEFAULT_TITLE}` : DEFAULT_TITLE;
+
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, [title, pathname]);
+
+  return null;
 }

--- a/frontend/components/shared/page-title.tsx
+++ b/frontend/components/shared/page-title.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+/**
+ * Names the browser tab after what is on screen.
+ *
+ * A rendered `<title>` rather than route metadata: these pages are client
+ * components whose subject arrives from a query, which `generateMetadata` on
+ * the server has no way to read. React hoists this into the head, and the last
+ * one rendered wins over the app-wide default.
+ */
+export function PageTitle({ title }: { title: string }) {
+  const trimmed = title.trim();
+
+  return <title>{trimmed ? `${trimmed} · Draft Detective` : 'Draft Detective'}</title>;
+}

--- a/frontend/components/ui/editable-title.tsx
+++ b/frontend/components/ui/editable-title.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { Check, SquarePenIcon, X } from 'lucide-react';
 import * as React from 'react';
@@ -115,9 +116,14 @@ export function EditableTitle({
     <div className={cn('flex items-center gap-2', className)}>
       <h1 className={cn(titleClassName)}>{title}</h1>
       {!disabled && !isLoading && (
-        <Button variant="ghost" size="icon" onClick={handleStartEdit} className="h-8 w-8" aria-label="Edit title">
-          <SquarePenIcon className="h-4 w-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" onClick={handleStartEdit} className="h-8 w-8" aria-label="Edit title">
+              <SquarePenIcon className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Rename this project</TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/frontend/components/ui/radio-group-with-description.tsx
+++ b/frontend/components/ui/radio-group-with-description.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 import { CircleIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { ReactNode } from 'react';
 
 export { RadioGroup } from './radio-group';
 
@@ -13,6 +14,8 @@ interface RadioGroupItemWithDescriptionProps {
   label: string;
   description: string;
   disabled?: boolean;
+  /** Rendered under the description, for options that need more than a line. */
+  help?: ReactNode;
 }
 
 export function RadioGroupItemWithDescription({
@@ -21,6 +24,7 @@ export function RadioGroupItemWithDescription({
   label,
   description,
   disabled = false,
+  help,
 }: RadioGroupItemWithDescriptionProps) {
   return (
     <label
@@ -51,6 +55,7 @@ export function RadioGroupItemWithDescription({
         <span className={cn('text-sm font-medium leading-none select-none', disabled && 'opacity-70')}>{label}</span>
       </div>
       <p className="text-sm text-muted-foreground pl-6">{description}</p>
+      {help && <p className="text-sm pl-6">{help}</p>}
     </label>
   );
 }

--- a/frontend/components/ui/radio-group-with-description.tsx
+++ b/frontend/components/ui/radio-group-with-description.tsx
@@ -27,35 +27,40 @@ export function RadioGroupItemWithDescription({
   help,
 }: RadioGroupItemWithDescriptionProps) {
   return (
-    <label
-      htmlFor={id}
+    // The card is a div and only the radio, its name and its description live
+    // inside the label. `help` is a real button at its call sites, and a button
+    // nested in a label is invalid: assistive technology can announce the help
+    // action as part of the radio, and clicking it reads as choosing the option.
+    <div
       className={cn(
-        'border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-all block space-y-1',
+        'border rounded-lg p-4 transition-all block space-y-1',
+        disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-accent/50',
         value === id ? 'border-primary border-1' : 'border',
-        disabled && 'cursor-not-allowed opacity-50',
       )}
     >
-      <div className="flex items-center space-x-2">
-        <RadioGroupPrimitive.Item
-          id={id}
-          value={id}
-          disabled={disabled}
-          data-slot="radio-group-item"
-          className={cn(
-            'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
-          )}
-        >
-          <RadioGroupPrimitive.Indicator
-            data-slot="radio-group-indicator"
-            className="relative flex items-center justify-center"
+      <label htmlFor={id} className={cn('block space-y-1', disabled ? 'cursor-not-allowed' : 'cursor-pointer')}>
+        <div className="flex items-center space-x-2">
+          <RadioGroupPrimitive.Item
+            id={id}
+            value={id}
+            disabled={disabled}
+            data-slot="radio-group-item"
+            className={cn(
+              'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+            )}
           >
-            <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
-          </RadioGroupPrimitive.Indicator>
-        </RadioGroupPrimitive.Item>
-        <span className={cn('text-sm font-medium leading-none select-none', disabled && 'opacity-70')}>{label}</span>
-      </div>
-      <p className="text-sm text-muted-foreground pl-6">{description}</p>
+            <RadioGroupPrimitive.Indicator
+              data-slot="radio-group-indicator"
+              className="relative flex items-center justify-center"
+            >
+              <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+            </RadioGroupPrimitive.Indicator>
+          </RadioGroupPrimitive.Item>
+          <span className={cn('text-sm font-medium leading-none select-none', disabled && 'opacity-70')}>{label}</span>
+        </div>
+        <p className="text-sm text-muted-foreground pl-6">{description}</p>
+      </label>
       {help && <p className="text-sm pl-6">{help}</p>}
-    </label>
+    </div>
   );
 }

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -3,9 +3,13 @@
 import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
+import { TOOLTIP_DELAY } from '@/lib/tooltip';
 import { cn } from '@/lib/utils';
 
-function TooltipProvider({ delayDuration = 0, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+function TooltipProvider({
+  delayDuration = TOOLTIP_DELAY,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return <TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />;
 }
 

--- a/frontend/components/workflows/results/about-this-ger-results.tsx
+++ b/frontend/components/workflows/results/about-this-ger-results.tsx
@@ -168,7 +168,7 @@ export function AboutThisGerResults({ workflowDetail }: AboutThisGerResultsProps
   const state = workflowDetail.state as AboutThisGerState | undefined;
 
   if (!state) {
-    return <EmptyState message="No results available for this workflow run." />;
+    return <EmptyState message="No results available for this run." />;
   }
 
   return <AboutThisGerContent state={state} />;

--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -107,7 +107,7 @@ export function SimpleDeepAgentResults({
   const state = workflowDetail.state as SimpleDeepAgentState | undefined;
 
   if (!state?.result) {
-    return <EmptyState message="No results available for this workflow run." />;
+    return <EmptyState message="No results available for this run." />;
   }
 
   const { result } = state;

--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/shared/empty-state';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { ProjectDetailed, SimpleDeepAgentState } from '@/lib/generated-api';
 import {
   isWorkflowCancelled,
@@ -115,14 +116,35 @@ export function SimpleDeepAgentResults({
     <Tabs value={activeTab} onValueChange={setActiveTab}>
       <div className="flex items-center justify-between gap-2">
         <TabsList>
-          <TabsTrigger value="results" className="gap-1.5">
-            <ClipboardList className="h-3.5 w-3.5" />
-            Results
-          </TabsTrigger>
-          <TabsTrigger value="messages" className="gap-1.5">
-            <MessageSquare className="h-3.5 w-3.5" />
-            Messages
-          </TabsTrigger>
+          {/* The tooltip hangs off a wrapper, not the trigger itself: Radix
+              writes data-state="closed" on whatever it is attached to, which
+              would overwrite the data-state="active" the tab styles itself by. */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex h-full flex-1">
+                <TabsTrigger value="results" className="gap-1.5">
+                  <ClipboardList className="h-3.5 w-3.5" />
+                  Results
+                </TabsTrigger>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              What this assessment concluded: its report and the issues it raised.
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex h-full flex-1">
+                <TabsTrigger value="messages" className="gap-1.5">
+                  <MessageSquare className="h-3.5 w-3.5" />
+                  Messages
+                </TabsTrigger>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              The agent&apos;s own transcript: what it read and how it worked its way to those results.
+            </TooltipContent>
+          </Tooltip>
         </TabsList>
         {/* Only on the Results tab: the other tab unmounts the frame, which
             would leave this printing nothing. */}

--- a/frontend/components/workflows/start-workflow-button.tsx
+++ b/frontend/components/workflows/start-workflow-button.tsx
@@ -8,7 +8,7 @@ import { getErrorMessage } from '@/lib/api-error';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Loader2Icon, PlayIcon, XIcon } from 'lucide-react';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { toast } from 'sonner';
 import {
   AlertDialog,
@@ -32,7 +32,7 @@ export interface StartWorkflowButtonProps {
   /** Match the button to the toolbar it sits in. */
   size?: 'sm' | 'xs';
   /** Overrides the idle label, e.g. "Re-run Abbreviation Scan". */
-  startLabel?: string;
+  startLabel?: ReactNode;
   /** Shown on hover while the button is idle. */
   tooltip?: React.ReactNode;
 }

--- a/frontend/components/workflows/start-workflow-button.tsx
+++ b/frontend/components/workflows/start-workflow-button.tsx
@@ -117,10 +117,10 @@ export function StartWorkflowButton({
       <AlertDialog open={isCancelDialogOpen} onOpenChange={setIsCancelDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Cancel {workflowName} workflow?</AlertDialogTitle>
+            <AlertDialogTitle>Cancel {workflowName}?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will stop the currently running workflow. Any other workflows that depend on it will also be
-              cancelled. You can retrigger it at any time.
+              This stops the run in progress. Any assessment waiting on it is cancelled too. You can run it again at any
+              time.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -160,7 +160,7 @@ export function StartWorkflowButton({
                 {cancelWorkflowMutation.isPending ? <Loader2Icon className="animate-spin" /> : <XIcon />}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Cancel workflow</TooltipContent>
+            <TooltipContent>Cancel this run</TooltipContent>
           </Tooltip>
         )}
       </div>

--- a/frontend/components/workflows/start-workflow-button.tsx
+++ b/frontend/components/workflows/start-workflow-button.tsx
@@ -29,9 +29,23 @@ export interface StartWorkflowButtonProps {
   projectId: string;
   workflow?: WorkflowRun;
   onConfirm: (values: WorkflowConfigFormValues) => Promise<unknown>;
+  /** Match the button to the toolbar it sits in. */
+  size?: 'sm' | 'xs';
+  /** Overrides the idle label, e.g. "Re-run Abbreviation Scan". */
+  startLabel?: string;
+  /** Shown on hover while the button is idle. */
+  tooltip?: React.ReactNode;
 }
 
-export function StartWorkflowButton({ type, projectId, workflow, onConfirm }: StartWorkflowButtonProps) {
+export function StartWorkflowButton({
+  type,
+  projectId,
+  workflow,
+  onConfirm,
+  size = 'sm',
+  startLabel,
+  tooltip,
+}: StartWorkflowButtonProps) {
   const [isConfigDialogOpen, setIsConfigDialogOpen] = useState(false);
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
   const queryClient = useQueryClient();
@@ -72,6 +86,32 @@ export function StartWorkflowButton({ type, projectId, workflow, onConfirm }: St
 
   const isActive = workflow?.status === WorkflowRunStatus.Running || workflow?.status === WorkflowRunStatus.Pending;
 
+  const startButton = (
+    <Button
+      size={size}
+      variant="outline"
+      onClick={() => setIsConfigDialogOpen(true)}
+      disabled={startWorkflowMutation.isPending || isActive}
+    >
+      {startWorkflowMutation.isPending ? (
+        <>
+          <Loader2Icon className="animate-spin" />
+          Starting...
+        </>
+      ) : isActive ? (
+        <>
+          <Loader2Icon className="animate-spin" />
+          Running...
+        </>
+      ) : (
+        <>
+          <PlayIcon />
+          {startLabel ?? `Start ${workflowName}`}
+        </>
+      )}
+    </Button>
+  );
+
   return (
     <>
       <AlertDialog open={isCancelDialogOpen} onOpenChange={setIsCancelDialogOpen}>
@@ -99,37 +139,21 @@ export function StartWorkflowButton({ type, projectId, workflow, onConfirm }: St
       />
 
       <div className="flex items-center gap-1">
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => setIsConfigDialogOpen(true)}
-          disabled={startWorkflowMutation.isPending || isActive}
-        >
-          {startWorkflowMutation.isPending ? (
-            <>
-              <Loader2Icon className="animate-spin" />
-              Starting...
-            </>
-          ) : isActive ? (
-            <>
-              <Loader2Icon className="animate-spin" />
-              Running...
-            </>
-          ) : (
-            <>
-              <PlayIcon />
-              Start {workflowName}
-            </>
-          )}
-        </Button>
+        {tooltip && !startWorkflowMutation.isPending && !isActive ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{startButton}</TooltipTrigger>
+            <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
+          </Tooltip>
+        ) : (
+          startButton
+        )}
 
         {isActive && (
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                size="sm"
+                size={size}
                 variant="ghost"
-                className=""
                 onClick={() => setIsCancelDialogOpen(true)}
                 disabled={cancelWorkflowMutation.isPending}
               >

--- a/frontend/components/workflows/workflow-config-dialog.tsx
+++ b/frontend/components/workflows/workflow-config-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { HelpLink } from '@/components/help/help-link';
+import { HelpTopicId } from '@/components/help/topics';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
@@ -28,6 +29,16 @@ interface WorkflowConfigDialogProps {
   projectId: string;
   onConfirm: (values: WorkflowConfigFormValues) => void;
   onCancel: () => void;
+  /**
+   * Names the action in the caller's own words. Without these the dialog talks
+   * about running an assessment, which is wrong for the internal workflows —
+   * nobody asked to "run Reference Downloader", they asked to fetch a source.
+   */
+  title?: string;
+  description?: string;
+  submitLabel?: string;
+  /** The help topic the dialog's link opens. Follows what the dialog is for. */
+  helpTopic?: HelpTopicId;
 }
 
 export interface WorkflowConfigFormValues {
@@ -36,12 +47,26 @@ export interface WorkflowConfigFormValues {
   workflowTypes: WorkflowRunType[];
 }
 
-export function WorkflowConfigDialog({ isOpen, type, projectId, onConfirm, onCancel }: WorkflowConfigDialogProps) {
+export function WorkflowConfigDialog({
+  isOpen,
+  type,
+  projectId,
+  onConfirm,
+  onCancel,
+  title,
+  description,
+  submitLabel,
+  helpTopic = 'assessments',
+}: WorkflowConfigDialogProps) {
   const [storedWebSearchConsent] = useWebSearchConsent(projectId);
   const { showExperimentalFeatures } = useExperimentalFeatures();
   const { data: user } = useUserMe();
 
-  const { workflowTypes } = useWorkflowTypes();
+  const { workflowTypes, getWorkflowTypeName } = useWorkflowTypes();
+
+  // Named when the dialog is opened for one assessment; otherwise it is the
+  // picker over all of them.
+  const assessmentName = type ? getWorkflowTypeName(type) : null;
 
   const needsPublicationDate = type ? hasPublicationDateRequirement([type]) : false;
 
@@ -93,10 +118,15 @@ export function WorkflowConfigDialog({ isOpen, type, projectId, onConfirm, onCan
           no specific `type` is given. */}
       <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Start Workflow</DialogTitle>
+          <DialogTitle>{title ?? (assessmentName ? `Run ${assessmentName}` : 'Run assessments')}</DialogTitle>
           <DialogDescription>
-            Please select the workflow configuration to start.{' '}
-            <HelpLink topic="assessments">How assessments work</HelpLink>
+            {description ??
+              (assessmentName
+                ? 'Confirm how this assessment should run on your document.'
+                : 'Choose which assessments to run on your document.')}{' '}
+            <HelpLink topic={helpTopic}>
+              {helpTopic === 'assessments' ? 'How assessments work' : 'What this is for'}
+            </HelpLink>
           </DialogDescription>
         </DialogHeader>
 
@@ -183,7 +213,9 @@ export function WorkflowConfigDialog({ isOpen, type, projectId, onConfirm, onCan
                 Cancel
               </Button>
               <Button onClick={() => form.handleSubmit()} disabled={!canSubmit || isSubmitting}>
-                {isSubmitting ? 'Starting...' : 'Start Workflow'}
+                {isSubmitting
+                  ? 'Starting...'
+                  : (submitLabel ?? (assessmentName ? 'Run assessment' : 'Run assessments'))}
               </Button>
             </DialogFooter>
           )}

--- a/frontend/components/workflows/workflow-config-dialog.tsx
+++ b/frontend/components/workflows/workflow-config-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { HelpLink } from '@/components/help/help-link';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
@@ -93,7 +94,10 @@ export function WorkflowConfigDialog({ isOpen, type, projectId, onConfirm, onCan
       <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Start Workflow</DialogTitle>
-          <DialogDescription>Please select the workflow configuration to start.</DialogDescription>
+          <DialogDescription>
+            Please select the workflow configuration to start.{' '}
+            <HelpLink topic="assessments">How assessments work</HelpLink>
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">

--- a/frontend/components/workflows/workflow-run-history.tsx
+++ b/frontend/components/workflows/workflow-run-history.tsx
@@ -7,6 +7,7 @@ import { History, CheckCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { StatusIndicator } from '@/components/ui/status-indicator';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   WorkflowRunDetail,
   WorkflowRunType,
@@ -23,6 +24,10 @@ interface WorkflowRunHistoryProps {
   onSelectRun: (run: WorkflowRunDetail) => void;
   /** Pre-loaded history data to avoid fetching on popover open */
   historyData?: WorkflowRunDetail[];
+  /** Match the button to the toolbar it sits in. */
+  size?: 'sm' | 'xs';
+  /** Shown on hover. */
+  tooltip?: React.ReactNode;
 }
 
 export function WorkflowRunHistory({
@@ -31,6 +36,8 @@ export function WorkflowRunHistory({
   currentRunId,
   onSelectRun,
   historyData,
+  size = 'sm',
+  tooltip,
 }: WorkflowRunHistoryProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -54,15 +61,26 @@ export function WorkflowRunHistory({
   // Don't show history button if there's only one run or less
   const runCount = runDetails?.length ?? 0;
 
+  const trigger = (
+    <PopoverTrigger asChild>
+      <Button variant="ghost" size={size} className="gap-1.5">
+        <History className={size === 'xs' ? 'size-3' : 'h-4 w-4'} />
+        History
+        {runCount > 1 && <span className="text-muted-foreground">({runCount})</span>}
+      </Button>
+    </PopoverTrigger>
+  );
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button variant="ghost" size="sm" className="gap-1.5">
-          <History className="h-4 w-4" />
-          History
-          {runCount > 1 && <span className="text-muted-foreground">({runCount})</span>}
-        </Button>
-      </PopoverTrigger>
+      {tooltip ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
+        </Tooltip>
+      ) : (
+        trigger
+      )}
       <PopoverContent align="end" className="w-80 p-0">
         <div className="p-3 border-b">
           <h4 className="font-medium text-sm">Run History</h4>

--- a/frontend/components/workflows/workflow-type-selector.tsx
+++ b/frontend/components/workflows/workflow-type-selector.tsx
@@ -144,14 +144,14 @@ export function WorkflowTypeSelector({
       )}
       <div className="space-y-3">
         {isLoadingWorkflowTypes ? (
-          <p className="text-sm text-muted-foreground">Loading available workflows...</p>
+          <p className="text-sm text-muted-foreground">Loading available assessments...</p>
         ) : restrictToType !== undefined ? (
           // Single-type mode: render from API types directly. Category config often omits internal workflows,
           // so walking categories would show nothing even when restrictToType is valid.
           workflowTypes.length > 0 ? (
             <div className="space-y-2">{workflowTypes.map(renderCheckbox)}</div>
           ) : (
-            <p className="text-sm text-muted-foreground">This workflow type is not available for your account.</p>
+            <p className="text-sm text-muted-foreground">This assessment is not available for your account.</p>
           )
         ) : (
           visibleGroups.map(({ category, workflows }) => (

--- a/frontend/lib/rail-style.ts
+++ b/frontend/lib/rail-style.ts
@@ -1,0 +1,17 @@
+/**
+ * How a rail marks the item you are on.
+ *
+ * One definition because every rail in the view needs it — filters, lenses,
+ * steps, assessments, help topics — and because the first attempt was too
+ * quiet: selected was `bg-accent` against a `bg-accent/60` hover, two shades of
+ * the same token, so the selection read as a hover that had got stuck.
+ *
+ * The foreground at low alpha rather than the accent token: `--accent` is
+ * oklch(0.97) in light mode, near enough to white that a row wearing it barely
+ * separates from one that is not. Layering the foreground instead darkens the
+ * row on a light theme and lightens it on a dark one, so selection gains
+ * contrast either way. Hover keeps the accent, well below it.
+ */
+export const RAIL_ITEM_ACTIVE = 'bg-foreground/8 text-foreground';
+
+export const RAIL_ITEM_IDLE = 'hover:bg-accent/40';

--- a/frontend/lib/severity-style.ts
+++ b/frontend/lib/severity-style.ts
@@ -1,0 +1,48 @@
+import { SeverityEnum } from './generated-api';
+
+export interface SeverityStyle {
+  /** Severity marker: the dot beside a note and the rule in the document gutter. */
+  dot: string;
+  /** Border of an open note. */
+  edge: string;
+  /** Fill for the selected block and the open note. */
+  wash: string;
+  label: string;
+  text: string;
+}
+
+/**
+ * The one severity palette. The document, the margin, the issue list and the
+ * reference-review explainer all read from here so a colour cannot drift
+ * between where an issue is marked and where it is read.
+ */
+export const SEVERITY: Record<SeverityEnum, SeverityStyle> = {
+  [SeverityEnum.High]: {
+    dot: 'bg-red-500',
+    edge: 'border-red-400 dark:border-red-700',
+    wash: 'bg-red-50 dark:bg-red-950/30',
+    label: 'High',
+    text: 'text-red-700 dark:text-red-300',
+  },
+  [SeverityEnum.Medium]: {
+    dot: 'bg-amber-500',
+    edge: 'border-amber-400 dark:border-amber-700',
+    wash: 'bg-amber-50 dark:bg-amber-950/30',
+    label: 'Medium',
+    text: 'text-amber-800 dark:text-amber-300',
+  },
+  [SeverityEnum.Low]: {
+    dot: 'bg-blue-500',
+    edge: 'border-blue-400 dark:border-blue-700',
+    wash: 'bg-blue-50 dark:bg-blue-950/30',
+    label: 'Low',
+    text: 'text-blue-700 dark:text-blue-300',
+  },
+  [SeverityEnum.None]: {
+    dot: 'bg-green-500',
+    edge: 'border-green-400 dark:border-green-700',
+    wash: 'bg-green-50 dark:bg-green-950/30',
+    label: 'Passing',
+    text: 'text-green-700 dark:text-green-300',
+  },
+};

--- a/frontend/lib/tooltip.ts
+++ b/frontend/lib/tooltip.ts
@@ -1,0 +1,6 @@
+/**
+ * How long a pointer has to rest on a control before its tooltip appears.
+ * Radix defaults to none, which fires tooltips at anything the pointer crosses
+ * on its way somewhere else.
+ */
+export const TOOLTIP_DELAY = 400;

--- a/frontend/lib/use-media-query.ts
+++ b/frontend/lib/use-media-query.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * Whether a media query currently matches, kept in sync with the browser.
+ *
+ * The server has no viewport, so it answers `wide` and the client corrects on
+ * hydration if it is wrong. That bias is deliberate: this view is used on
+ * desktop most of the time, and guessing narrow would flash the layout on
+ * nearly every load.
+ */
+export function useMediaQuery(query: string, serverFallback = true): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const list = window.matchMedia(query);
+      list.addEventListener('change', onChange);
+      return () => list.removeEventListener('change', onChange);
+    },
+    [query],
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => serverFallback,
+  );
+}
+
+/** The widths the v2 panes appear at, matching Tailwind's xl and lg. */
+export const WIDE_ENOUGH_FOR_RAIL = '(min-width: 80rem)';
+export const WIDE_ENOUGH_FOR_PANE = '(min-width: 64rem)';


### PR DESCRIPTION
## Summary

Adds a second project view at `/v2/projects/[projectId]`, mirroring the production routes one level down, so the redesign can be used and compared side by side against the current one without touching it. All five tabs — Document Explorer, References, Files, Assessments, Peer Review — are redesigned. The production route is unchanged in behaviour; the shared components it relies on gained optional props rather than new defaults.

You can move between the two from the project header's overflow menu ("Try the new layout" / "Back to the classic layout"), which keeps the tab and the URL hash.

## Motivation

The current project view spends about 160px of vertical space on chrome before any content, and its 7/5 grid leaves roughly a third of a wide display as gutter. The tabs were also inconsistent with each other: each had invented its own filtering, its own list idiom, and its own place to put actions.

The v2 view reduces chrome to two thin rows (44px + 48px) and gives every tab the same frame: a rail that narrows or navigates, a toolbar that acts on the whole set, a scrolling middle, and — where a row has more to say than fits — a detail pane. Learning one tab now teaches you the rest.

## What's Changed

### Backend

None. No API, model, or workflow changes.

### Frontend

**New: the v2 tree** (`components/results-v2/`, `app/(authenticated)/v2/projects/[projectId]/`)

- `project-shell.tsx`, `app-bar.tsx`, `project-tabs.tsx`, `use-project-shell-state.ts` — the two-row chrome. Title centred in the app bar, tab strip with an active marker riding the panel edge, and the project actions (Run assessments / Export / Revision / overflow) on the right.
- `document-explorer/` — issues rendered in the document margin beside the paragraph they belong to, with a List mode as the alternative. Includes a forked markdown renderer that fixes two real bugs: list markers colliding with the line-number gutter, and currency-heavy prose being parsed as MathML.
- `references/`, `files/`, `assessments/`, `peer-review/` — one directory per redesigned tab, each with its rail, its rows, and its detail pane.
- `new-assessment-button.tsx` — starting assessments from the project header, so it is reachable from every tab rather than only the Assessments tab.
- `panes.tsx` and `lib/use-media-query.ts` — the rail and detail pane, rendered as a column where there is room and a sheet where there is not. Each renders in one place or the other, never both: the detail panes own mutations and dialogs, and mounting them twice would portal duplicate dialogs.
- `reference-review-banner.tsx` and `tabs/reference-review/reference-review-explainer.tsx` — the reference-review gate now names the assessment that is waiting (Claim Reference Validation is the only workflow with `HUMAN_APPROVAL` among its dependencies) and explains why, with two worked examples.

**Shared, extracted so both views read from one source**

- `lib/severity-style.ts` — the severity palette, previously duplicated.
- `lib/tooltip.ts` — the tooltip delay.
- `app/globals.css` — `.text-scale-compact`, which drops the Tailwind type-scale variables one step for a subtree. Lets the v2 view reuse v1's result components at its own density without forking them.

**Shared, changed additively (v1 behaviour preserved at every existing call site)**

- `analysis-options-menu.tsx` — `downloadVariant` prop; the layout switcher; export now precedes the revision picker.
- `revision-switcher.tsx` — a menu button rather than a Select. It sits in a row of buttons, and one of its entries uploads a document rather than choosing a value.
- `start-workflow-button.tsx`, `workflow-run-history.tsx` — `size`, `startLabel`, `tooltip` props.
- `use-workflow-selection.ts` — `defaultWorkflowType`, so a rail-based view can open on the first assessment.
- `peer-review-stage-card.tsx` — `'xs'` added to the size union.
- `profile-dropdown.tsx`, `document-issue-card.tsx`, `editable-title.tsx`, `ui/tooltip.tsx`, `simple-deep-agent-results.tsx` — props, an export, tooltips, and the tooltip delay default.

## Risks and Mitigations

**Narrow screens.** An earlier revision of this branch hid the rails, the panes and the tab strip below `xl`/`lg`, which removed navigation and per-row actions outright rather than merely cramping them as v1 does. That is fixed: each of those now changes form instead of disappearing — the rail and the detail pane become sheets, and the tab strip becomes a menu. Two panes that are not selection-driven get a button (`Issues` on the explorer, `Memos` on peer review). The layout is still built for desktop first, but nothing is unreachable.

**Shared components changed.** Every change is an optional prop with the previous behaviour as its default, except three deliberate ones that apply to v1 too: the revision switcher's shape, the export/revision ordering, and the 400ms tooltip delay (previously 0ms, which fired tooltips at anything the pointer crossed). All three were agreed while building.

**Deliberate omissions, listed so they are not rediscovered as bugs:** the authors line and creation date are gone from the header, and the explorer's line-range selection chip is gone. The Summary tab still renders in the placeholder framing; it has a route but is in neither tab strip.

`pnpm build` passes and all six v2 routes compile. Lint and typecheck are clean apart from three warnings that predate this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
