### PR TITLE
feat(frontend): restyle processing errors notice as a chrome banner

### DIFF
--- a/frontend/components/results/document-explorer/document-explorer-tab.tsx
+++ b/frontend/components/results/document-explorer/document-explorer-tab.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { Callout } from '@/components/ui/callout';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { AccessLevel, Issue, ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { useLineHashNavigation } from '@/lib/line-hash';
@@ -21,7 +20,7 @@ import {
 } from '@/lib/workflow-state';
 import { WIDE_ENOUGH_FOR_PANE, useMediaQuery } from '@/lib/use-media-query';
 import { cn } from '@/lib/utils';
-import { AlertTriangleIcon, Columns2, ListFilter, Loader2 } from 'lucide-react';
+import { Columns2, ListFilter, Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { DocumentHeader, DocumentView, DocumentViewHandle } from './document-view';
 import { IssuesColumn, IssuesColumnHandle, issueCountLabel } from './issues-column';
@@ -29,6 +28,7 @@ import { IssueNav, useIssueShortcuts } from './issue-nav';
 import { Rail, RailToggle, SidePane, useRailState } from '../panes';
 import { OutlineRail } from './outline-rail';
 import { OutlineEntry, extractOutline } from './outline';
+import { ProcessingErrorsBanner } from '../processing-errors-banner';
 
 /** The two ways to read the issues: beside the text, or gathered in a column. */
 const MODES = [
@@ -297,8 +297,8 @@ export function DocumentExplorerTab({ projectDetail, onNavigateToAnalyses }: Doc
 
   if (isDocumentProcessing && !mainDocumentMarkdown) {
     return (
-      <div className="space-y-4 p-6">
-        {workflowErrors.length > 0 && <ProcessingErrorNotice onNavigateToAnalyses={onNavigateToAnalyses} />}
+      <div className="flex h-full min-h-0 flex-col">
+        {workflowErrors.length > 0 && <ProcessingErrorsBanner onViewAssessments={onNavigateToAnalyses} />}
         <div className="flex items-center justify-center py-12">
           <div className="space-y-3 text-center">
             <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
@@ -311,11 +311,7 @@ export function DocumentExplorerTab({ projectDetail, onNavigateToAnalyses }: Doc
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg">
-      {workflowErrors.length > 0 && (
-        <div className="border-b p-3">
-          <ProcessingErrorNotice onNavigateToAnalyses={onNavigateToAnalyses} />
-        </div>
-      )}
+      {workflowErrors.length > 0 && <ProcessingErrorsBanner onViewAssessments={onNavigateToAnalyses} />}
 
       <div className="flex min-h-0 flex-1">
         <Rail state={rail} label="Filters and outline">
@@ -448,19 +444,5 @@ export function DocumentExplorerTab({ projectDetail, onNavigateToAnalyses }: Doc
         </SidePane>
       </div>
     </div>
-  );
-}
-
-function ProcessingErrorNotice({ onNavigateToAnalyses }: { onNavigateToAnalyses: () => void }) {
-  return (
-    <Callout variant="warning" icon={AlertTriangleIcon} title="Unexpected processing errors occurred">
-      <p className="text-sm">
-        Check the{' '}
-        <button onClick={onNavigateToAnalyses} className="cursor-pointer font-medium underline underline-offset-2">
-          Assessments tab
-        </button>{' '}
-        for details.
-      </p>
-    </Callout>
   );
 }

--- a/frontend/components/results/processing-errors-banner.tsx
+++ b/frontend/components/results/processing-errors-banner.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { AlertTriangle } from 'lucide-react';
+
+interface ProcessingErrorsBannerProps {
+  onViewAssessments: () => void;
+}
+
+/**
+ * The strip that appears when an assessment on this revision hit an error it
+ * could not recover from. It matches the reference-review and old-revision
+ * strips so the chrome reads as one set of notices, and it points at the
+ * Assessments tab because that is where the failing run and its message live.
+ */
+export function ProcessingErrorsBanner({ onViewAssessments }: ProcessingErrorsBannerProps) {
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 border-b bg-amber-50 px-3 py-2 dark:bg-amber-950/30">
+      <div className="flex min-w-0 grow basis-96 items-start gap-2">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-700 dark:text-amber-400" />
+        <p className="min-w-0 text-sm">
+          <strong className="font-medium">Unexpected processing errors occurred.</strong>{' '}
+          <span className="text-muted-foreground">
+            One or more assessments stopped before finishing, so their results may be incomplete.
+          </span>
+        </p>
+      </div>
+
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        <Button size="xs" variant="outline" className="h-6" onClick={onViewAssessments}>
+          View assessments
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The "Unexpected processing errors occurred" notice on the Document Explorer tab now renders as a full-width strip that matches the reference-review and old-revision banners, instead of a padded Callout card.

## Motivation

When an assessment records a blocking error, the explorer showed a boxed yellow Callout directly under the amber reference-review strip. The two notices used different shapes, spacing, and action styles, so the chrome read as two unrelated widgets. This aligns the error notice with the existing banner pattern so all project-level notices stack as one consistent set.

## What's Changed

### Frontend

- `frontend/components/results/processing-errors-banner.tsx` (new): a `ProcessingErrorsBanner` component that copies the layout of `ReferenceReviewBanner` and `OldRevisionBanner`. Flush row with bottom border, amber background, `AlertTriangle` icon, bold lead sentence, muted explanation, and an extra-small outline "View assessments" button that navigates to the Assessments tab.
- `frontend/components/results/document-explorer/document-explorer-tab.tsx`: renders the new banner in both places the old notice appeared (the document-processing placeholder and the main explorer view), drops the padded wrapper so the strip sits flush against the tab chrome, and removes the inline `ProcessingErrorNotice` component along with its now-unused `Callout` and `AlertTriangleIcon` imports.

### Backend

No changes.

## Risks and Mitigations

- **Visual only.** The trigger condition is unchanged: the banner still appears when `getBlockingWorkflowErrors` returns any current-run, non-chunk, non-warning error. No data or navigation logic changed.
- **Two amber strips can stack** when the reference-review banner is also showing. This mirrors the previous behavior (the Callout was also yellow) and is easy to change to a red strip later if we want the two distinguished.
- Verified with `tsc --noEmit`, eslint, and prettier on the touched files, and manually on a local project whose Advocacy and Tone run carries a blocking error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)