### PR TITLE
refactor(document-explorer): drop the duplicated loading indicator, add an issues empty state

### DIFF
--- a/frontend/components/results/document-explorer-panel.tsx
+++ b/frontend/components/results/document-explorer-panel.tsx
@@ -8,7 +8,18 @@ import { DocumentExplorerTab } from './document-explorer/document-explorer-tab';
  * revision switcher, the banners — comes from ProjectShell.
  */
 export function DocumentExplorerPanel() {
-  const { projectDetail, navigateToTab } = useProjectView();
+  const { projectDetail, readOnly, navigateToTab } = useProjectView();
 
-  return <DocumentExplorerTab projectDetail={projectDetail} onNavigateToAnalyses={() => navigateToTab('analyses')} />;
+  return (
+    <DocumentExplorerTab
+      projectDetail={projectDetail}
+      // The shell's read-only covers older revisions as well as projects that
+      // aren't the reader's, which is what starting a run has to answer to:
+      // the start API targets the project's current revision, not the one on
+      // screen. Rating and resolving issues is a separate question, answered
+      // inside the tab by the access level.
+      canRunAssessments={!readOnly}
+      onNavigateToAnalyses={() => navigateToTab('analyses')}
+    />
+  );
 }

--- a/frontend/components/results/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results/document-explorer/document-explorer-tab.tsx
@@ -43,6 +43,8 @@ const MODES = [
 
 interface DocumentExplorerTabProps {
   projectDetail: ProjectDetailed;
+  /** False on a shared or older revision, where the header hides its run button too. */
+  canRunAssessments: boolean;
   onNavigateToAnalyses: () => void;
 }
 
@@ -54,7 +56,11 @@ function getIssueLineRange(issue: Issue): [number, number] | null {
   return [start_line, end_line];
 }
 
-export function DocumentExplorerTab({ projectDetail, onNavigateToAnalyses }: DocumentExplorerTabProps) {
+export function DocumentExplorerTab({
+  projectDetail,
+  canRunAssessments,
+  onNavigateToAnalyses,
+}: DocumentExplorerTabProps) {
   const { selectedLineRange, selectLineRange, clearLineSelection, filter, setFilter, clearFilters } =
     useDocumentExplorerStore();
 
@@ -429,6 +435,7 @@ export function DocumentExplorerTab({ projectDetail, onNavigateToAnalyses }: Doc
             issues={highlightIssues}
             totalIssueCount={issues.length}
             activeIssueId={activeIssueId}
+            canRunAssessments={canRunAssessments}
             isAnyProcessing={isAnyProcessing}
             readOnly={!canEditIssues}
             onSelectIssue={handleSelectIssue}

--- a/frontend/components/results/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results/document-explorer/document-explorer-tab.tsx
@@ -424,8 +424,10 @@ export function DocumentExplorerTab({ projectDetail, onNavigateToAnalyses }: Doc
         >
           <IssuesColumn
             ref={issuesRef}
+            projectId={projectDetail.project.id}
             visibleIssues={visibleIssues}
             issues={highlightIssues}
+            totalIssueCount={issues.length}
             activeIssueId={activeIssueId}
             isAnyProcessing={isAnyProcessing}
             readOnly={!canEditIssues}

--- a/frontend/components/results/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results/document-explorer/document-explorer-tab.tsx
@@ -342,22 +342,8 @@ export function DocumentExplorerTab({ projectDetail, onNavigateToAnalyses }: Doc
             <span className="truncate text-xs text-muted-foreground">
               {outline.length > 0 ? `${outline.length} sections` : 'Document'}
               {mainDocumentMarkdown ? ` · ${mainDocumentMarkdown.split('\n').length} lines` : ''}
-              {` · ${countLabel ?? (isAnyProcessing ? 'Finding issues...' : 'No issues')}`}
+              {` · ${countLabel ?? 'No issues'}`}
             </span>
-
-            {isAnyProcessing && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className="inline-flex size-3.5 shrink-0 items-center justify-center text-muted-foreground"
-                    aria-label="Some results are still loading"
-                  >
-                    <Loader2 className="size-3.5 animate-spin" />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>Some results are still loading, see the Assessments tab for details</TooltipContent>
-              </Tooltip>
-            )}
 
             <div className="ml-auto flex shrink-0 items-center gap-2">
               {/* Only while something on screen can show what it steps to.

--- a/frontend/components/results/document-explorer/issues-column.tsx
+++ b/frontend/components/results/document-explorer/issues-column.tsx
@@ -3,7 +3,9 @@
 import { Button } from '@/components/ui/button';
 import { Issue } from '@/lib/generated-api';
 import { getIssueCount, hasActiveFilters, useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
-import { Ref, useImperativeHandle, useRef, useState } from 'react';
+import { CheckCircle2, FileSearch, Loader2 } from 'lucide-react';
+import { ReactNode, Ref, useImperativeHandle, useRef, useState } from 'react';
+import { NewAssessmentButton } from '../new-assessment-button';
 import { IssuesList, IssuesListHandle } from './issues-list';
 
 /**
@@ -25,10 +27,13 @@ export interface IssuesColumnHandle {
 
 interface IssuesColumnProps {
   ref?: Ref<IssuesColumnHandle>;
+  projectId: string;
   /** Issues after the passing/resolved toggles, before severity and type. */
   visibleIssues: Issue[];
   /** Issues after every filter — what the list shows. */
   issues: Issue[];
+  /** Every issue on the document, before any filtering. */
+  totalIssueCount: number;
   /** The issue whose row is expanded. */
   activeIssueId: string | null;
   isAnyProcessing: boolean;
@@ -44,8 +49,10 @@ interface IssuesColumnProps {
  */
 export function IssuesColumn({
   ref,
+  projectId,
   visibleIssues,
   issues,
+  totalIssueCount,
   activeIssueId,
   isAnyProcessing,
   readOnly,
@@ -64,19 +71,23 @@ export function IssuesColumn({
   return (
     <div className="flex h-full flex-col">
       <div ref={setScrollContainer} className="min-h-0 flex-1 overflow-y-auto">
-        {visibleIssues.length === 0 && !isAnyProcessing && (
-          <p className="p-4 text-sm text-muted-foreground">No issues found for this document.</p>
+        {visibleIssues.length === 0 && (
+          <EmptyIssues
+            projectId={projectId}
+            totalIssueCount={totalIssueCount}
+            isAnyProcessing={isAnyProcessing}
+            readOnly={readOnly}
+          />
         )}
 
-        {visibleIssues.length > 0 && issues.length === 0 && !isAnyProcessing && (
-          <div className="space-y-1 py-8 text-center text-sm text-muted-foreground">
-            <p>No issues match the current filters.</p>
+        {visibleIssues.length > 0 && issues.length === 0 && (
+          <EmptyState title="No issues match the current filters">
             {hasActiveFilters(filter) && (
               <Button variant="link" size="sm" className="text-xs" onClick={clearFilters}>
                 Clear filters
               </Button>
             )}
-          </div>
+          </EmptyState>
         )}
 
         <IssuesList
@@ -88,6 +99,92 @@ export function IssuesColumn({
           readOnly={readOnly}
         />
       </div>
+    </div>
+  );
+}
+
+/**
+ * What the column says when it has nothing to list. Never nothing: an empty
+ * panel reads as something that failed to load, and the three ways to arrive
+ * here want different answers — wait, clear a toggle, or run an assessment.
+ */
+function EmptyIssues({
+  projectId,
+  totalIssueCount,
+  isAnyProcessing,
+  readOnly,
+}: {
+  projectId: string;
+  totalIssueCount: number;
+  isAnyProcessing: boolean;
+  readOnly: boolean;
+}) {
+  const { setFilter } = useDocumentExplorerStore();
+
+  if (isAnyProcessing) {
+    return (
+      <EmptyState
+        icon={<Loader2 className="size-5 animate-spin" />}
+        title="No issues yet"
+        description="Assessments are still running. Findings appear here as they land."
+      />
+    );
+  }
+
+  // Issues exist, but every one of them is resolved or passing and the toggles
+  // that would show them are off. Saying "no issues" here would be a lie about
+  // the document rather than about the filters.
+  if (totalIssueCount > 0) {
+    return (
+      <EmptyState
+        icon={<CheckCircle2 className="size-5" />}
+        title="No open issues"
+        description="Every issue on this document is resolved or passing."
+      >
+        <Button
+          variant="link"
+          size="sm"
+          className="text-xs"
+          onClick={() => setFilter({ showResolved: true, showPassing: true })}
+        >
+          Show resolved and passing
+        </Button>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <EmptyState
+      icon={<FileSearch className="size-5" />}
+      title="No issues found"
+      description={
+        readOnly
+          ? 'No assessment has reported anything on this document.'
+          : 'Run an assessment to have this document reviewed.'
+      }
+    >
+      {!readOnly && <NewAssessmentButton projectId={projectId} collapseLabel={false} />}
+    </EmptyState>
+  );
+}
+
+function EmptyState({
+  icon,
+  title,
+  description,
+  children,
+}: {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-2 px-6 py-10 text-center text-sm text-muted-foreground">
+      {icon && <span className="text-muted-foreground/70">{icon}</span>}
+      <p className="font-medium text-foreground">{title}</p>
+      {description && <p className="text-xs text-balance">{description}</p>}
+      {children}
     </div>
   );
 }

--- a/frontend/components/results/document-explorer/issues-column.tsx
+++ b/frontend/components/results/document-explorer/issues-column.tsx
@@ -37,6 +37,9 @@ interface IssuesColumnProps {
   /** The issue whose row is expanded. */
   activeIssueId: string | null;
   isAnyProcessing: boolean;
+  /** Whether starting a run is offered here — false on shared views and older revisions. */
+  canRunAssessments: boolean;
+  /** Whether the issues themselves can be resolved and rated. */
   readOnly: boolean;
   onSelectIssue: (issue: Issue) => void;
 }
@@ -55,6 +58,7 @@ export function IssuesColumn({
   totalIssueCount,
   activeIssueId,
   isAnyProcessing,
+  canRunAssessments,
   readOnly,
   onSelectIssue,
 }: IssuesColumnProps) {
@@ -76,7 +80,7 @@ export function IssuesColumn({
             projectId={projectId}
             totalIssueCount={totalIssueCount}
             isAnyProcessing={isAnyProcessing}
-            readOnly={readOnly}
+            canRunAssessments={canRunAssessments}
           />
         )}
 
@@ -112,12 +116,12 @@ function EmptyIssues({
   projectId,
   totalIssueCount,
   isAnyProcessing,
-  readOnly,
+  canRunAssessments,
 }: {
   projectId: string;
   totalIssueCount: number;
   isAnyProcessing: boolean;
-  readOnly: boolean;
+  canRunAssessments: boolean;
 }) {
   const { setFilter } = useDocumentExplorerStore();
 
@@ -158,12 +162,12 @@ function EmptyIssues({
       icon={<FileSearch className="size-5" />}
       title="No issues found"
       description={
-        readOnly
-          ? 'No assessment has reported anything on this document.'
-          : 'Run an assessment to have this document reviewed.'
+        canRunAssessments
+          ? 'Run an assessment to have this document reviewed.'
+          : 'No assessment has reported anything on this document.'
       }
     >
-      {!readOnly && <NewAssessmentButton projectId={projectId} collapseLabel={false} />}
+      {canRunAssessments && <NewAssessmentButton projectId={projectId} collapseLabel={false} />}
     </EmptyState>
   );
 }

--- a/frontend/components/results/new-assessment-button.tsx
+++ b/frontend/components/results/new-assessment-button.tsx
@@ -19,7 +19,14 @@ import { toast } from 'sonner';
  * the assessments that already exist, and every other control in this view
  * speaks the same way — "Ready to run", "Run more", "Re-run X".
  */
-export function NewAssessmentButton({ projectId }: { projectId: string }) {
+export function NewAssessmentButton({
+  projectId,
+  /** Off where the button is the only thing in its space and the label always fits. */
+  collapseLabel = true,
+}: {
+  projectId: string;
+  collapseLabel?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
 
@@ -53,7 +60,7 @@ export function NewAssessmentButton({ projectId }: { projectId: string }) {
             <PlayIcon />
             {/* A phone header cannot carry five labelled controls; here the
                 icon and its tooltip say it instead. */}
-            <span className="hidden sm:inline">Run assessments</span>
+            <span className={collapseLabel ? 'hidden sm:inline' : undefined}>Run assessments</span>
           </Button>
         </TooltipTrigger>
         <TooltipContent>Choose assessments to run on this document</TooltipContent>


### PR DESCRIPTION
## Summary

Two related changes to the Document Explorer's issue surfaces: the per-tab loading indicators are gone, and the issues column now has a real empty state instead of a blank panel.

## Motivation

While workflows ran, the Document Explorer header showed two loading signals — a `Finding issues...` status label and a spinner tooltip reading `Some results are still loading, see the Assessments tab for details` — both of which now just repeat the global run-activity indicator in the header.

Removing them exposed the other half of the problem: in List mode, the issues column rendered *nothing at all* while assessments were running, because both of its empty branches were gated on "not processing". A blank panel reads as something that failed to load, and the ways to arrive there want different answers.

## What's Changed

### Frontend

- `frontend/components/results/document-explorer/document-explorer-tab.tsx`
  - Removed the `Finding issues...` label and the spinner + tooltip; the header status line shows the issue count, falling back to `No issues`.
  - Passes `projectId` and `totalIssueCount` (the unfiltered issue count) to `IssuesColumn`.
- `frontend/components/results/document-explorer/issues-column.tsx`
  - New `EmptyIssues` / `EmptyState` components covering four cases: assessments running (`No issues yet` + spinner); nothing found and the project is writable (`No issues found` + a **Run assessments** button); the same on a read-only project (no CTA); and issues that all exist but are resolved or passing (`No open issues` + a link that flips both toggles on).
  - The "no issues match the current filters" branch no longer hides while processing — the message is accurate either way.
- `frontend/components/results/new-assessment-button.tsx`
  - Optional `collapseLabel` prop (default `true`, header unchanged) so the empty state can reuse the header's button with its label always visible.

### Backend

No backend changes.

## Risks and Mitigations

- **The header can read `No issues` before all workflows finish.** Intended: the global indicator carries the "still working" signal, and the issues column now states it explicitly too.
- **Telling the wrong reader to run assessments.** The CTA is gated on write access (same condition as the header's button), and the `totalIssueCount` check keeps a document whose issues are merely all resolved from being described as clean.
- **Reusing `NewAssessmentButton` in the column.** The new prop defaults to the existing behaviour, so the header call site is untouched.

`tsc`, `eslint` and `prettier` are clean; verified by hand against a local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)