### PR TITLE
feat(theme): default to light mode

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -38,7 +38,7 @@ export default async function RootLayout({
   return (
     <html lang="en" className="h-full" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased h-full`}>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false} disableTransitionOnChange>
           <PostHogProvider>
             <SessionProvider session={session}>
               <QueryProvider>

--- a/frontend/components/ui/sonner.tsx
+++ b/frontend/components/ui/sonner.tsx
@@ -4,11 +4,11 @@ import { useTheme } from 'next-themes';
 import { Toaster as Sonner, ToasterProps } from 'sonner';
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = 'light' } = useTheme();
+  const { resolvedTheme } = useTheme();
 
   return (
     <Sonner
-      theme={theme as ToasterProps['theme']}
+      theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
       className="toaster group"
       style={
         {


### PR DESCRIPTION
## Summary

Light mode is now the app's default theme. The app no longer follows the operating system's color-scheme preference; it starts in light and stays there until the user flips the dark/light switch in the app bar.

## Motivation

The theme provider was configured with `defaultTheme="system"` and `enableSystem`, so a visitor whose OS was set to dark landed in dark mode on their first visit. We want light to be what people see out of the box, with dark as an opt-in.

## What's Changed

### Backend

No backend changes.

### Frontend

- **`frontend/app/layout.tsx`** — the `ThemeProvider` goes from `defaultTheme="system" enableSystem` to `defaultTheme="light" enableSystem={false}`. Anyone without a stored preference gets light regardless of their OS setting. The existing toggle is unaffected: it only ever sets `light` or `dark`, and that choice still persists in `localStorage`.
- **`frontend/components/ui/sonner.tsx`** — the toaster read the raw `theme` value from `useTheme()`, which can still be the string `"system"` for users who stored it before this change. It now reads `resolvedTheme` and passes only `'light' | 'dark'`, so toasts match the page instead of following the OS.

No CSS changes were needed: `app/globals.css` defines the light palette on `:root` and the dark palette only under the `.dark` class, so dropping system resolution cannot leave the page in dark.

## Risks and Mitigations

- **Users who prefer dark are switched to light on next load.** Only those who never touched the toggle and were relying on their OS preference; the toggle is one click and its choice persists. Deliberate — it is the point of the change.
- **A stale `theme: "system"` value in `localStorage`.** With `enableSystem={false}`, `next-themes` writes `"system"` onto the `<html>` class rather than resolving it. That class matches no stylesheet rule, so the page renders light, which is the intended result, and the value self-heals the first time the user toggles. The sonner change covers the one place that read the raw value.
- **Not verified by typecheck.** `frontend/node_modules` was not installed in this workspace, so `tsc` was not run locally. Both edits are prop-type-correct (`enableSystem?: boolean`; sonner's `theme` accepts `'light' | 'dark'`) and CI will typecheck the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)