### PR TITLE
fix(progress): keep the progress toast up while the approval gate waits

### DIFF
--- a/frontend/app/(authenticated)/projects/[projectId]/layout.tsx
+++ b/frontend/app/(authenticated)/projects/[projectId]/layout.tsx
@@ -6,7 +6,7 @@ import { useWorkflowProgressToast } from '@/hooks/use-workflow-progress-toast';
 import { getErrorMessage, isApiError } from '@/lib/api-error';
 import { AccessLevel, ProjectDetailed, updateProjectEndpointApiProjectProjectIdPatch } from '@/lib/generated-api';
 import { useProjectDetails } from '@/lib/hooks/use-project-details';
-import { isAnyWorkflowProcessing, needsHumanApproval } from '@/lib/workflow-state';
+import { hasWorkflowProgressToShow, needsHumanApproval } from '@/lib/workflow-state';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FileXIcon, LockIcon } from 'lucide-react';
 import { useParams } from 'next/navigation';
@@ -40,14 +40,9 @@ export default function ProjectLayout({ children }: { children: ReactNode }) {
     setSelectedRevision(null);
   }, []);
 
-  const isProcessing = isAnyWorkflowProcessing(workflowDetails);
-  const awaitingHumanApproval = needsHumanApproval(workflowDetails);
-  // HumanApproval stays Pending/Running until the user approves, which keeps isProcessing true even though
-  // the pipeline is intentionally paused. The progress API then has no active step → "Going to next step...".
-  const showWorkflowProgressToast = isProcessing && !awaitingHumanApproval;
-
-  // Show progress in toast when automated workflows are running (not while waiting on reference review / approve)
-  useWorkflowProgressToast(projectId, showWorkflowProgressToast);
+  // Show progress in toast while assessments are actually running. A pipeline
+  // parked on the reference-review gate doesn't count — see hasWorkflowProgressToShow.
+  useWorkflowProgressToast(projectId, hasWorkflowProgressToShow(workflowDetails));
 
   const updateTitleMutation = useMutation({
     mutationFn: async (newTitle: string) => {

--- a/frontend/components/results-v2/use-project-shell-state.ts
+++ b/frontend/components/results-v2/use-project-shell-state.ts
@@ -4,7 +4,7 @@ import { useWorkflowProgressToast } from '@/hooks/use-workflow-progress-toast';
 import { getErrorMessage } from '@/lib/api-error';
 import { AccessLevel, ProjectDetailed, updateProjectEndpointApiProjectProjectIdPatch } from '@/lib/generated-api';
 import { useProjectDetails } from '@/lib/hooks/use-project-details';
-import { isAnyWorkflowProcessing, needsHumanApproval } from '@/lib/workflow-state';
+import { hasWorkflowProgressToShow } from '@/lib/workflow-state';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
@@ -39,11 +39,9 @@ export function useProjectShellState(projectId: string) {
     setSelectedRevision(null);
   }, []);
 
-  const isProcessing = isAnyWorkflowProcessing(workflowDetails);
-  const awaitingHumanApproval = needsHumanApproval(workflowDetails);
-  // HumanApproval stays Pending/Running until the user approves, which keeps
-  // isProcessing true even though the pipeline is intentionally paused.
-  useWorkflowProgressToast(projectId, isProcessing && !awaitingHumanApproval);
+  // A pipeline parked on the reference-review gate isn't progressing — see
+  // hasWorkflowProgressToShow.
+  useWorkflowProgressToast(projectId, hasWorkflowProgressToShow(workflowDetails));
 
   const updateTitleMutation = useMutation({
     mutationFn: async (newTitle: string) => {

--- a/frontend/lib/workflow-state.ts
+++ b/frontend/lib/workflow-state.ts
@@ -179,3 +179,19 @@ export function needsHumanApproval(workflowRuns: WorkflowRunDetail[]): boolean {
   const state = humanApprovalRun.state as HumanApprovalState | null;
   return !state?.approved;
 }
+
+/**
+ * Whether the pipeline has work in flight worth showing progress for.
+ *
+ * A run that is only Pending doesn't count while a human-approval gate is
+ * outstanding: HumanApproval and the runs behind it stay Pending until the
+ * user approves, so counting them would leave an empty progress toast on
+ * screen for as long as the review takes. A Running run always counts — the
+ * rest of the assessments keep working while the gate waits, and that is
+ * exactly what the toast is there to show.
+ */
+export function hasWorkflowProgressToShow(workflowRuns: WorkflowRunDetail[]): boolean {
+  if (workflowRuns.some((workflowRun) => workflowRun.run.status === WorkflowRunStatus.Running)) return true;
+  if (needsHumanApproval(workflowRuns)) return false;
+  return isAnyWorkflowProcessing(workflowRuns);
+}


### PR DESCRIPTION
## Summary

The workflow progress toast stopped appearing while assessments run. The toast machinery was fine — the condition gating it was wrong. Any project that includes Claim Reference Validation never showed progress at all.

## Motivation

Both project shells computed:

```ts
const showWorkflowProgressToast = isProcessing && !awaitingHumanApproval;
```

`needsHumanApproval` is true whenever a `human_approval` run exists and isn't approved. That run is created **up front**, in the same batch as every other assessment, whenever Claim Reference Validation is part of the selection. So from the moment the assessments start, the toast is suppressed for the entire pipeline — even with a dozen workflows running and writing progress rows.

Reproduced against a live local instance: a project with 6 workflows `RUNNING` and active progress rows ("Fetch reference" 38/40) showed the "Reference Review Required" banner and no toast whatsoever.

The guard was added in `ce2180aa` for a real reason — without it, an empty "Going to next step..." toast sits on screen for as long as the user takes to review references, because `HumanApproval` and everything behind it stay Pending. It just over-applied.

## What's Changed

### Frontend

- **`frontend/lib/workflow-state.ts`** — new `hasWorkflowProgressToShow()`. Anything actually `Running` shows the toast; merely-`Pending` runs stop counting once an approval gate is outstanding. That split is safe because `human_approval` has `requires_human_trigger`, so it and its downstream runs stay `Pending` (never `Running`) while they wait — `wait_for_dependencies` blocks before the runner flips a run to `RUNNING`.
- **`frontend/app/(authenticated)/projects/[projectId]/layout.tsx`** — use the new helper instead of the inline `isProcessing && !awaitingHumanApproval`.
- **`frontend/components/results-v2/use-project-shell-state.ts`** — same swap for the v2 shell.

### Backend

None.

## Risks and Mitigations

- **The empty-toast regression comes back.** Guarded by the `needsHumanApproval` branch, and verified: a project parked on approval with nothing running shows no toast.
- **Brief gap at batch start when a gate is present.** All runs are `PENDING` for a second or two before the first flips to `RUNNING`, so the toast appears a beat later than before in that one case. Without a gate, behaviour is unchanged.

## Verification

Ran the branch against a live backend:

- Approval pending + assessments running → toast is back, with per-step progress bars.
- Parked on approval, nothing running → no toast, as intended.

`tsc --noEmit` clean; `pnpm lint` clean (3 pre-existing warnings in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)