### PR TITLE
fix(results-v2): keep header banners and share badge legible on narrow screens

### DIFF
--- a/frontend/components/results-v2/old-revision-banner.tsx
+++ b/frontend/components/results-v2/old-revision-banner.tsx
@@ -18,15 +18,17 @@ interface OldRevisionBannerProps {
  */
 export function OldRevisionBanner({ selectedRevision, currentRevision, onViewCurrent }: OldRevisionBannerProps) {
   return (
-    <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-blue-50 px-3 py-2 dark:bg-blue-950/30">
-      <History className="size-4 shrink-0 text-blue-700 dark:text-blue-400" />
-      <p className="min-w-0 text-sm">
-        <strong className="font-medium">Viewing revision {selectedRevision}.</strong>{' '}
-        <span className="text-muted-foreground">
-          This is an earlier draft, kept as it was, so nothing here can be changed.
-        </span>{' '}
-        <HelpLink topic="revisions">What this is</HelpLink>
-      </p>
+    <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 border-b bg-blue-50 px-3 py-2 dark:bg-blue-950/30">
+      <div className="flex min-w-0 grow basis-96 items-start gap-2">
+        <History className="mt-0.5 size-4 shrink-0 text-blue-700 dark:text-blue-400" />
+        <p className="min-w-0 text-sm">
+          <strong className="font-medium">Viewing revision {selectedRevision}.</strong>{' '}
+          <span className="text-muted-foreground">
+            This is an earlier draft, kept as it was, so nothing here can be changed.
+          </span>{' '}
+          <HelpLink topic="revisions">What this is</HelpLink>
+        </p>
+      </div>
 
       {onViewCurrent && (
         <div className="ml-auto flex shrink-0 items-center gap-2">

--- a/frontend/components/results-v2/reference-review-banner.tsx
+++ b/frontend/components/results-v2/reference-review-banner.tsx
@@ -22,17 +22,19 @@ export function ReferenceReviewBanner({ projectDetail, onReviewReferences }: Ref
   const approval = useReferenceApprovalFlow(projectDetail, projectDetail.project.id);
 
   return (
-    <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-amber-50 px-3 py-2 dark:bg-amber-950/30">
-      <BookOpen className="size-4 shrink-0 text-amber-700 dark:text-amber-400" />
-      <p className="min-w-0 text-sm">
-        <strong className="font-medium">Reference review required.</strong>{' '}
-        <span className="text-muted-foreground">
-          Claim Reference Validation reads each citation against the source it cites, and needs those sources first.
-        </span>{' '}
-        <HelpLink topic="source-files" onReviewReferences={onReviewReferences}>
-          Why this is needed
-        </HelpLink>
-      </p>
+    <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 border-b bg-amber-50 px-3 py-2 dark:bg-amber-950/30">
+      <div className="flex min-w-0 grow basis-96 items-start gap-2">
+        <BookOpen className="mt-0.5 size-4 shrink-0 text-amber-700 dark:text-amber-400" />
+        <p className="min-w-0 text-sm">
+          <strong className="font-medium">Reference review required.</strong>{' '}
+          <span className="text-muted-foreground">
+            Claim Reference Validation reads each citation against the source it cites, and needs those sources first.
+          </span>{' '}
+          <HelpLink topic="source-files" onReviewReferences={onReviewReferences}>
+            Why this is needed
+          </HelpLink>
+        </p>
+      </div>
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
         <Button size="xs" variant="outline" className="h-6" onClick={onReviewReferences}>

--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -178,7 +178,13 @@ export function AnalysisOptionsMenu({
     <>
       <div className="flex items-center gap-1">
         <div className="flex items-center gap-2">
-          {!readOnly && <ShareStatusBadge isEnabled={share.isEnabled} onClick={() => share.setIsDialogOpen(true)} />}
+          {!readOnly && (
+            <ShareStatusBadge
+              isEnabled={share.isEnabled}
+              onClick={() => share.setIsDialogOpen(true)}
+              compact={compact}
+            />
+          )}
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/frontend/components/share/share-status-badge.tsx
+++ b/frontend/components/share/share-status-badge.tsx
@@ -2,14 +2,20 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import { Link } from 'lucide-react';
 
 interface ShareStatusBadgeProps {
   isEnabled: boolean;
   onClick?: () => void;
+  /**
+   * Drops the label on narrow screens, leaving the link icon, the way the
+   * buttons beside it in the header shed their labels.
+   */
+  compact?: boolean;
 }
 
-export function ShareStatusBadge({ isEnabled, onClick }: ShareStatusBadgeProps) {
+export function ShareStatusBadge({ isEnabled, onClick, compact = false }: ShareStatusBadgeProps) {
   if (!isEnabled) return null;
 
   return (
@@ -19,9 +25,10 @@ export function ShareStatusBadge({ isEnabled, onClick }: ShareStatusBadgeProps) 
           variant="outline"
           className="h-7 cursor-pointer gap-1 bg-green-50 text-green-700 border-green-200 hover:bg-green-100 dark:bg-green-950 dark:text-green-300 dark:border-green-800 dark:hover:bg-green-900"
           onClick={onClick}
+          aria-label="Sharing enabled"
         >
           <Link className="h-3 w-3" />
-          Sharing enabled
+          <span className={cn(compact && 'hidden sm:inline')}>Sharing enabled</span>
         </Badge>
       </TooltipTrigger>
       <TooltipContent>


### PR DESCRIPTION
## Summary

Two responsive fixes in the v2 project header: the notice banners no longer strand their icon on a line of its own, and the "Sharing enabled" badge collapses to its icon on small screens the way the buttons beside it already do.

## Motivation

On narrower viewports the reference-review banner broke into three ragged lines — the icon alone on the first, the sentence on the second, the buttons on a third — because the icon, the paragraph and the button group were siblings in a `flex-wrap` row and the paragraph's natural width is the whole sentence, so the wrap landed between the icon and the text. The old-revision banner had the same structure and the same result.

In the same header, "Sharing enabled" keeps its full label while the Export button and the revision switcher shed theirs, so it takes a disproportionate share of a phone-width row.

## What's Changed

### Frontend

- `components/results-v2/reference-review-banner.tsx` — icon and text moved into a single `flex min-w-0 grow basis-96 items-start` wrapper, so they stay together and only the button group wraps. Outer gap split into `gap-x-3 gap-y-2` to tighten wrapped rows, and the icon aligns to the first line now that the text can run to several lines.
- `components/results-v2/old-revision-banner.tsx` — same change, same reason.
- `components/share/share-status-badge.tsx` — new optional `compact` prop hides the label below `sm`, leaving the link icon; `aria-label` plus the existing tooltip keep it identifiable.
- `components/results/components/analysis-options-menu.tsx` — passes its own `compact` through to the badge, so the v2 header gets the icon-only variant and the classic layout keeps the label at every width.

Verified in Chrome against a Tailwind-compiled preview at 1000px, 700px and 380px: single row when there is room, buttons dropping to a right-aligned row below ~700px, and the icon beside the first line of text throughout. `tsc --noEmit`, eslint and prettier are clean.

## Risks and Mitigations

Presentation only — no data, state or API changes. The `compact` prop defaults to `false`, so the classic layout and any other caller render exactly as before. Worst case is a layout regression at some width, visible immediately and revertible on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)