### PR TITLE
feat(help): add a feedback topic to the help center

### DIFF
--- a/frontend/components/feedback/feedback-privacy-dialog.tsx
+++ b/frontend/components/feedback/feedback-privacy-dialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { HelpLink } from '@/components/help/help-link';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -77,7 +78,10 @@ export function FeedbackPrivacyDialog({
 
         <p className="text-xs text-muted-foreground flex items-start gap-1.5">
           <InfoIcon className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-          You can change this preference at any time in the project settings.
+          <span>
+            You can change this preference at any time in the project settings.{' '}
+            <HelpLink topic="feedback">What each option shares</HelpLink>
+          </span>
         </p>
 
         <DialogFooter>

--- a/frontend/components/help/topics.ts
+++ b/frontend/components/help/topics.ts
@@ -1,13 +1,30 @@
-import { BookOpen, CircleAlert, FileText, History, ListChecks, LucideIcon, MessagesSquare } from 'lucide-react';
+import {
+  BookOpen,
+  CircleAlert,
+  FileText,
+  History,
+  ListChecks,
+  LucideIcon,
+  MessagesSquare,
+  ThumbsUp,
+} from 'lucide-react';
 import { ComponentType } from 'react';
 import { AssessmentsTopic } from './topics/assessments';
+import { FeedbackTopic } from './topics/feedback';
 import { IssuesTopic } from './topics/issues';
 import { PeerReviewTopic } from './topics/peer-review';
 import { ReferencesTopic } from './topics/references';
 import { RevisionsTopic } from './topics/revisions';
 import { SourceFilesTopic } from './topics/source-files';
 
-export type HelpTopicId = 'assessments' | 'issues' | 'references' | 'source-files' | 'revisions' | 'peer-review';
+export type HelpTopicId =
+  | 'assessments'
+  | 'issues'
+  | 'references'
+  | 'source-files'
+  | 'revisions'
+  | 'peer-review'
+  | 'feedback';
 
 export interface HelpTopicBodyProps {
   /**
@@ -42,8 +59,9 @@ export interface HelpTopic {
 /**
  * The concepts the app explains in one place, ordered as the work runs:
  * assessments produce issues, references name sources, one assessment needs
- * those sources, revisions are what all of it hangs from, and peer review is
- * what happens once someone else has read the draft. Every "what is this" link
+ * those sources, revisions are what all of it hangs from, peer review is what
+ * happens once someone else has read the draft, and feedback is how any of it
+ * gets better. Every "what is this" link
  * in the product opens this list at one of them, so a question asked in one
  * corner is answered next to all the others.
  */
@@ -97,5 +115,13 @@ export const HELP_TOPICS: HelpTopic[] = [
     icon: MessagesSquare,
     Body: PeerReviewTopic,
     experimental: true,
+  },
+  {
+    id: 'feedback',
+    label: 'Feedback',
+    title: 'Feedback, and what sharing it means',
+    description: 'Telling us whether a finding was any good, and deciding how much of it we get to see.',
+    icon: ThumbsUp,
+    Body: FeedbackTopic,
   },
 ];

--- a/frontend/components/help/topics/feedback.tsx
+++ b/frontend/components/help/topics/feedback.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { Eye, EyeOff, FolderOpen, Lock, LucideIcon, ScrollText, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { ReactNode } from 'react';
+import { SectionTitle, TopicLink } from '../help-primitives';
+import { HelpTopicBodyProps } from '../topics';
+
+interface ShareMode {
+  icon: LucideIcon;
+  /** Worded as the dialog words it, so the two are recognisably the same choice. */
+  label: string;
+  tag?: string;
+  /** What an administrator gets. */
+  shared: string;
+  /** What stays with you, or null where the mode holds nothing back. */
+  withheld: string | null;
+}
+
+/**
+ * The three answers to "who can see your feedback?", in the order the dialog
+ * offers them: least shared first, so the default is the one a reader meets
+ * before any of the others.
+ */
+const SHARE_MODES: ShareMode[] = [
+  {
+    icon: Lock,
+    label: 'Don’t share any information',
+    tag: 'Default',
+    shared: 'Nothing. The rating is yours, and it stays inside your project.',
+    withheld: 'The issue, your note, your document, your files, and every result.',
+  },
+  {
+    icon: ScrollText,
+    label: 'Share only this issue information',
+    shared: 'The issue itself — its title and description — with your rating and your note.',
+    withheld: 'Your document, the files you uploaded, and the rest of the assessment results.',
+  },
+  {
+    icon: FolderOpen,
+    label: 'Share whole project information',
+    shared: 'All of the above, plus read-only access to the project: the draft, every uploaded file, and every result.',
+    withheld: null,
+  },
+];
+
+/**
+ * The thumbs, the note, and what sharing them actually hands over. The
+ * privacy question is the one people hesitate on, so the modes are laid out as
+ * what an administrator would see rather than as three labels — nobody should
+ * have to guess what "share this issue" covers.
+ */
+export function FeedbackTopic({ onOpenTopic }: HelpTopicBodyProps) {
+  return (
+    <div className="space-y-5">
+      <section>
+        <SectionTitle>Rating a finding</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          Every{' '}
+          <TopicLink to="issues" onOpenTopic={onOpenTopic}>
+            issue
+          </TopicLink>{' '}
+          carries a pair of thumbs. They are how you tell us{' '}
+          <strong className="text-foreground font-medium">whether the finding was worth raising</strong> — that an{' '}
+          <TopicLink to="assessments" onOpenTopic={onOpenTopic}>
+            assessment
+          </TopicLink>{' '}
+          caught something real, or that it wasted your time on something it misread.
+        </p>
+
+        <div className="mt-2 overflow-hidden rounded-md border">
+          <div className="flex items-start gap-2 border-b px-3 py-2">
+            <div className="min-w-0">
+              <p className="text-xs font-medium">Abbreviation “GER” is used before it is defined</p>
+              <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                It first appears on line 21, and is spelled out on line 96.
+              </p>
+            </div>
+            <span className="ml-auto flex shrink-0 items-center gap-1">
+              <span className="rounded border p-1 text-muted-foreground">
+                <ThumbsUp className="size-3" aria-hidden />
+              </span>
+              <span className="bg-primary text-primary-foreground rounded p-1">
+                <ThumbsDown className="size-3" aria-hidden />
+              </span>
+            </span>
+          </div>
+
+          <div className="space-y-2 px-3 py-2">
+            <p className="text-xs font-medium">What could be improved?</p>
+            <p className="bg-background/60 rounded border border-dashed px-2 py-1.5 text-xs leading-relaxed text-muted-foreground italic">
+              The term is defined in the caption of Figure 1, which this seems to have skipped.
+            </p>
+          </div>
+        </div>
+
+        <ul className="mt-2 space-y-1.5">
+          <Fact term="Thumbs up is one click">Nothing else to fill in. It records that the finding landed.</Fact>
+          <Fact term="Thumbs down asks a question">
+            <strong className="text-foreground font-medium">What could be improved?</strong> The note is optional, and
+            it is the most useful thing you can send: a thumbs down says something is wrong, a note says what.
+          </Fact>
+          <Fact term="One rating per issue">
+            Rating an issue again replaces what you said before, so changing your mind costs nothing.
+          </Fact>
+        </ul>
+
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          Ratings belong to the person whose project it is. Anyone else reading the project — an administrator on a
+          shared one, or someone following a share link — sees what was said, and cannot change it.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Who gets to see it</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          The first time you rate anything in a project, we ask before saving it. The answer covers{' '}
+          <strong className="text-foreground font-medium">the whole project, not that one issue</strong>, and until you
+          give one, nothing is shared.
+        </p>
+
+        <div className="mt-2 space-y-2">
+          {SHARE_MODES.map((mode) => (
+            <ModeCard key={mode.label} mode={mode} />
+          ))}
+        </div>
+
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          Only the last two put anything in front of an administrator. On the first, the thumbs still work and the
+          ratings are still yours to read — they simply go no further.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>What sharing is for</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          Shared feedback collects in one list that the people building Draft Detective read, search, and export. It is
+          the only direct signal we have about{' '}
+          <strong className="text-foreground font-medium">which assessments are earning their place</strong> and which
+          keep raising things you did not need — and it is what the next round of changes to them is built on.
+        </p>
+        <p className="text-foreground/80 mt-2 leading-relaxed">
+          Sharing the whole project is worth more than sharing the issue alone, because a finding read without the
+          paragraph it came from is often impossible to judge. It also hands over more, which is exactly why the choice
+          is yours and the default is to share nothing.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Changing your mind</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          The setting lives in the project&apos;s details, under{' '}
+          <strong className="text-foreground font-medium">Feedback Visibility</strong>, and it can be changed whenever
+          you like. It applies to everything you have already rated in that project, not only to what comes next: turn
+          it back to <em>Only me</em> and those ratings stop appearing to administrators, along with the project itself.
+        </p>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          Each project is answered separately. Sharing one says nothing about the others, and a new project starts with
+          the question unanswered.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function ModeCard({ mode }: { mode: ShareMode }) {
+  const { icon: Icon } = mode;
+
+  return (
+    <div className="rounded-md border p-2.5">
+      <p className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-medium">
+        <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        {mode.label}
+        {mode.tag && (
+          <span className="bg-primary/10 text-primary rounded-sm px-1.5 py-0.5 text-[10px] font-semibold">
+            {mode.tag}
+          </span>
+        )}
+      </p>
+      <Line icon={Eye} label="Administrators see">
+        {mode.shared}
+      </Line>
+      {mode.withheld && (
+        <Line icon={EyeOff} label="Stays with you">
+          {mode.withheld}
+        </Line>
+      )}
+    </div>
+  );
+}
+
+function Line({ icon: Icon, label, children }: { icon: LucideIcon; label: string; children: ReactNode }) {
+  return (
+    <p className="mt-1 flex gap-1.5 text-xs leading-relaxed text-muted-foreground">
+      <Icon className="mt-0.5 size-3 shrink-0" aria-hidden />
+      <span className="min-w-0">
+        <span className="text-foreground/80 font-medium">{label}:</span> {children}
+      </span>
+    </p>
+  );
+}
+
+function Fact({ term, children }: { term: string; children: ReactNode }) {
+  return (
+    <li className="text-xs leading-relaxed">
+      <strong className="font-medium">{term}.</strong> <span className="text-muted-foreground">{children}</span>
+    </li>
+  );
+}

--- a/frontend/components/help/topics/issues.tsx
+++ b/frontend/components/help/topics/issues.tsx
@@ -106,8 +106,15 @@ export function IssuesTopic({ onOpenTopic }: HelpTopicBodyProps) {
             Once you have dealt with it, or decided not to. Resolved issues drop out of the view and out of the counts,
             and the filter panel brings them back.
           </Fact>
-          <Fact term="Say whether it was any good">
+          <Fact
+            term={
+              <TopicLink to="feedback" onOpenTopic={onOpenTopic}>
+                Say whether it was any good
+              </TopicLink>
+            }
+          >
             The thumbs on an issue tell us where an assessment is earning its place and where it is wasting your time.
+            Nothing you say there leaves the project until you choose to share it.
           </Fact>
           <Fact term="Narrow the list">
             The filters take the explorer down to one severity or one assessment, which is how a few hundred issues
@@ -127,7 +134,7 @@ export function IssuesTopic({ onOpenTopic }: HelpTopicBodyProps) {
   );
 }
 
-function Fact({ term, children }: { term: string; children: ReactNode }) {
+function Fact({ term, children }: { term: ReactNode; children: ReactNode }) {
   return (
     <li className="text-xs leading-relaxed">
       <strong className="font-medium">{term}.</strong> <span className="text-muted-foreground">{children}</span>

--- a/frontend/components/projects/edit-project-dialog.tsx
+++ b/frontend/components/projects/edit-project-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { HelpLink } from '@/components/help/help-link';
 import { Label } from '@/components/ui/label';
 import { Callout } from '@/components/ui/callout';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -153,7 +154,8 @@ export function EditProjectDialog({
                 </SelectContent>
               </Select>
               <p className="text-sm text-muted-foreground">
-                Controls what administrators can see when you submit feedback on issues.
+                Controls what administrators can see when you submit feedback on issues.{' '}
+                <HelpLink topic="feedback">What each option shares</HelpLink>
               </p>
             </div>
           )}


### PR DESCRIPTION
## Summary

Adds a **Feedback** topic to the help center, covering the thumbs on an issue, the note behind a thumbs down, and the three sharing modes — with an emphasis on what administrators actually get to see, and why sharing helps.

## Motivation

The feedback controls are the only place in the app where a user is asked to hand something over, and the question arrives at an awkward moment: the privacy dialog interrupts the very first thumbs-up someone gives. Three radio labels are all the explanation there is, and "share only this issue information" does not tell you whether your document is included.

Nothing else explained it either. The help center already covers assessments, issues, references, source files, revisions and peer review, but stopped short of the one feature whose value depends entirely on users opting in. Explaining what each mode shares — and that shared feedback is what tells us which assessments are earning their place — makes the choice an informed one instead of a guess, which is the only honest way to ask for it.

## What's Changed

### Frontend

- **`components/help/topics/feedback.tsx`** (new) — the topic body, in four sections. *Rating a finding* shows the thumbs with a rendered mock of the real control, and covers one-click thumbs up, the *What could be improved?* note, one rating per issue, and that only the project owner can rate (others see it read-only). *Who gets to see it* lays out the three modes as cards, each spelling out what an administrator sees and what stays with you. *What sharing is for* explains that shared feedback drives which assessments get changed, and why whole-project sharing is more useful than issue-only while being explicit that it hands over more. *Changing your mind* covers the project setting and the fact that the change is retroactive.
- **`components/help/topics.ts`** — registers the topic as the last entry with a `ThumbsUp` icon; widens `HelpTopicId` with `'feedback'` and extends the ordering comment.
- **`components/help/topics/issues.tsx`** — the "Say whether it was any good" bullet now links through to the new topic, and notes that nothing leaves the project until you choose to share it. Its local `Fact` term widens from `string` to `ReactNode`, matching the Revisions topic.
- **`components/feedback/feedback-privacy-dialog.tsx`** — adds a *What each option shares* help link to the footnote, so the explanation is reachable from the moment the question is asked.
- **`components/projects/edit-project-dialog.tsx`** — the same link beside the *Feedback Visibility* field description.

### Backend

None. The copy was written against the existing behaviour: `get_admin_feedbacks` filtering on the project's current visibility, `_is_shared_feedback` in the admin dashboard queries, and the `FULL_PROJECT` branch of `get_project_access` that grants admins read-only access.

## Risks and Mitigations

- **Copy drifting from behaviour.** The topic makes concrete claims — that the choice is retroactive, that issue-only withholds your files, that re-rating replaces the old rating. Each was checked against the code rather than the UI labels. If the visibility rules change, this topic needs updating alongside them.
- **Nested dialogs.** The help link inside the privacy dialog and the edit-project dialog opens a second Radix dialog on top of the first. This already happens elsewhere (`replace-main-document-dialog`, `file-upload-dialog`), so it is an established pattern rather than a new one.
- **Reach.** Purely additive: a new topic and three links. No existing topic changes meaning, and nothing in the feedback flow itself behaves differently.

Verified with `tsc --noEmit` (clean), `pnpm lint` (only the three pre-existing warnings in untouched files), and Prettier. The layout was not checked in a browser by the author of this branch — worth a look at the mode cards in both themes when reviewing.
