### PR TITLE
feat(reference-downloader): surface agent messages in the eval transcript

### DIFF
--- a/evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py
+++ b/evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py
@@ -5,9 +5,10 @@ from typing import List, Optional
 from inspect_ai import Task, task
 from inspect_ai.agent import Agent, AgentState, agent
 from inspect_ai.dataset import Sample, json_dataset
-from inspect_ai.model import ModelOutput
+from inspect_ai.model import ChatMessage, ModelOutput
 from inspect_ai.scorer import CORRECT, INCORRECT, Score
 from inspect_ai.solver import TaskState
+from langchain_core.messages.utils import convert_to_messages
 from pydantic import BaseModel, Field
 
 from evals_inspectai.common.api_client import (
@@ -15,6 +16,7 @@ from evals_inspectai.common.api_client import (
     poll_workflow_run_until_complete,
     start_workflow,
 )
+from evals_inspectai.common.converters import messages_from_langchain
 from evals_inspectai.common.errors import WorkflowCompletionError
 from evals_inspectai.common.scorers import structured_output_scorer
 
@@ -105,6 +107,10 @@ def _reference_downloader_api_agent(
         workflow_state = run_detail.get("state") or {}
         _check_item_errors(workflow_state)
 
+        messages = _pop_agent_messages(workflow_state)
+        if messages:
+            state.messages = messages
+
         state.output = ModelOutput(
             completion=json.dumps(workflow_state),
             model="api",
@@ -112,6 +118,22 @@ def _reference_downloader_api_agent(
         return state
 
     return execute
+
+
+def _pop_agent_messages(workflow_state: dict) -> List[ChatMessage]:
+    """Remove per-reference agent messages from the state and convert them.
+
+    Messages are removed so the scored completion stays a compact JSON payload;
+    they are surfaced in the Inspect transcript via ``state.messages`` instead.
+    """
+    messages: List[ChatMessage] = []
+    for item in workflow_state.get("fetched_references", []):
+        if not isinstance(item, dict):
+            continue
+        raw_messages = item.pop("messages", None) or []
+        if raw_messages:
+            messages.extend(messages_from_langchain(convert_to_messages(raw_messages)))
+    return messages
 
 
 def _check_item_errors(workflow_state: dict) -> None:

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -2590,6 +2590,14 @@ export type ReferenceFetchResult = {
    * Error message, present on failure
    */
   error?: string | null;
+  /**
+   * Messages
+   *
+   * LLM conversation messages from the reference fetcher agent invocation.
+   */
+  messages?: Array<{
+    [key: string]: unknown;
+  }>;
 };
 
 /**

--- a/lib/workflows/reference_downloader/nodes/fetch_references.py
+++ b/lib/workflows/reference_downloader/nodes/fetch_references.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List
 
+from langchain_core.messages import BaseMessage
 from langgraph.runtime import Runtime
 from langgraph.types import Send
 
@@ -108,9 +109,12 @@ async def fetch_single_reference(state: dict, runtime: Runtime[ContextSchema]):
     result = None
     error = None
     status = ReferenceFetchStatus.COMPLETED
+    messages: List[BaseMessage] = []
 
     try:
-        result, _ = await agent.ainvoke(ReferenceFetcherAgentInput(reference=reference))
+        result, messages = await agent.ainvoke(
+            ReferenceFetcherAgentInput(reference=reference)
+        )
 
         if (
             result
@@ -155,6 +159,7 @@ async def fetch_single_reference(state: dict, runtime: Runtime[ContextSchema]):
                 status=status,
                 result=result,
                 error=error,
+                messages=messages,
             )
         ]
     }

--- a/lib/workflows/reference_downloader/state.py
+++ b/lib/workflows/reference_downloader/state.py
@@ -1,7 +1,8 @@
 from enum import Enum
 from typing import Annotated, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from langchain_core.messages import BaseMessage
+from pydantic import BaseModel, Field, field_serializer
 
 from lib.workflows.models import BaseWorkflowConfig, BaseWorkflowState, WorkflowRunType
 from lib.workflows.reference_downloader.agents.reference_fetcher import (
@@ -33,6 +34,17 @@ class ReferenceFetchResult(BaseModel):
     error: Optional[str] = Field(
         default=None, description="Error message, present on failure"
     )
+    messages: List[BaseMessage] = Field(
+        default_factory=list,
+        description="LLM conversation messages from the reference fetcher agent invocation.",
+    )
+
+    @field_serializer("messages")
+    @classmethod
+    def _serialize_messages(cls, messages: List[BaseMessage]) -> list[dict]:
+        # Checkpointer-hydrated states may contain raw dicts in `messages`
+        # because reducers can append items that bypass model construction.
+        return [m if isinstance(m, dict) else m.model_dump() for m in messages]
 
 
 def merge_fetch_results(


### PR DESCRIPTION
## Summary

The reference downloader eval showed no conversation in the Inspect AI transcript because the workflow discarded the fetcher agent's messages. This PR persists those messages on each fetched reference and surfaces them in the eval transcript, matching how the abbreviation scan, reviewer coverage report, and revision planning evals already work.

## Motivation

When a reference downloader eval sample fails, the only thing visible was the final structured output. Seeing the agent's web searches, download attempts, and file reads makes it possible to understand why a reference was or was not found.

## What's Changed

### Backend

- `lib/workflows/reference_downloader/state.py`: `ReferenceFetchResult` gains a `messages` list of LangChain messages, with the same `field_serializer` used by `ReferenceValidationV2Item` to handle checkpointer-hydrated dicts.
- `lib/workflows/reference_downloader/nodes/fetch_references.py`: `fetch_single_reference` keeps the messages returned by `ReferenceFetcherAgent.ainvoke` and stores them on the result instead of discarding them.
- `evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py`: the eval agent pops the per-reference messages from the workflow state, converts them with the shared `messages_from_langchain` helper, and sets them as `state.messages` so they appear in the transcript. They are removed from the scored JSON completion so it stays compact.

### Frontend

- `frontend/lib/generated-api/types.gen.ts`: regenerated to add the optional `messages` field on `ReferenceFetchResult`. Purely additive.

## Risks and Mitigations

- **Larger workflow state.** Per-reference messages are now persisted and returned from the API. This mirrors what reference validation v2 already does, and the `read_file_content` tool truncates output to 4000 characters, so growth per reference is bounded.
- **Serialization of hydrated state.** The serializer accepts both `BaseMessage` instances and raw dicts, the same pattern already proven in the other workflows.
- **Verification.** Full `mypy .` passes, the downloader unit tests and fetch-result removal test pass, the frontend type check passes, and a round-trip check confirmed user, assistant with tool calls, and tool messages survive JSON serialization and convert to the matching Inspect message types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)