### PR TITLE
fix(explorer): stop the loading spinner while the approval gate waits

### DIFF
--- a/frontend/app/(authenticated)/projects/[projectId]/layout.tsx
+++ b/frontend/app/(authenticated)/projects/[projectId]/layout.tsx
@@ -6,7 +6,7 @@ import { useWorkflowProgressToast } from '@/hooks/use-workflow-progress-toast';
 import { getErrorMessage, isApiError } from '@/lib/api-error';
 import { AccessLevel, ProjectDetailed, updateProjectEndpointApiProjectProjectIdPatch } from '@/lib/generated-api';
 import { useProjectDetails } from '@/lib/hooks/use-project-details';
-import { hasWorkflowProgressToShow, needsHumanApproval } from '@/lib/workflow-state';
+import { isAnyWorkflowActive, needsHumanApproval } from '@/lib/workflow-state';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FileXIcon, LockIcon } from 'lucide-react';
 import { useParams } from 'next/navigation';
@@ -41,8 +41,8 @@ export default function ProjectLayout({ children }: { children: ReactNode }) {
   }, []);
 
   // Show progress in toast while assessments are actually running. A pipeline
-  // parked on the reference-review gate doesn't count — see hasWorkflowProgressToShow.
-  useWorkflowProgressToast(projectId, hasWorkflowProgressToShow(workflowDetails));
+  // parked on the reference-review gate doesn't count — see isAnyWorkflowActive.
+  useWorkflowProgressToast(projectId, isAnyWorkflowActive(workflowDetails));
 
   const updateTitleMutation = useMutation({
     mutationFn: async (newTitle: string) => {

--- a/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results-v2/document-explorer/document-explorer-tab.tsx
@@ -16,7 +16,7 @@ import {
 import {
   getBlockingWorkflowErrors,
   getWorkflowRunByType,
-  isAnyWorkflowProcessing,
+  isAnyWorkflowActive,
   isWorkflowProcessing,
 } from '@/lib/workflow-state';
 import { WIDE_ENOUGH_FOR_PANE, useMediaQuery } from '@/lib/use-media-query';
@@ -93,7 +93,7 @@ export function DocumentExplorerTabV2({ projectDetail, onNavigateToAnalyses }: D
 
   const documentProcessing = getWorkflowRunByType(workflowDetails, WorkflowRunType.DocumentProcessing);
   const isDocumentProcessing = isWorkflowProcessing(documentProcessing);
-  const isAnyProcessing = isAnyWorkflowProcessing(workflowDetails);
+  const isAnyProcessing = isAnyWorkflowActive(workflowDetails);
 
   const issuesRef = useRef<IssuesColumnHandle>(null);
   const documentRef = useRef<DocumentViewHandle>(null);

--- a/frontend/components/results-v2/use-project-shell-state.ts
+++ b/frontend/components/results-v2/use-project-shell-state.ts
@@ -4,7 +4,7 @@ import { useWorkflowProgressToast } from '@/hooks/use-workflow-progress-toast';
 import { getErrorMessage } from '@/lib/api-error';
 import { AccessLevel, ProjectDetailed, updateProjectEndpointApiProjectProjectIdPatch } from '@/lib/generated-api';
 import { useProjectDetails } from '@/lib/hooks/use-project-details';
-import { hasWorkflowProgressToShow } from '@/lib/workflow-state';
+import { isAnyWorkflowActive } from '@/lib/workflow-state';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
@@ -40,8 +40,8 @@ export function useProjectShellState(projectId: string) {
   }, []);
 
   // A pipeline parked on the reference-review gate isn't progressing — see
-  // hasWorkflowProgressToShow.
-  useWorkflowProgressToast(projectId, hasWorkflowProgressToShow(workflowDetails));
+  // isAnyWorkflowActive.
+  useWorkflowProgressToast(projectId, isAnyWorkflowActive(workflowDetails));
 
   const updateTitleMutation = useMutation({
     mutationFn: async (newTitle: string) => {

--- a/frontend/components/results/tabs/document-explorer-tab.tsx
+++ b/frontend/components/results/tabs/document-explorer-tab.tsx
@@ -14,7 +14,7 @@ import {
 import {
   getBlockingWorkflowErrors,
   getWorkflowRunByType,
-  isAnyWorkflowProcessing,
+  isAnyWorkflowActive,
   isWorkflowProcessing,
 } from '@/lib/workflow-state';
 import { AlertTriangleIcon, History, Loader2 } from 'lucide-react';
@@ -62,7 +62,7 @@ export function DocumentExplorerTab({
 
   const documentProcessing = getWorkflowRunByType(workflowDetails, WorkflowRunType.DocumentProcessing);
   const isDocumentProcessing = isWorkflowProcessing(documentProcessing);
-  const isAnyProcessing = isAnyWorkflowProcessing(workflowDetails);
+  const isAnyProcessing = isAnyWorkflowActive(workflowDetails);
 
   const sidebarRef = useRef<DocumentExplorerSidebarHandle>(null);
   const markdownRef = useRef<DocumentMarkdownRendererHandle>(null);

--- a/frontend/lib/workflow-state.ts
+++ b/frontend/lib/workflow-state.ts
@@ -181,16 +181,17 @@ export function needsHumanApproval(workflowRuns: WorkflowRunDetail[]): boolean {
 }
 
 /**
- * Whether the pipeline has work in flight worth showing progress for.
+ * Whether assessments are actively working, as opposed to parked waiting on
+ * the user.
  *
  * A run that is only Pending doesn't count while a human-approval gate is
  * outstanding: HumanApproval and the runs behind it stay Pending until the
- * user approves, so counting them would leave an empty progress toast on
- * screen for as long as the review takes. A Running run always counts — the
- * rest of the assessments keep working while the gate waits, and that is
- * exactly what the toast is there to show.
+ * user approves, so counting them would claim the pipeline is busy for as long
+ * as the review takes — an empty progress toast, a spinner that never stops.
+ * A Running run always counts: the rest of the assessments keep working while
+ * the gate waits, and that work is exactly what the UI should report.
  */
-export function hasWorkflowProgressToShow(workflowRuns: WorkflowRunDetail[]): boolean {
+export function isAnyWorkflowActive(workflowRuns: WorkflowRunDetail[]): boolean {
   if (workflowRuns.some((workflowRun) => workflowRun.run.status === WorkflowRunStatus.Running)) return true;
   if (needsHumanApproval(workflowRuns)) return false;
   return isAnyWorkflowProcessing(workflowRuns);


### PR DESCRIPTION
## Summary

The "Some results are still loading, see the Assessments tab for details" spinner in the document explorer stays on for as long as a reference review is pending, even when nothing is actually running. This is the same root cause as the progress-toast fix in #709, one layer up, and it reuses the predicate that PR introduced.

## Motivation

The indicator is gated on `isAnyWorkflowProcessing`, which counts `Pending` as well as `Running`. The `human_approval` run is created up front as `PENDING` alongside every other assessment, and because its manifest sets `requires_human_trigger` it is never auto-run (`lib/api/services/workflow_runner.py:241`). So it — and everything queued behind it — sits `Pending` for the entire review, and `isAnyWorkflowProcessing` never goes false. The spinner claims results are loading while the pipeline is deliberately parked waiting on the user.

`hasWorkflowProgressToShow` (added in #709) already asks the right question: is anything actually working, as opposed to parked? A `Running` run always counts, since the other assessments keep going while the gate waits; a merely-`Pending` run stops counting once a gate is outstanding.

## What's Changed

### Frontend

- `lib/workflow-state.ts` — renamed `hasWorkflowProgressToShow` to `isAnyWorkflowActive`. The old name was toast-specific and reads wrong now that the document explorer uses it; docstring updated to cover both callers. Behavior is unchanged.
- `components/results-v2/document-explorer/document-explorer-tab.tsx`, `components/results/tabs/document-explorer-tab.tsx` — `isAnyProcessing` now derives from `isAnyWorkflowActive`. Applied to both the v1 and v2 explorers, which carry the same indicator.
- `app/(authenticated)/projects/[projectId]/layout.tsx`, `components/results-v2/use-project-shell-state.ts` — rename only, no behavior change.

### Backend

None.

## Risks and Mitigations

`isAnyProcessing` also drives the "Finding issues..." label and the "No issues found for this document." empty state in the same components, so all three now agree on when the pipeline is parked. The visible consequence: with the gate outstanding, nothing running, and zero issues so far, the explorer shows "No issues found" instead of an indefinite spinner. That is the honest state — the queued work is waiting on the user, and the pending gate is surfaced in the Assessments tab — but if we'd rather keep that empty state silent until after approval, it's a one-line follow-up in `issues-column.tsx`.

The gate-aware branch only suppresses runs that are `Pending`; anything `Running` still shows, so an in-flight pipeline is unaffected. Verified `tsc --noEmit` and `eslint` clean on the touched files. The repo has no frontend test runner, so there is no unit test to add here, and the change was not exercised in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
