### PR TITLE
feat(results-v2): replace the progress toast with a header run indicator

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -161,3 +161,28 @@
   --text-xl: 1.125rem;
   --text-2xl: 1.25rem;
 }
+
+/**
+ * The v2 project header's activity line: a sweep that says work is happening
+ * without claiming to know how far along it is. Reduced motion gets a static
+ * filled line, which still reads as "busy".
+ */
+@keyframes run-activity-sweep {
+  0% {
+    transform: translateX(-110%);
+  }
+  100% {
+    transform: translateX(410%);
+  }
+}
+
+.run-activity-sweep {
+  animation: run-activity-sweep 1.8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .run-activity-sweep {
+    width: 100%;
+    animation: none;
+  }
+}

--- a/frontend/components/results-v2/project-shell.tsx
+++ b/frontend/components/results-v2/project-shell.tsx
@@ -15,7 +15,7 @@ import { ProjectFeedbackProvider } from '@/lib/contexts/project-feedback-context
 import { AccessLevel, ProjectDetailed, UserRole, WorkflowRunType } from '@/lib/generated-api';
 import { useUserMe } from '@/lib/hooks/use-user-me';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
-import { getWorkflowRunByType } from '@/lib/workflow-state';
+import { getWorkflowRunByType, isAnyWorkflowActive } from '@/lib/workflow-state';
 import { ReactNode, useMemo } from 'react';
 import { AppBar } from './app-bar';
 import { NewAssessmentButton } from './new-assessment-button';
@@ -23,6 +23,8 @@ import { OldRevisionBanner } from './old-revision-banner';
 import { PageTitle } from '@/components/shared/page-title';
 import { ProjectTab, ProjectTabs } from './project-tabs';
 import { ReferenceReviewBanner } from './reference-review-banner';
+import { RunActivityIndicator } from './run-activity/run-activity-indicator';
+import { RunActivityLine } from './run-activity/run-activity-line';
 
 /** Tabs redesigned for the v2 frame, which manage their own scrolling. */
 /** Every redesigned tab manages its own scrolling; only Summary still does not. */
@@ -66,6 +68,9 @@ export function ProjectShellV2({
   const { isWorkflowTypeVisible } = useWorkflowTypes();
 
   const currentRevision = projectDetail.project.current_revision ?? 1;
+  // A pipeline parked on the reference-review gate isn't progressing — see
+  // isAnyWorkflowActive.
+  const runsActive = isAnyWorkflowActive(results);
   const referenceExtraction = getWorkflowRunByType(results, WorkflowRunType.ReferenceExtraction);
 
   const { showExperimentalFeatures } = useExperimentalFeatures();
@@ -152,6 +157,9 @@ export function ProjectShellV2({
                   Read-only view
                 </Badge>
               )}
+              {/* What is running sits next to what starts a run, so the answer to
+                  "did that go?" is where the question was asked. */}
+              <RunActivityIndicator projectId={projectDetail.project.id} workflowDetails={results} />
               {!readOnly && <NewAssessmentButton projectId={projectDetail.project.id} />}
               <AnalysisOptionsMenu
                 project={projectDetail.project}
@@ -166,6 +174,8 @@ export function ProjectShellV2({
               />
             </div>
           </header>
+
+          <RunActivityLine active={runsActive} />
 
           {needsReferenceReview && (
             <ReferenceReviewBanner projectDetail={projectDetail} onReviewReferences={() => onTabChange('references')} />

--- a/frontend/components/results-v2/run-activity/run-activity-indicator.tsx
+++ b/frontend/components/results-v2/run-activity/run-activity-indicator.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Progress } from '@/components/ui/progress';
+import { WorkflowRunDetail } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+import { isAnyWorkflowActive } from '@/lib/workflow-state';
+import { Loader2 } from 'lucide-react';
+import { RunActivityItem, useRunActivity } from './use-run-activity';
+
+interface RunActivityIndicatorProps {
+  projectId: string;
+  workflowDetails: WorkflowRunDetail[];
+}
+
+/**
+ * What is running, as one control in the project header instead of a panel over
+ * the page.
+ *
+ * The toast this replaces grew a row per active assessment and, with a dozen of
+ * them going, covered the whole right-hand side of every tab — the pane you
+ * would be reading while you wait. A header button is the same information at a
+ * fixed size: the count is always in view, and the list is one click away in a
+ * popover that closes on Escape and never sits on top of the content.
+ *
+ * Only current work is listed. Finished assessments are read in the Assessments
+ * tab, where their results are.
+ */
+export function RunActivityIndicator({ projectId, workflowDetails }: RunActivityIndicatorProps) {
+  const active = isAnyWorkflowActive(workflowDetails);
+  const { running, queued } = useRunActivity(projectId, workflowDetails, active);
+
+  if (!active) return null;
+
+  // Naming the one thing that runs beats counting it. Past that the names stop
+  // fitting, and the count is what the header can usefully say.
+  const summary =
+    running.length === 0 ? 'Starting…' : running.length === 1 ? running[0].label : `${running.length} running`;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        {/* Ghost, not outlined: this reports state, it does not ask to be
+            pressed, and the row already carries three bordered controls and a
+            filled one. The spinner keeps its colour so the row still has one
+            live thing in it. */}
+        <Button
+          variant="ghost"
+          size="xs"
+          className="gap-1.5 px-1.5 text-muted-foreground hover:text-foreground"
+          aria-label={`${running.length} assessment${running.length === 1 ? '' : 's'} running. Show details`}
+        >
+          <Loader2 className="text-primary size-3.5 animate-spin" />
+          <span className="hidden max-w-52 truncate sm:inline">{summary}</span>
+          {running.length > 1 && <span className="font-mono tabular-nums sm:hidden">{running.length}</span>}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent align="end" className="w-80 p-0">
+        {/* A dozen assessments is a normal batch, so the whole list scrolls as
+            one region — bounded by whatever room Radix found below the button,
+            never by the number of things running. */}
+        <div className="max-h-[min(26rem,calc(var(--radix-popover-content-available-height)-4.5rem))] overflow-y-auto">
+          <ActivitySection title="Running now" count={running.length}>
+            {running.length > 0 ? (
+              running.map((item) => <ActivityRow key={item.runId} item={item} />)
+            ) : (
+              <p className="px-2 py-1.5 text-[13px] text-muted-foreground">Getting the first assessment started…</p>
+            )}
+          </ActivitySection>
+
+          {queued.length > 0 && (
+            <ActivitySection title="Queued" count={queued.length} bordered>
+              {queued.map((item) => (
+                <ActivityRow key={item.runId} item={item} queued />
+              ))}
+            </ActivitySection>
+          )}
+        </div>
+
+        <p className="border-t px-3 py-2 text-[11px] leading-relaxed text-muted-foreground">
+          Results appear as each assessment finishes.
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ActivitySection({
+  title,
+  count,
+  bordered = false,
+  children,
+}: {
+  title: string;
+  count: number;
+  bordered?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn(bordered && 'border-t')}>
+      {/* Sticky, so a long list never leaves you unsure which section you are
+          scrolling through. */}
+      <div className="bg-popover sticky top-0 flex items-center justify-between px-3 pt-2.5 pb-1">
+        <h3 className="font-mono text-[10px] tracking-wide text-muted-foreground uppercase">{title}</h3>
+        <span className="font-mono text-[10px] tabular-nums text-muted-foreground">{count}</span>
+      </div>
+      <div className="space-y-px p-1.5 pt-0">{children}</div>
+    </div>
+  );
+}
+
+function ActivityRow({ item, queued = false }: { item: RunActivityItem; queued?: boolean }) {
+  // A single-step node has nothing to report but that it is going, and a bar
+  // pinned at 0% or 100% would say something untrue about it.
+  const showSteps = item.totalSteps > 1;
+  const percent = showSteps ? Math.min(100, Math.round((item.currentStep / item.totalSteps) * 100)) : 0;
+
+  return (
+    <div className="flex items-start gap-2 rounded-md px-2 py-1.5">
+      {/* The same dot the assessment rail uses for the same states. */}
+      <span
+        className={cn(
+          'mt-1.5 size-1.5 shrink-0 rounded-full',
+          queued ? 'bg-muted-foreground/40' : 'bg-primary animate-pulse',
+        )}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className={cn('min-w-0 flex-1 truncate text-[13px]', queued && 'text-muted-foreground')}>
+            {item.label}
+          </span>
+          {showSteps && (
+            <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+              {item.currentStep}/{item.totalSteps}
+            </span>
+          )}
+        </div>
+        {item.detail && <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</p>}
+        {showSteps && <Progress value={percent} className="mt-1.5 h-1" />}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/results-v2/run-activity/run-activity-line.tsx
+++ b/frontend/components/results-v2/run-activity/run-activity-line.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+/**
+ * A hairline under the project header that sweeps while assessments run.
+ *
+ * The header button says what is running; this says *that* something is,
+ * peripherally, without asking for a glance. Two pixels is the whole cost, and
+ * unlike the toast it cannot cover anything.
+ */
+export function RunActivityLine({ active }: { active: boolean }) {
+  if (!active) return null;
+
+  return (
+    <div className="bg-primary/15 relative h-0.5 shrink-0 overflow-hidden" aria-hidden="true">
+      <div className="bg-primary run-activity-sweep absolute inset-y-0 w-1/3 rounded-full" />
+    </div>
+  );
+}

--- a/frontend/components/results-v2/run-activity/use-run-activity.ts
+++ b/frontend/components/results-v2/run-activity/use-run-activity.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useShare } from '@/context/share-context';
+import {
+  getProjectWorkflowProgressEndpointApiProjectProjectIdWorkflowProgressGet,
+  WorkflowProgressResponse,
+  WorkflowRunDetail,
+  WorkflowRunStatus,
+} from '@/lib/generated-api';
+import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+const REFETCH_INTERVAL_MS = 3000;
+
+/** One assessment that is working right now, or waiting its turn to. */
+export interface RunActivityItem {
+  runId: string;
+  /** The assessment, named the way the rest of the view names it. */
+  label: string;
+  /** What it is doing right now, when that says more than the label does. */
+  detail: string | null;
+  currentStep: number;
+  totalSteps: number;
+}
+
+export interface RunActivity {
+  running: RunActivityItem[];
+  queued: RunActivityItem[];
+}
+
+const EMPTY: RunActivity = { running: [], queued: [] };
+
+/**
+ * What the project is doing at this moment: one entry per active workflow run,
+ * carrying the step counts of whatever it is working on.
+ *
+ * Progress rows accumulate for the life of a revision, so the finished ones are
+ * dropped here rather than being offered as history — a run that has already
+ * delivered its results is read in the Assessments tab, not in a progress list.
+ * Rows are keyed back to their run so twelve concurrent assessments read as
+ * twelve lines instead of however many nodes they happen to have open.
+ */
+export function useRunActivity(projectId: string, workflowDetails: WorkflowRunDetail[], enabled: boolean): RunActivity {
+  const { shareToken } = useShare();
+  const { getWorkflowTypeName } = useWorkflowTypes();
+
+  const { data: progress } = useQuery({
+    queryKey: ['project-workflow-progress', projectId],
+    queryFn: () =>
+      getProjectWorkflowProgressEndpointApiProjectProjectIdWorkflowProgressGet({
+        path: { project_id: projectId },
+        query: { share_token: shareToken },
+      }),
+    enabled,
+    refetchInterval: REFETCH_INTERVAL_MS,
+  });
+
+  return useMemo(() => {
+    if (!enabled) return EMPTY;
+
+    const openByRun = new Map<string, WorkflowProgressResponse[]>();
+    for (const entry of progress ?? []) {
+      if (entry.completed_at || !entry.started_at) continue;
+      const open = openByRun.get(entry.workflow_run_id);
+      if (open) open.push(entry);
+      else openByRun.set(entry.workflow_run_id, [entry]);
+    }
+
+    const running: RunActivityItem[] = [];
+    const queued: RunActivityItem[] = [];
+
+    for (const { run } of workflowDetails) {
+      const isRunning = run.status === WorkflowRunStatus.Running;
+      const isQueued = run.status === WorkflowRunStatus.Pending;
+      if (!isRunning && !isQueued) continue;
+
+      const open = openByRun.get(run.id) ?? [];
+      const label = getWorkflowTypeName(run.type);
+      // Parallel nodes of the same name batch into one row upstream, so what is
+      // left here is genuinely distinct work. A node named after its own
+      // assessment would only repeat the line above it.
+      const names = Array.from(new Set(open.map((entry) => entry.name))).filter((name) => name !== label);
+
+      (isRunning ? running : queued).push({
+        runId: run.id,
+        label,
+        detail: names.length > 0 ? names.join(' · ') : null,
+        currentStep: open.reduce((sum, entry) => sum + (entry.current_step ?? 0), 0),
+        totalSteps: open.reduce((sum, entry) => sum + (entry.total_steps ?? 0), 0),
+      });
+    }
+
+    return { running, queued };
+  }, [enabled, progress, workflowDetails, getWorkflowTypeName]);
+}

--- a/frontend/components/results-v2/use-project-shell-state.ts
+++ b/frontend/components/results-v2/use-project-shell-state.ts
@@ -1,10 +1,8 @@
 'use client';
 
-import { useWorkflowProgressToast } from '@/hooks/use-workflow-progress-toast';
 import { getErrorMessage } from '@/lib/api-error';
 import { AccessLevel, ProjectDetailed, updateProjectEndpointApiProjectProjectIdPatch } from '@/lib/generated-api';
 import { useProjectDetails } from '@/lib/hooks/use-project-details';
-import { isAnyWorkflowActive } from '@/lib/workflow-state';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
@@ -38,10 +36,6 @@ export function useProjectShellState(projectId: string) {
   const handleRevisionCreated = useCallback(() => {
     setSelectedRevision(null);
   }, []);
-
-  // A pipeline parked on the reference-review gate isn't progressing — see
-  // isAnyWorkflowActive.
-  useWorkflowProgressToast(projectId, isAnyWorkflowActive(workflowDetails));
 
   const updateTitleMutation = useMutation({
     mutationFn: async (newTitle: string) => {


### PR DESCRIPTION
## Summary

Replaces the v2 project view's floating progress toast with a run indicator that lives in the project header: a ghost button that names what is running, a popover that lists it, and a hairline that sweeps under the header while work is in flight.

## Motivation

The toast rendered one row per active progress entry. A normal batch is a dozen assessments, so it grew into a full-height panel pinned over the right-hand side of every tab — covering the margin notes, the reference detail, the file detail: exactly the panes you read while waiting. It also carried two controls nobody needs mid-run: a Show/Hide toggle over completed steps and a "Show all N steps" expander. Finished assessments are read in the Assessments tab, where their results are.

The replacement is a fixed-size control. Twelve assessments and one look identical in footprint, and the detail is behind a click, in a popover that closes on Escape and is bounded by the room Radix finds below the trigger.

## What's Changed

### Frontend

- **`components/results-v2/run-activity/use-run-activity.ts`** (new) — polls the existing `/workflow-progress` endpoint and derives current activity. Drops completed entries rather than offering them as history, and keys open progress rows back to their workflow run, so twelve concurrent assessments read as twelve lines instead of however many nodes they happen to have open. Splits Running from Pending.
- **`components/results-v2/run-activity/run-activity-indicator.tsx`** (new) — the header control. Ghost variant, so it reports state without adding a fourth bordered control to a row that already has a filled button and two outlined ones; the spinner keeps `text-primary` so the row still has one live thing in it. Names the single running assessment, counts them past that. The popover lists Running now and Queued as one bounded scroll region (`--radix-popover-content-available-height`, capped at 26rem) with sticky section headers, a step bar where a node reports real sub-steps, and the same status dot the assessment rail uses.
- **`components/results-v2/run-activity/run-activity-line.tsx`** (new) — a 2px sweep under the project header while anything runs. Ambient signal at no layout cost; static filled line under `prefers-reduced-motion`.
- **`components/results-v2/project-shell.tsx`** — mounts the indicator in the header's action cluster and the line below the header.
- **`components/results-v2/use-project-shell-state.ts`** — drops `useWorkflowProgressToast`.
- **`app/globals.css`** — `run-activity-sweep` keyframes and its reduced-motion fallback.

### Backend

None. This reads the existing `GET /api/project/{id}/workflow-progress` endpoint unchanged.

## Risks and Mitigations

- **v1 is untouched.** `app/(authenticated)/projects/[projectId]/layout.tsx` and `hooks/use-workflow-progress-toast.tsx` keep the toast, consistent with the v2 tree being deletable. Fold the two together when v2 takes over.
- **Visibility rule is unchanged.** The indicator hides on `isAnyWorkflowActive`, the same predicate the toast used, so a pipeline parked on the reference-review gate still shows nothing rather than a spinner that never stops.
- **Same query key** (`['project-workflow-progress', id]`) and same 3s interval as the toast, so no new polling load; the query is disabled whenever nothing is active.
- **Verified in the browser** against a running backend with mocked run states: 12 running and 1 running, the popover scrolling into the Queued section, sticky headers, the "Starting…" state before the first step reports, and both light and dark themes. `tsc --noEmit` and prettier clean, eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)