### PR TITLE
feat(claim-reference-validation): report the full citation resolution chain

### DIFF
--- a/lib/agents/citation_validator.py
+++ b/lib/agents/citation_validator.py
@@ -69,10 +69,27 @@ class CitationAssessment(BaseModel):
     citation_to_file_mapping: Optional[str] = Field(
         default=None,
         description=(
-            "Display-friendly summary of which bibliography entry was matched to "
-            "which supporting file when checking this citation, e.g. "
-            "'Smith (2020) → smith_2020.pdf'. Do not include file_id UUIDs in this "
-            "string; the file_id belongs in each entry of evidence_sources."
+            "The full resolution chain from the in-text citation to the supporting "
+            "file, with every intermediate jump you actually took, joined by ' → '. "
+            "Always start with the citation marker as it appears in the text and end "
+            "with the supporting file name. Include the bibliography entry as "
+            "'Reference: \"<text>\"', and — when the citation is a footnote marker — "
+            "the footnote entry it points to. Identify the bibliography entry by its "
+            "text, never by a number or position in the bibliography; truncate a very "
+            "long entry with ' [...]' but keep enough to identify it (authors, title, "
+            "publisher, year). Examples — an author-year citation, with the long entry "
+            "truncated: '(Appenzeller, Bornstein, and Casado, 2023) → Reference: "
+            "\"Appenzeller, Guido, Matt Bornstein, and Martin Casado, “Navigating the "
+            "High Cost of AI Compute,” Andreessen Horowitz, April 27, 2023 [...]\" → "
+            "navigating_the_high_cost_of_ai_compute.md'; and a footnote marker, whose "
+            "footnote entry is a jump of its own: '[^12] → Footnote 12: \"World Bank "
+            "Group, “World Bank Open Data,” 2024\" → Reference: \"World Bank Group, "
+            "“World Bank Open Data,” webpage, undated. As of October 15, 2024: "
+            "https://data.worldbank.org/\" → world_bank_open_data.md'. "
+            "When no supporting file was matched, end the chain with "
+            "'No supporting file available'. Do not "
+            "include file_id UUIDs in this string; the file_id belongs in each entry "
+            "of evidence_sources."
         ),
     )
 
@@ -141,7 +158,7 @@ Start by reading your assigned section with `read_document(main_file_id, {start_
 
 ## Bibliography-to-file mapping
 
-This table maps each bibliography entry to its supporting file. Use the file_id when calling the tools; a citation whose entry has no supporting file is `unverifiable`.
+This table maps each bibliography entry to its supporting file. Use the file_id when calling the tools; a citation whose entry has no supporting file is `unverifiable`. Identify an entry by its text when reporting `citation_to_file_mapping` — the order of this table is not stable, so never refer to an entry by its position in it.
 
 ```
 {reference_file_map}
@@ -156,7 +173,7 @@ Return `issues` — one `CitationAssessment` per citation you validate — each 
 - `rationale`: a brief explanation of the judgment;
 - `feedback`: an actionable suggestion for the author (`"No changes needed"` if the citation is correct);
 - `evidence_sources`: every reference file you checked for this citation (with a quote, location, and file_id each);
-- `citation_to_file_mapping`: a display-friendly summary of which bibliography entry matched which file (e.g. `"Smith (2020) → smith_2020.pdf"`; no file_id UUIDs here).
+- `citation_to_file_mapping`: every jump you took from the in-text marker to the supporting file, joined by ` → ` — see the field's own description for the exact shape.
 """
 
 

--- a/lib/agents/citation_validator.py
+++ b/lib/agents/citation_validator.py
@@ -71,8 +71,9 @@ class CitationAssessment(BaseModel):
         description=(
             "The full resolution chain from the in-text citation to the supporting "
             "file, with every intermediate jump you actually took, joined by ' → '. "
-            "Always start with the citation marker as it appears in the text and end "
-            "with the supporting file name. Include the bibliography entry as "
+            "Always start with the citation marker as it appears in the text, and end "
+            "with the supporting file name — or with 'No supporting file available' "
+            "when no supporting file was matched. Include the bibliography entry as "
             "'Reference: \"<text>\"', and — when the citation is a footnote marker — "
             "the footnote entry it points to. Identify the bibliography entry by its "
             "text, never by a number or position in the bibliography; truncate a very "
@@ -86,10 +87,8 @@ class CitationAssessment(BaseModel):
             "Group, “World Bank Open Data,” 2024\" → Reference: \"World Bank Group, "
             "“World Bank Open Data,” webpage, undated. As of October 15, 2024: "
             "https://data.worldbank.org/\" → world_bank_open_data.md'. "
-            "When no supporting file was matched, end the chain with "
-            "'No supporting file available'. Do not "
-            "include file_id UUIDs in this string; the file_id belongs in each entry "
-            "of evidence_sources."
+            "Do not include file_id UUIDs in this string; the file_id belongs in each "
+            "entry of evidence_sources."
         ),
     )
 


### PR DESCRIPTION
## Summary

The Claim Reference Validation results include a "Citation-to-file mapping" per citation. It was rendering only the endpoints — `World Bank Group, World Bank Open Data → world_bank_group_....md` — which left the reader unable to tell *which* bibliography entry the citation was resolved through, and hid the footnote hop entirely for footnote-marker citations.

This asks the agent for the whole resolution chain instead:

```
(Appenzeller, Bornstein, and Casado, 2023) → Reference: "Appenzeller, Guido, Matt Bornstein, and Martin Casado, “Navigating the High Cost of AI Compute,” Andreessen Horowitz, April 27, 2023 [...]" → navigating_the_high_cost_of_ai_compute.md

[^12] → Footnote 12: "World Bank Group, “World Bank Open Data,” 2024" → Reference: "World Bank Group, “World Bank Open Data,” webpage, undated. As of October 15, 2024: https://data.worldbank.org/" → world_bank_open_data.md
```

## Motivation

The mapping exists so a reviewer can audit the resolution, not just the outcome. Endpoints alone are not auditable: if the agent matched the wrong bibliography entry, or resolved a footnote to the wrong work, the old string looked identical to a correct match. Every intermediate jump has to be visible for the field to do its job.

Bibliography entries are deliberately identified by **text, not number**. The reference ordering comes from extraction and shifts between runs and revisions, so a "Reference 56" label would go stale and mislead. Very long entries are truncated with ` [...]` so the chain stays readable.

## What's Changed

### Backend

- `lib/agents/citation_validator.py` — the whole change, entirely prompt/schema text:
  - `CitationAssessment.citation_to_file_mapping` field description now specifies the full chain (marker → footnote entry when applicable → `Reference: "<text>"` → file name), joined by ` → `, with two worked examples (an author-year citation with a truncated entry, and a footnote marker), the ` [...]` truncation rule, `No supporting file available` as the terminal step when nothing matched, and the existing "no file_id UUIDs" rule kept.
  - The prompt's bibliography-to-file section states that the table's order is not stable and that entries must be identified by text, never by position.
  - The `Output` bullet for the field is one line deferring to the field description, so the rules live in exactly one place (the description reaches the model through the structured-output schema).

### Frontend

No changes. The mapping is a free-text string already rendered under "Citation-to-file mapping" in the issue detail, and no API shape changed, so no `openapi-generate` run is needed.

## Risks and Mitigations

- **Prompt-only change, so behavior is model-dependent.** Nothing enforces the chain format at the type level; a model may still emit a short mapping. Mitigation: the field is display-only and optional (`Optional[str]`), so a short or missing chain degrades to today's output rather than failing a run. The manifest still handles `None` with "No citation-to-file mapping provided".
- **Longer strings in the results.** Chains now carry reference text, so the rendered section is wordier. Mitigated by the ` [...]` truncation instruction for long entries.
- **Unverified against a live run.** `uv run mypy .` is clean and the 33 citation-validator / `claim_reference_validation_v2` unit tests pass, but those cover prompt composition, not model output. Worth one eval or manual run on a document with footnote markers to confirm the footnote hop actually appears before relying on it.
- **No state, DB, or API surface touched**, so there is nothing to migrate and no rollback beyond reverting the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)