### PR TITLE
feat(feedback): surface revisions in admin feedback, and keep issue actions available on older revisions

### DIFF
--- a/frontend/components/admin/feedbacks-list.tsx
+++ b/frontend/components/admin/feedbacks-list.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { UserCombobox } from '@/components/admin/user-combobox';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { DocumentIssueCard } from '@/components/results/components/document-issue-card';
 import {
   AdminFeedbackItem,
@@ -41,6 +42,26 @@ function VisibilityBadge({ visibility }: { visibility: FeedbackVisibility }) {
     return <Badge variant="default">{VISIBILITY_LABELS[visibility]}</Badge>;
   }
   return <Badge variant="secondary">{VISIBILITY_LABELS[visibility]}</Badge>;
+}
+
+/** Shows which project revision the feedback was given on, and whether that is still the latest one. */
+function RevisionBadge({ revision, currentRevision }: { revision: number; currentRevision: number }) {
+  const isLatest = revision >= currentRevision;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant="outline" className="font-normal whitespace-nowrap">
+          Rev {revision}
+          {!isLatest && <span className="text-muted-foreground">of {currentRevision}</span>}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">
+        {isLatest
+          ? `This feedback is about revision ${revision} of the document, which is still the latest one.`
+          : `This feedback is about revision ${revision} of the document. The project has since moved on to revision ${currentRevision}.`}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 function FeedbackDetailSheet({ item, onClose }: { item: AdminFeedbackItem | null; onClose: () => void }) {
@@ -86,6 +107,14 @@ function FeedbackDetailSheet({ item, onClose }: { item: AdminFeedbackItem | null
                       <ExternalLinkIcon className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
                     </Link>
                   )}
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <RevisionBadge revision={item.revision} currentRevision={item.project_current_revision} />
+                  <span className="text-xs text-muted-foreground">
+                    {item.revision >= item.project_current_revision
+                      ? 'Latest revision of the document'
+                      : `The document has since moved on to revision ${item.project_current_revision}`}
+                  </span>
                 </div>
               </section>
 
@@ -301,7 +330,8 @@ export function FeedbacksList() {
                           User <span className="text-xs text-muted-foreground"> (Name / Email)</span>
                         </TableHead>
                         <TableHead>
-                          Project <span className="text-xs text-muted-foreground"> (Title / Visibility)</span>
+                          Project{' '}
+                          <span className="text-xs text-muted-foreground"> (Title / Visibility / Revision)</span>
                         </TableHead>
                         <TableHead>
                           Issue <span className="text-xs text-muted-foreground"> (Title / Workflow type)</span>
@@ -324,7 +354,7 @@ export function FeedbacksList() {
                             <div className="font-medium text-sm">{item.user_name}</div>
                             <div className="text-xs text-muted-foreground">{item.user_email}</div>
                           </TableCell>
-                          <TableCell className="max-w-[180px]">
+                          <TableCell className="max-w-[200px]">
                             <div className="flex items-center gap-1 min-w-0">
                               <span className="text-sm truncate">{item.project_title}</span>
                               {item.visibility === FeedbackVisibility.FullProject && (
@@ -338,8 +368,9 @@ export function FeedbacksList() {
                                 </Link>
                               )}
                             </div>
-                            <div className="mt-0.5">
+                            <div className="mt-0.5 flex flex-wrap items-center gap-1">
                               <VisibilityBadge visibility={item.visibility} />
+                              <RevisionBadge revision={item.revision} currentRevision={item.project_current_revision} />
                             </div>
                           </TableCell>
                           <TableCell className="max-w-[220px]">

--- a/frontend/components/results-v2/document-explorer-v2-panel.tsx
+++ b/frontend/components/results-v2/document-explorer-v2-panel.tsx
@@ -10,13 +10,7 @@ import { DocumentExplorerTabV2 } from './document-explorer/document-explorer-tab
  * the explorer itself.
  */
 export function DocumentExplorerV2Panel() {
-  const { projectDetail, readOnly, navigateToTab } = useProjectView();
+  const { projectDetail, navigateToTab } = useProjectView();
 
-  return (
-    <DocumentExplorerTabV2
-      projectDetail={projectDetail}
-      readOnly={readOnly}
-      onNavigateToAnalyses={() => navigateToTab('analyses')}
-    />
-  );
+  return <DocumentExplorerTabV2 projectDetail={projectDetail} onNavigateToAnalyses={() => navigateToTab('analyses')} />;
 }

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { Callout } from '@/components/ui/callout';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { Issue, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { AccessLevel, Issue, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useLineHashNavigation } from '@/lib/line-hash';
 import {
   getHighlightIssues,
@@ -62,6 +62,11 @@ export function DocumentExplorerTabV2({
 }: DocumentExplorerTabProps) {
   const { selectedLineRange, selectLineRange, clearLineSelection, filter, setFilter, clearFilters } =
     useDocumentExplorerStore();
+
+  // Resolving an issue and rating it are judgements about the analysis, not edits to the
+  // document, so they stay open on older revisions. `readOnly` covers both here, and only
+  // the half about not owning the project should reach the issue notes.
+  const canEditIssues = projectDetail.access_level === AccessLevel.Write;
 
   const rail = useRailState();
   const isWideEnoughForColumn = useMediaQuery(WIDE_ENOUGH_FOR_PANE);
@@ -417,7 +422,11 @@ export function DocumentExplorerTabV2({
               issues={highlightIssues}
               selectedLineRange={selectedLineRange}
               onIssueSelect={handleIssueSelectFromDocument}
-              margin={mode === 'margin' ? { activeIssueId, readOnly, onSelect: handleToggleMarginNote } : undefined}
+              margin={
+                mode === 'margin'
+                  ? { activeIssueId, readOnly: !canEditIssues, onSelect: handleToggleMarginNote }
+                  : undefined
+              }
             />
           </div>
         </main>
@@ -438,7 +447,7 @@ export function DocumentExplorerTabV2({
             issues={highlightIssues}
             activeIssueId={activeIssueId}
             isAnyProcessing={isAnyProcessing}
-            readOnly={readOnly}
+            readOnly={!canEditIssues}
             onSelectIssue={handleSelectIssue}
           />
         </SidePane>

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -43,7 +43,6 @@ const MODES = [
 
 interface DocumentExplorerTabProps {
   projectDetail: ProjectDetailed;
-  readOnly?: boolean;
   onNavigateToAnalyses: () => void;
 }
 
@@ -55,11 +54,7 @@ function getIssueLineRange(issue: Issue): [number, number] | null {
   return [start_line, end_line];
 }
 
-export function DocumentExplorerTabV2({
-  projectDetail,
-  readOnly = false,
-  onNavigateToAnalyses,
-}: DocumentExplorerTabProps) {
+export function DocumentExplorerTabV2({ projectDetail, onNavigateToAnalyses }: DocumentExplorerTabProps) {
   const { selectedLineRange, selectLineRange, clearLineSelection, filter, setFilter, clearFilters } =
     useDocumentExplorerStore();
 

--- a/frontend/components/results-v2/document-explorer/issue-note.tsx
+++ b/frontend/components/results-v2/document-explorer/issue-note.tsx
@@ -1,15 +1,25 @@
 'use client';
 
 import { Markdown } from '@/components/markdown';
-import { IssueFeedbackButtons } from '@/components/results/components/document-issue-card';
+import { feedbackLabel, IssueFeedbackButtons } from '@/components/results/components/document-issue-card';
+import { useIsIssueFeedbackVisible, useIssueFeedbackFromContext } from '@/lib/contexts/project-feedback-context';
 import { Button } from '@/components/ui/button';
-import { Issue } from '@/lib/generated-api';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { FeedbackType, Issue } from '@/lib/generated-api';
 import { useIssueActions } from '@/lib/hooks/use-issue-actions';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { SEVERITY } from '@/lib/severity-style';
 import { isIssueResolved } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon, LightbulbIcon, UndoIcon } from 'lucide-react';
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  LightbulbIcon,
+  ThumbsDownIcon,
+  ThumbsUpIcon,
+  UndoIcon,
+} from 'lucide-react';
 import { useState } from 'react';
 
 export function lineLabel(issue: Issue): string | null {
@@ -49,11 +59,44 @@ export function IssuePreview({ issue }: { issue: Issue }) {
   return <span className="mt-0.5 block truncate text-[12px] leading-snug text-muted-foreground">{text}</span>;
 }
 
+/**
+ * A closed issue says nothing about whether it was rated, so a whole margin of them hides
+ * where the reader has already been. This marks the ones carrying feedback, and its
+ * tooltip carries the note that was written with it — the thumb alone says a judgement
+ * was made but not what it was about.
+ *
+ * The trigger is a span, not the button Radix renders by default: this sits inside the
+ * heading button that opens the issue, and a button within a button is invalid markup.
+ * The padding is there to give a 12px icon something to hover.
+ */
+function IssueFeedbackIndicator({ issueId }: { issueId: string }) {
+  const { feedback } = useIssueFeedbackFromContext(issueId);
+  if (!feedback) return null;
+
+  const label = feedbackLabel(feedback.feedback_type, feedback.feedback_text);
+  const Icon = feedback.feedback_type === FeedbackType.ThumbsUp ? ThumbsUpIcon : ThumbsDownIcon;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          aria-label={label}
+          className="-my-1 inline-flex shrink-0 items-center px-0.5 py-1 text-muted-foreground hover:text-foreground"
+        >
+          <Icon className="size-3" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 /** The line above an issue's title: its severity, where it came from, where it lands. */
 export function IssueMeta({ issue }: { issue: Issue }) {
   const { getWorkflowTypeName } = useWorkflowTypes();
   const resolved = isIssueResolved(issue);
   const line = lineLabel(issue);
+  const feedbackVisible = useIsIssueFeedbackVisible(issue.id);
 
   return (
     <span className="flex items-center gap-1.5">
@@ -67,6 +110,7 @@ export function IssueMeta({ issue }: { issue: Issue }) {
           Resolved
         </span>
       )}
+      {feedbackVisible && issue.id && <IssueFeedbackIndicator issueId={issue.id} />}
       {line && (
         <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">{line}</span>
       )}
@@ -81,6 +125,7 @@ export function IssueMeta({ issue }: { issue: Issue }) {
  */
 export function IssueBody({ issue, readOnly }: { issue: Issue; readOnly: boolean }) {
   const { resolveIssue, unresolveIssue, isResolving, isUnresolving } = useIssueActions();
+  const showFeedback = useIsIssueFeedbackVisible(issue.id);
   const [showDetails, setShowDetails] = useState(false);
 
   const resolved = isIssueResolved(issue);
@@ -122,21 +167,25 @@ export function IssueBody({ issue, readOnly }: { issue: Issue; readOnly: boolean
         </>
       )}
 
-      {!readOnly && issue.id && (
+      {issue.id && (!readOnly || showFeedback) && (
         <div className="flex items-center gap-1.5 pt-0.5">
-          <Button
-            size="sm"
-            variant={resolved ? 'outline' : 'default'}
-            className="h-6 px-2 text-[11px]"
-            disabled={busy}
-            onClick={() => (resolved ? unresolveIssue(issue.id) : resolveIssue(issue.id))}
-          >
-            {resolved ? <UndoIcon className="size-3" /> : <CheckIcon className="size-3" />}
-            {resolved ? 'Mark unresolved' : 'Mark resolved'}
-          </Button>
-          <span className="ml-auto">
-            <IssueFeedbackButtons issueId={issue.id} />
-          </span>
+          {!readOnly && (
+            <Button
+              size="sm"
+              variant={resolved ? 'outline' : 'default'}
+              className="h-6 px-2 text-[11px]"
+              disabled={busy}
+              onClick={() => (resolved ? unresolveIssue(issue.id) : resolveIssue(issue.id))}
+            >
+              {resolved ? <UndoIcon className="size-3" /> : <CheckIcon className="size-3" />}
+              {resolved ? 'Mark unresolved' : 'Mark resolved'}
+            </Button>
+          )}
+          {showFeedback && (
+            <span className="ml-auto">
+              <IssueFeedbackButtons issueId={issue.id} />
+            </span>
+          )}
         </div>
       )}
     </div>

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -11,7 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { EditableTitle } from '@/components/ui/editable-title';
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { ProjectFeedbackProvider } from '@/lib/contexts/project-feedback-context';
-import { ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { AccessLevel, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
 import { ReactNode, useMemo } from 'react';
@@ -106,12 +106,16 @@ export function ProjectShellV2({
       <h1 className="truncate text-sm font-semibold">{projectDetail.project.title}</h1>
     );
 
+  // See the note in the v1 shell: the user's own feedback stays available on older
+  // revisions, and a shared project has none to show.
+  const canAccessFeedback = projectDetail.access_level === AccessLevel.Write;
+
   const navigateToTab = (tab: TabType, hash?: string) => onTabChange(tab, hash);
 
   return (
     <ProjectFeedbackProvider
-      projectId={readOnly ? undefined : projectDetail.project.id}
-      feedbackVisibility={readOnly ? null : (projectDetail.project.feedback_visibility ?? null)}
+      projectId={canAccessFeedback ? projectDetail.project.id : undefined}
+      feedbackVisibility={canAccessFeedback ? (projectDetail.project.feedback_visibility ?? null) : null}
     >
       <PageTitle title={projectDetail.project.title} />
 

--- a/frontend/components/results/components/document-issue-card.tsx
+++ b/frontend/components/results/components/document-issue-card.tsx
@@ -8,7 +8,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Textarea } from '@/components/ui/textarea';
-import { useIssueFeedbackFromContext } from '@/lib/contexts/project-feedback-context';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useIsIssueFeedbackVisible, useIssueFeedbackFromContext } from '@/lib/contexts/project-feedback-context';
 import { FeedbackType, Issue, SeverityEnum } from '@/lib/generated-api';
 import { useIssueActions } from '@/lib/hooks/use-issue-actions';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
@@ -28,7 +29,7 @@ import {
   TriangleAlertIcon,
   UndoIcon,
 } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo, ReactNode, useState } from 'react';
 import { Markdown } from '@/components/markdown';
 import { SeverityBadge } from './severity-badge';
 import { isIssueResolved } from '@/lib/stores/document-explorer-store';
@@ -70,6 +71,34 @@ export const severityColorMap: Record<
   },
 };
 
+/** How a piece of feedback reads back to the person who left it. Shared so the control and
+ *  the v2 collapsed indicator never describe the same feedback differently. */
+export function feedbackLabel(feedbackType: FeedbackType, feedbackText?: string | null): string {
+  if (feedbackType === FeedbackType.ThumbsUp) return 'You marked this issue as helpful';
+  return feedbackText
+    ? `You marked this issue as not helpful: "${feedbackText}"`
+    : 'You marked this issue as not helpful';
+}
+
+/**
+ * A tooltip for one of the thumbs.
+ *
+ * It hangs off a wrapper rather than the button itself because the button is disabled
+ * once that thumb is the one chosen — and a disabled button emits no pointer events, so
+ * the tooltip would go missing in exactly the case worth explaining: the rating already
+ * given, and whatever note came with it.
+ */
+function ThumbTooltip({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex">{children}</span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 /** Thumbs up/down with the "what could be improved" popover. Shared with the v2 margin note. */
 export function IssueFeedbackButtons({ issueId }: { issueId: string }) {
   const { feedback, submitFeedback, isSubmitting } = useIssueFeedbackFromContext(issueId);
@@ -90,30 +119,37 @@ export function IssueFeedbackButtons({ issueId }: { issueId: string }) {
     setFeedbackText('');
   };
 
+  const isThumbsUp = selectedFeedback === FeedbackType.ThumbsUp;
+  const isThumbsDown = selectedFeedback === FeedbackType.ThumbsDown;
+
   return (
     <div className="flex items-center gap-0.5">
-      <Button
-        variant={selectedFeedback === FeedbackType.ThumbsUp ? 'default' : 'ghost'}
-        size="xs"
-        onClick={handleThumbsUp}
-        className="h-6 w-6 p-0"
-        disabled={isSubmitting || (hasSubmitted && selectedFeedback === FeedbackType.ThumbsUp)}
-        title="Helpful"
-      >
-        <ThumbsUp className="h-3 w-3" />
-      </Button>
+      <ThumbTooltip label={isThumbsUp ? feedbackLabel(FeedbackType.ThumbsUp) : 'Helpful'}>
+        <Button
+          variant={isThumbsUp ? 'default' : 'ghost'}
+          size="xs"
+          onClick={handleThumbsUp}
+          className="h-6 w-6 p-0"
+          disabled={isSubmitting || isThumbsUp}
+        >
+          <ThumbsUp className="h-3 w-3" />
+        </Button>
+      </ThumbTooltip>
       <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant={selectedFeedback === FeedbackType.ThumbsDown ? 'default' : 'ghost'}
-            size="xs"
-            className="h-6 w-6 p-0"
-            disabled={hasSubmitted && selectedFeedback === FeedbackType.ThumbsDown}
-            title="Not helpful"
-          >
-            <ThumbsDown className="h-3 w-3" />
-          </Button>
-        </PopoverTrigger>
+        <ThumbTooltip
+          label={isThumbsDown ? feedbackLabel(FeedbackType.ThumbsDown, feedback?.feedback_text) : 'Not helpful'}
+        >
+          <PopoverTrigger asChild>
+            <Button
+              variant={isThumbsDown ? 'default' : 'ghost'}
+              size="xs"
+              className="h-6 w-6 p-0"
+              disabled={isThumbsDown}
+            >
+              <ThumbsDown className="h-3 w-3" />
+            </Button>
+          </PopoverTrigger>
+        </ThumbTooltip>
         <PopoverContent className="w-72" align="end">
           <div className="space-y-3">
             <p className="text-sm font-medium">What could be improved?</p>
@@ -172,6 +208,7 @@ function DocumentIssueCardRaw({ issue, hideJumpButton = false, onSelect, readOnl
   const { className, icon, accentClassName } = severityColorMap[issue.severity];
   const { getWorkflowTypeName } = useWorkflowTypes();
   const isResolved = isIssueResolved(issue);
+  const showFeedback = useIsIssueFeedbackVisible(issue.id);
 
   const { start_line: startLine, end_line: endLine } = issue as Issue & {
     start_line?: number | null;
@@ -218,7 +255,7 @@ function DocumentIssueCardRaw({ issue, hideJumpButton = false, onSelect, readOnl
           </hgroup>
         </div>
         <div className="flex items-center gap-1">
-          {!readOnly && issue.id && <IssueFeedbackButtons issueId={issue.id} />}
+          {showFeedback && issue.id && <IssueFeedbackButtons issueId={issue.id} />}
           {!readOnly && issue.id && <IssueActionsMenu issue={issue} />}
           <SeverityBadge severity={issue.severity} hideIcon={true} />
         </div>

--- a/frontend/components/results/components/document-issue-card.tsx
+++ b/frontend/components/results/components/document-issue-card.tsx
@@ -121,30 +121,36 @@ export function IssueFeedbackButtons({ issueId }: { issueId: string }) {
 
   const isThumbsUp = selectedFeedback === FeedbackType.ThumbsUp;
   const isThumbsDown = selectedFeedback === FeedbackType.ThumbsDown;
+  // Both thumbs are icon-only, and the tooltip cannot name them: it describes the wrapper
+  // the trigger hangs off, and only while it is open. So each carries its own label.
+  const thumbsUpLabel = isThumbsUp ? feedbackLabel(FeedbackType.ThumbsUp) : 'Helpful';
+  const thumbsDownLabel = isThumbsDown
+    ? feedbackLabel(FeedbackType.ThumbsDown, feedback?.feedback_text)
+    : 'Not helpful';
 
   return (
     <div className="flex items-center gap-0.5">
-      <ThumbTooltip label={isThumbsUp ? feedbackLabel(FeedbackType.ThumbsUp) : 'Helpful'}>
+      <ThumbTooltip label={thumbsUpLabel}>
         <Button
           variant={isThumbsUp ? 'default' : 'ghost'}
           size="xs"
           onClick={handleThumbsUp}
           className="h-6 w-6 p-0"
           disabled={isSubmitting || isThumbsUp}
+          aria-label={thumbsUpLabel}
         >
           <ThumbsUp className="h-3 w-3" />
         </Button>
       </ThumbTooltip>
       <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-        <ThumbTooltip
-          label={isThumbsDown ? feedbackLabel(FeedbackType.ThumbsDown, feedback?.feedback_text) : 'Not helpful'}
-        >
+        <ThumbTooltip label={thumbsDownLabel}>
           <PopoverTrigger asChild>
             <Button
               variant={isThumbsDown ? 'default' : 'ghost'}
               size="xs"
               className="h-6 w-6 p-0"
               disabled={isThumbsDown}
+              aria-label={thumbsDownLabel}
             >
               <ThumbsDown className="h-3 w-3" />
             </Button>

--- a/frontend/components/results/project-results-shell.tsx
+++ b/frontend/components/results/project-results-shell.tsx
@@ -7,7 +7,7 @@ import { EditableTitle } from '@/components/ui/editable-title';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { ProjectFeedbackProvider } from '@/lib/contexts/project-feedback-context';
-import { ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { AccessLevel, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { cn } from '@/lib/utils';
 import { getWorkflowRunByType } from '@/lib/workflow-state';
@@ -81,6 +81,11 @@ export function ProjectResultsShell({
   const mainSummary = documentSummarization?.state?.summaries?.find((s) => s.file_id === mainFileId);
   const authors = mainSummary?.authors;
 
+  // Feedback is the user's own, so it loads whenever the project is theirs to write to,
+  // older revisions included — `readOnly` there is about editing the document, not about
+  // rating the issues it found. A shared project is somebody else's and has none to show.
+  const canAccessFeedback = projectDetail.access_level === AccessLevel.Write;
+
   const peerReviewFacts = derivePeerReviewFacts(projectDetail);
   const peerReviewAttention = peerReviewNeedsAttention(peerReviewFacts, readOnly);
 
@@ -98,8 +103,8 @@ export function ProjectResultsShell({
 
   return (
     <ProjectFeedbackProvider
-      projectId={readOnly ? undefined : projectDetail.project.id}
-      feedbackVisibility={readOnly ? null : (projectDetail.project.feedback_visibility ?? null)}
+      projectId={canAccessFeedback ? projectDetail.project.id : undefined}
+      feedbackVisibility={canAccessFeedback ? (projectDetail.project.feedback_visibility ?? null) : null}
     >
       <PageTitle title={projectDetail.project.title} />
 

--- a/frontend/components/results/project-tab-panel.tsx
+++ b/frontend/components/results/project-tab-panel.tsx
@@ -50,7 +50,6 @@ export function ProjectTabPanel({ tab }: { tab: TabType }) {
       return (
         <DocumentExplorerTab
           projectDetail={projectDetail}
-          readOnly={readOnly}
           onNavigateToAnalyses={() => navigateToTab('analyses')}
           selectedRevision={selectedRevision}
           onRevisionChange={onRevisionChange}

--- a/frontend/components/results/tabs/document-explorer-tab.tsx
+++ b/frontend/components/results/tabs/document-explorer-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Issue, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
+import { AccessLevel, Issue, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useLineHashNavigation } from '@/lib/line-hash';
 import {
   getFilteredIssues,
@@ -54,6 +54,10 @@ export function DocumentExplorerTab({
   const mainDocumentMarkdown = projectDetail.main_document_markdown ?? '';
   const currentRevision = projectDetail.project.current_revision ?? 1;
   const isViewingOlderRevision = selectedRevision != null && selectedRevision !== currentRevision;
+  // Resolving an issue and rating it are judgements about the analysis, not edits to the
+  // document, so they stay open on older revisions. `readOnly` covers both here, and only
+  // the half about not owning the project should reach the issue cards.
+  const canEditIssues = projectDetail.access_level === AccessLevel.Write;
 
   const workflowDetails = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
   const issues = useMemo(() => projectDetail.issues ?? [], [projectDetail.issues]);
@@ -215,7 +219,7 @@ export function DocumentExplorerTab({
           passingCount={passingCount}
           isAnyProcessing={isAnyProcessing}
           projectDetail={projectDetail}
-          readOnly={readOnly}
+          readOnly={!canEditIssues}
           onSelectIssue={handleSelectIssue}
           onClearSelection={handleClearSelection}
         />

--- a/frontend/components/results/tabs/document-explorer-tab.tsx
+++ b/frontend/components/results/tabs/document-explorer-tab.tsx
@@ -26,7 +26,6 @@ import { DocumentMarkdownRenderer, DocumentMarkdownRendererHandle } from '../com
 
 interface DocumentExplorerTabProps {
   projectDetail: ProjectDetailed;
-  readOnly?: boolean;
   onNavigateToAnalyses: () => void;
   /** Currently displayed revision (for the non-current revision notice). */
   selectedRevision?: number;
@@ -44,7 +43,6 @@ function getIssueLineRange(issue: Issue): [number, number] | null {
 
 export function DocumentExplorerTab({
   projectDetail,
-  readOnly = false,
   onNavigateToAnalyses,
   selectedRevision,
   onRevisionChange,

--- a/frontend/lib/contexts/project-feedback-context.tsx
+++ b/frontend/lib/contexts/project-feedback-context.tsx
@@ -138,3 +138,14 @@ export function useIssueFeedbackFromContext(issueId: string) {
     isSubmitting,
   };
 }
+
+/**
+ * Whether feedback controls should render for an issue at all: only where there is a
+ * project whose feedback can be read and written. Shared projects and issues rendered
+ * outside the provider (the admin feedback sheet) have no feedback of the viewer's own,
+ * so they get no controls rather than dead ones.
+ */
+export function useIsIssueFeedbackVisible(issueId: string | undefined): boolean {
+  const { isEnabled } = useProjectFeedbackContext();
+  return !!issueId && isEnabled;
+}

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -251,6 +251,14 @@ export type AdminFeedbackItem = {
    * Project Title
    */
   project_title: string;
+  /**
+   * Project Current Revision
+   */
+  project_current_revision: number;
+  /**
+   * Revision
+   */
+  revision: number;
   visibility: FeedbackVisibility;
   issue: Issue;
 };

--- a/lib/api/routers/feedback.py
+++ b/lib/api/routers/feedback.py
@@ -202,6 +202,8 @@ class AdminFeedbackItem(BaseModel):
     user_email: str
     project_id: UUID
     project_title: str
+    project_current_revision: int
+    revision: int
     visibility: FeedbackVisibility
     issue: Issue
 
@@ -254,6 +256,8 @@ async def get_admin_feedbacks(
                 user_email=row["user"].email,
                 project_id=row["project"].id,
                 project_title=row["project"].title,
+                project_current_revision=row["project"].current_revision,
+                revision=row["workflow_run"].revision,
                 visibility=row["project"].feedback_visibility,
                 issue=row["issue"],
             )
@@ -301,6 +305,8 @@ async def export_admin_feedbacks_csv(
                 "User Email",
                 "Project ID",
                 "Project Title",
+                "Revision",
+                "Project Current Revision",
                 "Visibility",
                 "Issue ID",
                 "Issue Title",
@@ -322,6 +328,8 @@ async def export_admin_feedbacks_csv(
                     row["user"].email,
                     str(row["project"].id),
                     row["project"].title,
+                    row["workflow_run"].revision,
+                    row["project"].current_revision,
                     row["project"].feedback_visibility.value,
                     str(issue.id) if issue else "",
                     issue.title if issue else "",

--- a/lib/services/feedback_service.py
+++ b/lib/services/feedback_service.py
@@ -331,7 +331,7 @@ async def get_admin_feedbacks(
     from lib.models.user import User
 
     stmt = (
-        select(Feedback, Issue, Project, User)
+        select(Feedback, Issue, Project, User, WorkflowRun)
         .join(Issue, col(Feedback.issue_id) == col(Issue.id))
         .join(WorkflowRun, col(Feedback.workflow_run_id) == col(WorkflowRun.id))
         .join(Project, col(WorkflowRun.project_id) == col(Project.id))
@@ -369,13 +369,14 @@ async def get_admin_feedbacks(
 
     items = []
     for row in rows:
-        feedback, issue, project, user = row.tuple()
+        feedback, issue, project, user, workflow_run = row.tuple()
         items.append(
             {
                 "feedback": feedback,
                 "issue": issue,
                 "project": project,
                 "user": user,
+                "workflow_run": workflow_run,
             }
         )
     return items

--- a/tests/integration/test_feedback_admin_export.py
+++ b/tests/integration/test_feedback_admin_export.py
@@ -294,7 +294,28 @@ async def test_get_admin_feedbacks_row_structure(thumbs_down_feedback, issue):
 
     assert len(rows) >= 1
     row = next(r for r in rows if r["feedback"].id == thumbs_down_feedback.id)
-    assert set(row.keys()) == {"feedback", "issue", "project", "user"}
+    assert set(row.keys()) == {"feedback", "issue", "project", "user", "workflow_run"}
+
+
+@pytest.mark.asyncio
+async def test_get_admin_feedbacks_exposes_revision(
+    thumbs_down_feedback, shared_project, workflow_run, issue
+):
+    """The row carries the workflow run the feedback was given on, so admins can
+    tell which document revision it refers to."""
+    async with get_async_db_session() as session:
+        run = await session.get(WorkflowRun, workflow_run.id)
+        assert run is not None
+        run.revision = 3
+        session.add(run)
+        await session.commit()
+
+        rows = await feedback_service.get_admin_feedbacks(session=session)
+
+    row = next(r for r in rows if r["feedback"].id == thumbs_down_feedback.id)
+    assert row["workflow_run"].id == workflow_run.id
+    assert row["workflow_run"].revision == 3
+    assert row["project"].current_revision == shared_project.current_revision
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_feedback_csv_export.py
+++ b/tests/unit/test_feedback_csv_export.py
@@ -12,7 +12,7 @@ from lib.models.feedback import Feedback, FeedbackType
 from lib.models.issue import Issue, IssueStatus
 from lib.models.project import FeedbackVisibility, Project
 from lib.models.user import User, UserRole
-from lib.models.workflow_run import WorkflowRunType
+from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus, WorkflowRunType
 from lib.workflows.models import SeverityEnum
 
 
@@ -82,6 +82,20 @@ def _make_feedback(**kwargs) -> Feedback:
     return Feedback(**{**defaults, **kwargs})
 
 
+def _make_workflow_run(**kwargs) -> WorkflowRun:
+    defaults = dict(
+        id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        type=WorkflowRunType.RECOMMENDATION_CHECK,
+        langgraph_thread_id=str(uuid.uuid4()),
+        status=WorkflowRunStatus.COMPLETED,
+        revision=1,
+        created_at=_NOW,
+        last_updated_at=_NOW,
+    )
+    return WorkflowRun(**{**defaults, **kwargs})
+
+
 def _parse_csv(response_body: str) -> list[dict]:
     reader = csv.DictReader(io.StringIO(response_body))
     return list(reader)
@@ -123,6 +137,8 @@ async def test_csv_headers():
         "User Email",
         "Project ID",
         "Project Title",
+        "Revision",
+        "Project Current Revision",
         "Visibility",
         "Issue ID",
         "Issue Title",
@@ -174,7 +190,13 @@ async def test_csv_row_values():
     )
 
     mock_rows = [
-        {"feedback": feedback, "issue": issue, "project": project, "user": user}
+        {
+            "feedback": feedback,
+            "issue": issue,
+            "project": project,
+            "user": user,
+            "workflow_run": _make_workflow_run(revision=2),
+        }
     ]
 
     with patch(
@@ -197,6 +219,8 @@ async def test_csv_row_values():
     assert row["User Email"] == "bob@example.com"
     assert row["Project ID"] == str(project.id)
     assert row["Project Title"] == "Report"
+    assert row["Revision"] == "2"
+    assert row["Project Current Revision"] == str(project.current_revision)
     assert row["Visibility"] == FeedbackVisibility.FULL_PROJECT.value
     assert row["Issue ID"] == str(issue.id)
     assert row["Issue Title"] == "Wrong citation"
@@ -218,6 +242,7 @@ async def test_csv_empty_feedback_text():
             "issue": _make_issue(),
             "project": _make_project(),
             "user": _make_user(),
+            "workflow_run": _make_workflow_run(),
         }
     ]
 
@@ -264,12 +289,14 @@ async def test_csv_multiple_rows_ordered():
             "issue": _make_issue(title="Issue A"),
             "project": _make_project(title="Project A"),
             "user": _make_user(name="Alice"),
+            "workflow_run": _make_workflow_run(),
         },
         {
             "feedback": _make_feedback(feedback_type=FeedbackType.THUMBS_DOWN),
             "issue": _make_issue(title="Issue B"),
             "project": _make_project(title="Project B"),
             "user": _make_user(name="Bob"),
+            "workflow_run": _make_workflow_run(),
         },
     ]
 


### PR DESCRIPTION
## Summary

Two related gaps around feedback and document revisions:

1. Admins reviewing user feedback could not tell which revision of a document a given piece of feedback was about.
2. Feedback left on an older revision was invisible when viewing that revision, and issue actions were blocked there.

## Motivation

A thumbs-down on an issue that revision 3 already fixed read exactly like one still outstanding, so admins had no way to weigh feedback against the draft it was written about.

Separately, both project shells collapsed two unrelated ideas into a single `readOnly` flag: *the user does not own this project* and *the user is looking at an earlier revision*. On an older revision the feedback provider was handed no project id, so the query never ran and the user's own feedback disappeared from the view it belonged to. Rating an issue and marking it resolved are judgements about the analysis, not edits to the document, so neither needs blocking on an older draft.

## What's Changed

### Backend

- **`lib/services/feedback_service.py`** — `get_admin_feedbacks` already joined `WorkflowRun` to reach the project, so the revision was one column away. It is now selected and returned on each row as `workflow_run`.
- **`lib/api/routers/feedback.py`** — `AdminFeedbackItem` gains `revision` (the revision the feedback was given on) and `project_current_revision`. The CSV export gains matching `Revision` and `Project Current Revision` columns.
- **`tests/unit/test_feedback_csv_export.py`**, **`tests/integration/test_feedback_admin_export.py`** — cover the new columns and row key, plus a new test that bumps a run's revision and asserts it surfaces.

No migration: `WorkflowRun.revision` and `Project.current_revision` already exist.

### Frontend

- **`lib/generated-api/types.gen.ts`** — regenerated for the two new `AdminFeedbackItem` fields.
- **`components/admin/feedbacks-list.tsx`** — a "Rev N" badge beside the visibility badge in the Project column, reading "Rev N of M" once the project has moved on, with a tooltip saying whether that revision is still current.
- **`lib/contexts/project-feedback-context.tsx`** — new `useIsIssueFeedbackVisible` hook so the two issue components share one answer about whether feedback controls belong on screen.
- **`components/results/project-results-shell.tsx`**, **`components/results-v2/project-shell.tsx`** — load feedback on `access_level === Write` rather than the overloaded `readOnly`.
- **`components/results/tabs/document-explorer-tab.tsx`**, **`components/results-v2/document-explorer/document-explorer-tab.tsx`** — pass write access to the issue components instead of the blanket flag, which unblocks resolve/unresolve on older revisions. In both trees that prop only ever gated issue actions.
- **`components/results/components/document-issue-card.tsx`** — shared `feedbackLabel()`, and tooltips on both thumbs. The tooltip hangs off a wrapper rather than the button because the chosen thumb is `disabled`, and a disabled button emits no pointer events.
- **`components/results-v2/document-explorer/issue-note.tsx`**, **`margin-note.tsx`**, **`issues-list.tsx`** — a small thumb in the v2 issue meta line marking issues that carry feedback, with the written note in its tooltip. It stays visible when the issue is expanded.

## Risks and Mitigations

- **Shared/public project views** — the main risk is leaking feedback controls into a view that should not have them. Access level is `READ` there, so `isEnabled` is false and no controls render, which is the same outcome as the previous `!readOnly` check. The admin feedback sheet renders issue cards outside the provider and is covered by the same guard.
- **Document editing on older revisions stays blocked** — the revision banner, title editing, uploads and new assessments are untouched; only issue-level actions changed.
- **Write path on older revisions** — the backend never had a revision check on feedback or resolve, so no API change was needed; verified with a live request against a revision-2 issue.

Verified manually in both layouts across revisions 2 and 3. `mypy .` clean, 118 feedback/issue tests pass, `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
