### PR TITLE
Step through findings from the document explorer toolbar

### DIFF
--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -25,7 +25,7 @@ import { AlertTriangleIcon, Columns2, ListFilter, Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { DocumentHeader, DocumentView, DocumentViewHandle } from './document-view';
 import { IssuesColumn, IssuesColumnHandle, issueCountLabel } from './issues-column';
-import { IssueNav } from './issue-nav';
+import { IssueNav, useIssueShortcuts } from './issue-nav';
 import { Rail, RailToggle, SidePane, useRailState } from '../panes';
 import { OutlineRail } from './outline-rail';
 import { OutlineEntry, extractOutline } from './outline';
@@ -137,14 +137,19 @@ export function DocumentExplorerTabV2({
   // which is the same width the rail sits beside the text at.
   const issuesVisible = showIssuesColumn || (mode === 'margin' && rail.isWide);
 
+  /** Closing a finding, wherever the reader asked for it: a heading, or Escape. */
+  const handleCloseIssue = useCallback(() => {
+    setOpenIssueId(null);
+    clearLineSelection();
+  }, [clearLineSelection]);
+
   const handleSelectIssue = useCallback(
     (issue: Issue) => {
       // Pressing the open row's heading closes it, as pressing the open note's
       // does in the margin: the two are the same control on the same issue, so
       // they cannot answer the same press differently.
       if (openIssueId === issue.id) {
-        setOpenIssueId(null);
-        clearLineSelection();
+        handleCloseIssue();
         return;
       }
 
@@ -160,15 +165,14 @@ export function DocumentExplorerTabV2({
         clearLineSelection();
       }
     },
-    [openIssueId, selectLineRange, clearLineSelection],
+    [openIssueId, handleCloseIssue, selectLineRange, clearLineSelection],
   );
 
   /** Toggles a margin note without moving the document under the reader. */
   const handleToggleMarginNote = useCallback(
     (issue: Issue) => {
       if (openIssueId === issue.id) {
-        setOpenIssueId(null);
-        clearLineSelection();
+        handleCloseIssue();
         return;
       }
       const range = getIssueLineRange(issue);
@@ -176,7 +180,7 @@ export function DocumentExplorerTabV2({
       if (range) selectLineRange(range);
       else clearLineSelection();
     },
-    [openIssueId, selectLineRange, clearLineSelection],
+    [openIssueId, handleCloseIssue, selectLineRange, clearLineSelection],
   );
 
   /**
@@ -226,6 +230,14 @@ export function DocumentExplorerTabV2({
     },
     [orderedIssues, activeIndex, goToIssue],
   );
+
+  // Bound on the same condition the stepper is drawn on, so the keys and the
+  // control it belongs to arrive and leave together.
+  useIssueShortcuts({
+    enabled: issuesVisible && orderedIssues.length > 0,
+    onStep: handleStepIssue,
+    onClose: handleCloseIssue,
+  });
 
   const handleIssueSelectFromDocument = useCallback(
     (issue: Issue | null) => {

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -25,6 +25,7 @@ import { AlertTriangleIcon, Columns2, ListFilter, Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { DocumentHeader, DocumentView, DocumentViewHandle } from './document-view';
 import { IssuesColumn, IssuesColumnHandle, issueCountLabel } from './issues-column';
+import { IssueNav } from './issue-nav';
 import { Rail, RailToggle, SidePane, useRailState } from '../panes';
 import { OutlineRail } from './outline-rail';
 import { OutlineEntry, extractOutline } from './outline';
@@ -178,6 +179,54 @@ export function DocumentExplorerTabV2({
     [openIssueId, selectLineRange, clearLineSelection],
   );
 
+  /**
+   * The issues in the order the reader meets them: the ones about the whole
+   * document first, since that is where the margin gathers them, then the rest
+   * by the line they mark. Not the severity order the list is grouped into —
+   * stepping through that would send the reader up and down the document.
+   */
+  const orderedIssues = useMemo(() => {
+    const anchored: Issue[] = [];
+    const unanchored: Issue[] = [];
+    for (const issue of highlightIssues) (getIssueLineRange(issue) ? anchored : unanchored).push(issue);
+    anchored.sort((a, b) => getIssueLineRange(a)![0] - getIssueLineRange(b)![0]);
+    return [...unanchored, ...anchored];
+  }, [highlightIssues]);
+
+  const activeIndex = useMemo(
+    () => (activeIssueId ? orderedIssues.findIndex((issue) => issue.id === activeIssueId) : -1),
+    [orderedIssues, activeIssueId],
+  );
+
+  /** Takes the reader to an issue, wherever in the document it sits. */
+  const goToIssue = useCallback(
+    (issue: Issue) => {
+      const range = getIssueLineRange(issue);
+      setOpenIssueId(issue.id);
+      issuesRef.current?.scrollToIssue(issue);
+      if (range) {
+        selectLineRange(range);
+        documentRef.current?.scrollToLineRange(range);
+        return;
+      }
+      // Nothing anchors this one, so the margin keeps it above the first
+      // paragraph and that is the only place it can be shown.
+      clearLineSelection();
+      documentRef.current?.scrollToTop();
+    },
+    [selectLineRange, clearLineSelection],
+  );
+
+  // No issue open leaves the index at -1, so the first step forwards lands on
+  // the first issue and the first step back falls off the front and does nothing.
+  const handleStepIssue = useCallback(
+    (delta: 1 | -1) => {
+      const issue = orderedIssues[activeIndex + delta];
+      if (issue) goToIssue(issue);
+    },
+    [orderedIssues, activeIndex, goToIssue],
+  );
+
   const handleIssueSelectFromDocument = useCallback(
     (issue: Issue | null) => {
       if (!issue) {
@@ -298,39 +347,53 @@ export function DocumentExplorerTabV2({
               </Tooltip>
             )}
 
-            {!issuesVisible && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="xs" variant="outline" className="ml-auto" onClick={() => setIssuesOpen(true)}>
-                    <ListFilter className="size-3" />
-                    Issues
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Every issue found in this document</TooltipContent>
-              </Tooltip>
-            )}
+            <div className="ml-auto flex shrink-0 items-center gap-2">
+              {/* Only while something on screen can show what it steps to.
+                  Below the width the margin and the column arrive at, the
+                  issues live in a sheet the reader opens, and stepping would
+                  move the document without ever showing them the finding. */}
+              {issuesVisible && (
+                <IssueNav
+                  position={activeIndex >= 0 ? activeIndex + 1 : null}
+                  total={orderedIssues.length}
+                  onStep={handleStepIssue}
+                />
+              )}
 
-            <div className="ml-auto hidden items-center gap-1 rounded-md border p-0.5 xl:flex">
-              {MODES.map((option) => (
-                <Tooltip key={option.id}>
+              {!issuesVisible && (
+                <Tooltip>
                   <TooltipTrigger asChild>
-                    <button
-                      onClick={() => handleModeChange(option.id)}
-                      aria-pressed={mode === option.id}
-                      className={cn(
-                        'flex cursor-pointer items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs font-medium transition-colors',
-                        mode === option.id
-                          ? 'bg-accent text-accent-foreground'
-                          : 'text-muted-foreground hover:bg-accent/60',
-                      )}
-                    >
-                      <option.icon className="size-3.5" />
-                      {option.label}
-                    </button>
+                    <Button size="xs" variant="outline" onClick={() => setIssuesOpen(true)}>
+                      <ListFilter className="size-3" />
+                      Issues
+                    </Button>
                   </TooltipTrigger>
-                  <TooltipContent>{option.hint}</TooltipContent>
+                  <TooltipContent>Every issue found in this document</TooltipContent>
                 </Tooltip>
-              ))}
+              )}
+
+              <div className="hidden items-center gap-1 rounded-md border p-0.5 xl:flex">
+                {MODES.map((option) => (
+                  <Tooltip key={option.id}>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => handleModeChange(option.id)}
+                        aria-pressed={mode === option.id}
+                        className={cn(
+                          'flex cursor-pointer items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs font-medium transition-colors',
+                          mode === option.id
+                            ? 'bg-accent text-accent-foreground'
+                            : 'text-muted-foreground hover:bg-accent/60',
+                        )}
+                      >
+                        <option.icon className="size-3.5" />
+                        {option.label}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>{option.hint}</TooltipContent>
+                  </Tooltip>
+                ))}
+              </div>
             </div>
           </div>
 

--- a/frontend/components/results-v2/document-explorer/document-view.tsx
+++ b/frontend/components/results-v2/document-explorer/document-view.tsx
@@ -29,6 +29,8 @@ export interface ScrollAnchor {
 export interface DocumentViewHandle {
   scrollToLineRange: (range: [number, number]) => void;
   scrollToLine: (line: number, behavior?: ScrollBehavior) => void;
+  /** Where the findings that belong to no paragraph are gathered. */
+  scrollToTop: () => void;
   /** Where the reader is, precisely enough to put them back after a reflow. */
   getScrollAnchor: () => ScrollAnchor | null;
   scrollToAnchor: (anchor: ScrollAnchor) => void;
@@ -317,6 +319,7 @@ export function DocumentView({
     scrollToLineRange: (range: [number, number]) => scrollToRange(range, { at: 'center' }),
     scrollToLine: (line: number, behavior: ScrollBehavior = 'smooth') =>
       scrollToRange([line, line], { at: 'top', offset: 12 }, behavior),
+    scrollToTop: () => containerRef.current?.scrollTo({ top: 0, behavior: 'smooth' }),
     getScrollAnchor: () => {
       const container = containerRef.current;
       if (!container) return null;

--- a/frontend/components/results-v2/document-explorer/issue-nav.tsx
+++ b/frontend/components/results-v2/document-explorer/issue-nav.tsx
@@ -73,12 +73,50 @@ export function IssueNav({ position, total, onStep }: IssueNavProps) {
   );
 }
 
+/**
+ * The things that hold the keyboard while they are up — menus and alerts as
+ * much as plain dialogs, since each brings its own typeahead and its own
+ * Escape.
+ *
+ * Roles rather than open-state attributes, because the app speaks two dialects:
+ * Radix stamps `data-state="open"`, Headless UI stamps `data-open`, and the
+ * user menu is the second kind. Whether one is up is asked of the focus
+ * instead, which is the thing at issue and which no library can spell
+ * differently. Tooltips are left out on purpose — one is open for as long as
+ * the pointer rests on a button, and they take no focus.
+ */
+const OVERLAYS = '[role="dialog"],[role="alertdialog"],[role="menu"],[role="listbox"]';
+
+function overlayHasKeyboard(target: EventTarget | null): boolean {
+  const focused = document.activeElement;
+  if (focused instanceof HTMLElement && focused.closest(OVERLAYS)) return true;
+  return target instanceof HTMLElement && !!target.closest(OVERLAYS);
+}
+
 /** Widgets that steer themselves with the arrow keys and must keep them. */
 const ARROW_OWNERS = '[role="menu"],[role="listbox"],[role="radiogroup"],[role="tablist"],[role="slider"]';
 
 function isTyping(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   return target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName);
+}
+
+/**
+ * Whether the arrows are already spoken for where the press landed.
+ *
+ * Either a widget that navigates itself with them, or a region with more to the
+ * side than it can show: the document gives wide tables, code and maths their
+ * own horizontal scroll, a browser lets the keyboard pan those, and taking Left
+ * and Right would strand the part hanging off the edge.
+ */
+function ownsArrows(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.closest(ARROW_OWNERS)) return true;
+
+  for (let node: HTMLElement | null = target; node; node = node.parentElement) {
+    if (node.scrollWidth > node.clientWidth && /auto|scroll/.test(getComputedStyle(node).overflowX)) return true;
+  }
+  return false;
 }
 
 /**
@@ -106,7 +144,7 @@ export function useIssueShortcuts({
       // Chords belong to the browser and the system, and an open dialog owns
       // the keyboard until it closes — the Escape that dismisses it included.
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
-      if (isTyping(event.target) || document.querySelector('[role="dialog"][data-state="open"]')) return;
+      if (isTyping(event.target) || overlayHasKeyboard(event.target)) return;
 
       const key = event.key.toLowerCase();
       if (event.key === 'Escape') {
@@ -116,8 +154,7 @@ export function useIssueShortcuts({
         return;
       }
 
-      const arrow = key.startsWith('arrow');
-      if (arrow && (event.target as HTMLElement | null)?.closest?.(ARROW_OWNERS)) return;
+      if (key.startsWith('arrow') && ownsArrows(event.target)) return;
 
       const delta = matches(KEYS.next, key) ? 1 : matches(KEYS.previous, key) ? -1 : null;
       if (delta === null) return;

--- a/frontend/components/results-v2/document-explorer/issue-nav.tsx
+++ b/frontend/components/results-v2/document-explorer/issue-nav.tsx
@@ -3,6 +3,26 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { useEffect } from 'react';
+
+/**
+ * The keys the stepper answers to.
+ *
+ * `n` and `p` are the ones it advertises: they say what they do to anyone who
+ * has not read a shortcut list, which `j` and `k` only do for people who have.
+ * The arrows are aliases for readers who reach for them first, and they are the
+ * horizontal pair on purpose — the vertical two are how a keyboard scrolls a
+ * document, and taking those would cost more than it gave.
+ *
+ * No modifier on any of them: a reader working through ninety findings presses
+ * these a great many times.
+ */
+const KEYS = {
+  // Spelled as `KeyboardEvent.key` spells them, since that is also how
+  // `aria-keyshortcuts` names them to a screen reader. Compared case-insensitively.
+  next: { shortcut: 'n', aliases: ['ArrowRight'] },
+  previous: { shortcut: 'p', aliases: ['ArrowLeft'] },
+} as const;
 
 interface IssueNavProps {
   /** Where the reader stands in the walk, counting from one, or null before it. */
@@ -32,6 +52,7 @@ export function IssueNav({ position, total, onStep }: IssueNavProps) {
     <div className="flex items-center gap-0.5 rounded-md border p-0.5">
       <Step
         label="Previous issue"
+        shortcut={KEYS.previous}
         icon={ChevronUpIcon}
         // Nothing open means the reader has not started, so there is nothing
         // behind them; the first press has to go forwards.
@@ -43,6 +64,7 @@ export function IssueNav({ position, total, onStep }: IssueNavProps) {
       </span>
       <Step
         label="Next issue"
+        shortcut={KEYS.next}
         icon={ChevronDownIcon}
         disabled={position !== null && position >= total}
         onClick={() => onStep(1)}
@@ -51,13 +73,77 @@ export function IssueNav({ position, total, onStep }: IssueNavProps) {
   );
 }
 
+/** Widgets that steer themselves with the arrow keys and must keep them. */
+const ARROW_OWNERS = '[role="menu"],[role="listbox"],[role="radiogroup"],[role="tablist"],[role="slider"]';
+
+function isTyping(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName);
+}
+
+/**
+ * The stepper's keyboard half.
+ *
+ * Bound only while the stepper itself is on screen, so a reader never presses a
+ * key belonging to a control they cannot see, and the keys never move a
+ * document whose findings are hidden.
+ */
+export function useIssueShortcuts({
+  enabled,
+  onStep,
+  onClose,
+}: {
+  enabled: boolean;
+  onStep: (delta: 1 | -1) => void;
+  onClose: () => void;
+}) {
+  // A window subscription is what an effect is for: nothing here is derived and
+  // nothing is rendered, and the listener has to be taken back down.
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handle = (event: KeyboardEvent) => {
+      // Chords belong to the browser and the system, and an open dialog owns
+      // the keyboard until it closes — the Escape that dismisses it included.
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (isTyping(event.target) || document.querySelector('[role="dialog"][data-state="open"]')) return;
+
+      const key = event.key.toLowerCase();
+      if (event.key === 'Escape') {
+        // Left to bubble: something else may want it, and there may be no open
+        // finding for this to close.
+        onClose();
+        return;
+      }
+
+      const arrow = key.startsWith('arrow');
+      if (arrow && (event.target as HTMLElement | null)?.closest?.(ARROW_OWNERS)) return;
+
+      const delta = matches(KEYS.next, key) ? 1 : matches(KEYS.previous, key) ? -1 : null;
+      if (delta === null) return;
+
+      event.preventDefault();
+      onStep(delta);
+    };
+
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [enabled, onStep, onClose]);
+}
+
+function matches(binding: { shortcut: string; aliases: readonly string[] }, key: string): boolean {
+  return binding.shortcut === key || binding.aliases.some((alias) => alias.toLowerCase() === key);
+}
+
 function Step({
   label,
+  shortcut,
   icon: Icon,
   disabled,
   onClick,
 }: {
   label: string;
+  shortcut: { shortcut: string; aliases: readonly string[] };
   icon: typeof ChevronUpIcon;
   disabled: boolean;
   onClick: () => void;
@@ -69,6 +155,9 @@ function Step({
           onClick={onClick}
           disabled={disabled}
           aria-label={label}
+          // The name stays clean for a screen reader, which announces the keys
+          // from here rather than reading the tooltip's decoration aloud.
+          aria-keyshortcuts={[shortcut.shortcut, ...shortcut.aliases].join(' ')}
           className={cn(
             'flex size-5 items-center justify-center rounded-sm text-muted-foreground transition-colors',
             disabled ? 'opacity-40' : 'hover:bg-accent/60 hover:text-foreground cursor-pointer',
@@ -77,7 +166,14 @@ function Step({
           <Icon className="size-3.5" />
         </button>
       </TooltipTrigger>
-      <TooltipContent>{label}</TooltipContent>
+      {/* The advertised key only. A tooltip listing every alias reads as a
+          manual; the reader who reaches for an arrow finds it works anyway. */}
+      <TooltipContent>
+        {label}
+        <kbd className="ml-1.5 rounded border border-current/30 px-1 font-mono text-[10px] uppercase opacity-80">
+          {shortcut.shortcut}
+        </kbd>
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/frontend/components/results-v2/document-explorer/issue-nav.tsx
+++ b/frontend/components/results-v2/document-explorer/issue-nav.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+
+interface IssueNavProps {
+  /** Where the reader stands in the walk, counting from one, or null before it. */
+  position: number | null;
+  total: number;
+  onStep: (delta: 1 | -1) => void;
+}
+
+/**
+ * Step to the next finding, or back to the one before it.
+ *
+ * Findings are not spread evenly through a document: it can carry nothing for
+ * twenty pages and then eleven in a row. Without this the reader has to scroll
+ * the whole quiet stretch to find that out, and in margin mode there is nothing
+ * beside the text to tell them how much further to go.
+ *
+ * The count is here for the same reason — it answers how far through the review
+ * they are, which neither the document nor the margin can say.
+ *
+ * Whether the width can carry this at all is the caller's to decide: stepping is
+ * only worth offering while something on screen can show what it steps to.
+ */
+export function IssueNav({ position, total, onStep }: IssueNavProps) {
+  if (total === 0) return null;
+
+  return (
+    <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+      <Step
+        label="Previous issue"
+        icon={ChevronUpIcon}
+        // Nothing open means the reader has not started, so there is nothing
+        // behind them; the first press has to go forwards.
+        disabled={position === null || position <= 1}
+        onClick={() => onStep(-1)}
+      />
+      <span className="px-1 font-mono text-[11px] tabular-nums text-muted-foreground">
+        {position ?? '–'}/{total}
+      </span>
+      <Step
+        label="Next issue"
+        icon={ChevronDownIcon}
+        disabled={position !== null && position >= total}
+        onClick={() => onStep(1)}
+      />
+    </div>
+  );
+}
+
+function Step({
+  label,
+  icon: Icon,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  icon: typeof ChevronUpIcon;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={label}
+          className={cn(
+            'flex size-5 items-center justify-center rounded-sm text-muted-foreground transition-colors',
+            disabled ? 'opacity-40' : 'hover:bg-accent/60 hover:text-foreground cursor-pointer',
+          )}
+        >
+          <Icon className="size-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a previous/next stepper to the Document Explorer toolbar, with a position count and keyboard shortcuts, so a reader can walk the findings in document order instead of scrolling to look for them.

## Motivation

Findings are not spread evenly through a document. One can carry nothing for twenty pages and then eleven in a row, and until now the only way to learn that was to scroll the quiet stretch. Margin mode makes it worse rather than better: the notes sit beside the text, so when there is no text with findings on screen there is nothing at all to say how much further to go.

The count answers the other half of the same question — how much of the review is left — which neither the document nor the margin can say.

## What's Changed

### Backend

None.

### Frontend

- **`components/results-v2/document-explorer/issue-nav.tsx`** (new) — the control and its keyboard half.
  - `IssueNav`: an up arrow, a `position/total` count, a down arrow, styled to match the Margin/List switch it sits beside. Each arrow carries an `aria-label`, an `aria-keyshortcuts`, and a tooltip showing its key. Renders nothing when the document has no findings.
  - `useIssueShortcuts`: **N** and **P** step forward and back and are the keys the tooltips advertise, since they say what they do to a reader who has never seen a shortcut list. **→** and **←** are aliases for anyone who reaches for arrows first — the horizontal pair on purpose, because the vertical two are how a keyboard scrolls a document. **Esc** closes the open finding, the one gesture the stepper had no key for.
  - The keys are bound on the same condition the stepper is drawn on, so a reader never presses one belonging to a control that is not there. They stand down while a field has focus, while a modifier is held, and while a dialog is open — a dialog owns the keyboard until it closes, the Escape that dismisses it included. The arrows additionally stand down inside the widgets that steer themselves with them (`menu`, `listbox`, `radiogroup`, `tablist`, `slider`).
- **`components/results-v2/document-explorer/document-explorer-tab.tsx`** — builds the walk order, tracks where the reader is in it, and steps them:
  - `orderedIssues` sorts by line, with the findings about the whole document first, since that is where the margin gathers them. Deliberately *not* the severity order the list is grouped into: stepping through that would send the reader up and down the page.
  - `goToIssue` opens the finding, selects its lines and centres its paragraph. A finding with no lines has no paragraph to jump to, so it scrolls to the top of the margin where those are kept.
  - No finding open leaves the index at `-1`, so the first press forwards lands on the first finding and the first press back falls off the front and does nothing — which is why the up arrow starts disabled.
  - The stepper renders only while `issuesVisible`. Below the width the margin and the column arrive at, the findings live in a sheet, and stepping would move the document without ever showing the reader what it stepped to. That is the same flag whose complement already puts the "Issues" sheet button in the toolbar, so the two swap places.
  - `handleCloseIssue` gives "close the open finding" one definition; it was written out three times (list heading, margin note, and now Escape) and they have to agree.
  - The toolbar's right-hand controls are now one `ml-auto` group rather than several competing for the free space.
- **`components/results-v2/document-explorer/document-view.tsx`** — adds `scrollToTop()` to the handle, for the findings that belong to no paragraph.

## Risks and Mitigations

Low risk: additive, and confined to the v2 explorer. The only shared change is `handleCloseIssue`, which is the same two statements the three call sites already ran.

Checked in the browser on two projects. Stepping forward moves strictly down the document (L99 → 103 → 105 → 109 → 113); stepping back decrements. Opening the last margin note reads `104/104` with the down arrow disabled; the first reads `1/104` with the up arrow disabled — which also confirms the walk order matches what the margin renders, since the last note is the last step. On a project with 3 document-level findings among 55, stepping to one from 6000px down the page requests a scroll to 0 and opens it in the "About the whole document" group.

Every shortcut and guard was exercised with dispatched key events: `n`/`→` stepped 1 → 2 → 3, `p`/`←` came back 3 → 2 → 1, `Esc` closed the finding and cleared the line highlight, and `n` did nothing when typed into an input, when held with Cmd, or while the Help dialog was open.

Two judgement calls worth flagging:

- The stepper disappears between roughly `sm` and `lg` rather than opening the sheet on each press. Opening the sheet was the alternative, and it is what a paragraph click already does; hiding was chosen as the simpler behaviour.
- The chevrons point up and down while the arrow aliases are left and right. The icons follow what happens — press and the document moves down — rather than the keys. Worth revisiting if the arrows should be advertised rather than merely accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)