### PR TITLE
feat(reference-downloader): log fetch outcomes and support JINA_API_KEY

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -56,3 +56,9 @@ FRONTEND_URL=http://localhost:3000
 # RATE_LIMITER_REQUESTS_PER_SECOND=2     # Average LLM rps cap (default: 2)
 # RATE_LIMITER_MAX_BUCKET_SIZE=1         # Max burst size, must be >= 1 (default: 1)
 # RATE_LIMITER_CHECK_EVERY_N_SECONDS=0.25 # Poll interval while blocking (default: 0.25)
+
+# Jina Reader (used by the reference downloader to turn web pages into markdown)
+# Optional. Anonymous requests are rate-limited per source IP (20/min) and may be
+# challenged by Cloudflare from datacenter addresses; a key lifts the limit to
+# 500/min and is tracked per key. Get one at https://jina.ai/api-dashboard
+# JINA_API_KEY=

--- a/lib/config/env.py
+++ b/lib/config/env.py
@@ -139,6 +139,15 @@ class Config(BaseModel):
         description="Per-model API key overrides. Keys are model names (e.g. Azure deployment IDs).",
     )
 
+    # Jina Reader (https://r.jina.ai) turns web pages into markdown for the
+    # reference downloader. Optional: without a key requests are anonymous, which
+    # Jina rate-limits per source IP and which Cloudflare may challenge for
+    # datacenter egress addresses. With a key, limits are tracked per key instead.
+    JINA_API_KEY: Optional[str] = Field(
+        default=None,
+        description="Jina AI API key sent as a bearer token to the Reader API. Optional.",
+    )
+
     # Rate limiter configuration (shared across workers via Postgres)
     RATE_LIMITER_REQUESTS_PER_SECOND: float = Field(
         default=2,
@@ -188,6 +197,7 @@ config = Config(
         os.getenv("RATE_LIMITER_CHECK_EVERY_N_SECONDS", "0.25")
     ),
     MODEL_API_KEYS=json.loads(os.getenv("MODEL_API_KEYS", "{}")),
+    JINA_API_KEY=os.getenv("JINA_API_KEY") or None,
     AZURE_CLIENT_ID=os.getenv("AZURE_CLIENT_ID"),
     AZURE_TENANT_ID=os.getenv("AZURE_TENANT_ID"),
     AZURE_CLIENT_SECRET=os.getenv("AZURE_CLIENT_SECRET"),

--- a/lib/workflows/reference_downloader/fetch_logging.py
+++ b/lib/workflows/reference_downloader/fetch_logging.py
@@ -1,0 +1,84 @@
+"""Log lines for the reference downloader: one per reference, one per run.
+
+Kept apart from the node so the node stays about control flow and this stays
+about what a person reading the log needs to see.
+"""
+
+import logging
+from collections import Counter
+from typing import List, Optional
+
+from langchain_core.messages import BaseMessage
+
+from lib.workflows.reference_downloader.agents.reference_fetcher import (
+    ReferenceFetchConclusion,
+    ReferenceFetchItem,
+)
+from lib.workflows.reference_downloader.state import (
+    ReferenceFetchResult,
+    ReferenceFetchStatus,
+)
+from lib.workflows.reference_downloader.tool_usage import summarize_tool_usage
+
+logger = logging.getLogger(__name__)
+
+# How much of a reference to echo in a log line: enough to recognise it, not the
+# whole bibliography entry.
+REFERENCE_LOG_CHARS = 120
+
+
+def short_reference(reference: str) -> str:
+    return reference[:REFERENCE_LOG_CHARS]
+
+
+def log_fetch_outcome(
+    reference: str,
+    result: Optional[ReferenceFetchItem],
+    messages: List[BaseMessage],
+) -> None:
+    """One line per reference saying what was concluded and what it took."""
+    usage = summarize_tool_usage(messages).describe()
+    if result is None:
+        logger.warning(
+            "Reference %r: agent returned no result (%s)",
+            short_reference(reference),
+            usage,
+        )
+        return
+
+    conclusion = result.final_conclusion.value
+    detail = (
+        f"conclusion={conclusion} source_url={result.source_url} "
+        f"file_id={result.file_id} {usage}"
+    )
+    if result.final_conclusion == ReferenceFetchConclusion.SOURCE_FOUND:
+        logger.info("Reference %r: %s", short_reference(reference), detail)
+        return
+
+    logger.warning(
+        "Reference %r: %s reason=%r",
+        short_reference(reference),
+        detail,
+        result.inaccessibility_reason,
+    )
+
+
+def log_run_summary(
+    project_id: str, fetched_references: List[ReferenceFetchResult]
+) -> None:
+    """Tally the run so the headline is readable without counting lines."""
+    outcomes: Counter[str] = Counter()
+    for item in fetched_references:
+        if item.status != ReferenceFetchStatus.COMPLETED:
+            outcomes[item.status.value] += 1
+        elif item.result is None:
+            outcomes["no_result"] += 1
+        else:
+            outcomes[item.result.final_conclusion.value] += 1
+    tally = ", ".join(f"{name}={count}" for name, count in sorted(outcomes.items()))
+    logger.info(
+        "Reference downloader summary for project %s: %d references (%s)",
+        project_id,
+        len(fetched_references),
+        tally,
+    )

--- a/lib/workflows/reference_downloader/nodes/fetch_references.py
+++ b/lib/workflows/reference_downloader/nodes/fetch_references.py
@@ -28,6 +28,11 @@ from lib.workflows.reference_downloader.state import (
     ReferenceFetchResult,
     ReferenceFetchStatus,
 )
+from lib.workflows.reference_downloader.fetch_logging import (
+    log_fetch_outcome,
+    log_run_summary,
+    short_reference,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,10 +51,18 @@ async def initialize_references(
     file.
     """
     references = state.config.references
+    source = "explicit config"
     if references is None:
+        source = "unmatched extracted references"
         references = await _load_unmatched_references(
             runtime.context.file_artifacts_service
         )
+    logger.info(
+        "Reference downloader for project %s: %d references to fetch (from %s)",
+        runtime.context.project_id,
+        len(references),
+        source,
+    )
 
     pending_results = [
         ReferenceFetchResult(
@@ -115,6 +128,7 @@ async def fetch_single_reference(state: dict, runtime: Runtime[ContextSchema]):
         result, messages = await agent.ainvoke(
             ReferenceFetcherAgentInput(reference=reference)
         )
+        log_fetch_outcome(reference, result, messages)
 
         if (
             result
@@ -122,6 +136,12 @@ async def fetch_single_reference(state: dict, runtime: Runtime[ContextSchema]):
             and result.file_id
         ):
             # Sometimes the LLM will return a file ID for a non-found reference, so we need to clean it up
+            logger.warning(
+                "Reference %r concluded %s but carried file_id %s; dropping the file id",
+                short_reference(reference),
+                result.final_conclusion.value,
+                result.file_id,
+            )
             result.file_id = None
 
         if status == ReferenceFetchStatus.COMPLETED and result and result.file_id:
@@ -147,7 +167,13 @@ async def fetch_single_reference(state: dict, runtime: Runtime[ContextSchema]):
             )
 
     except Exception as e:
-        logger.error(f"Error fetching reference '{reference}': {e}", exc_info=True)
+        logger.error(
+            "Error fetching reference %r: %s: %s",
+            short_reference(reference),
+            type(e).__name__,
+            e,
+            exc_info=True,
+        )
         status = ReferenceFetchStatus.ERROR
         error = str(e)
 
@@ -196,10 +222,15 @@ async def cleanup_failed_resources(
         else:
             files_to_delete.append(file_id)
 
+    log_run_summary(project_id, fetched_references)
+
     if files_to_delete:
         deleted_count = await delete_project_files(project_id, files_to_delete)
         logger.info(
-            f"Deleted {deleted_count} failed reference files for project {project_id}"
+            "Deleted %d unlinked candidate files for project %s: %s",
+            deleted_count,
+            project_id,
+            ", ".join(files_to_delete),
         )
         if deleted_count != len(files_to_delete):
             logger.warning(

--- a/lib/workflows/reference_downloader/tool_usage.py
+++ b/lib/workflows/reference_downloader/tool_usage.py
@@ -1,0 +1,103 @@
+"""Summarise what a reference-fetch agent run actually did, for the logs.
+
+A reference that ends as "not found" looks identical in the log whether the model
+never searched, searched and found nothing, or found a URL that the download tool
+could not fetch. This module reads the agent transcript back and counts each kind of
+step, so a single INFO line per reference can tell those cases apart.
+"""
+
+import json
+from typing import Any, Sequence
+
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+from pydantic import BaseModel, Field
+
+DOWNLOAD_TOOL_NAME = "download_file_from_url"
+READ_TOOL_NAME = "read_file_content"
+MAX_LOGGED_QUERIES = 8
+
+
+class ToolUsageSummary(BaseModel):
+    llm_calls: int = 0
+    model_names: list[str] = Field(default_factory=list)
+    web_searches: int = 0
+    pages_opened: int = 0
+    search_queries: list[str] = Field(default_factory=list)
+    download_attempts: int = 0
+    download_successes: int = 0
+    download_failures: int = 0
+    reads: int = 0
+
+    def describe(self) -> str:
+        """One line, grep-friendly, for the per-reference log record."""
+        queries = "; ".join(
+            q.replace("\n", " ") for q in self.search_queries[:MAX_LOGGED_QUERIES]
+        )
+        models = ",".join(self.model_names) or "unknown"
+        return (
+            f"llm_calls={self.llm_calls} model={models} "
+            f"web_searches={self.web_searches} pages_opened={self.pages_opened} "
+            f"downloads={self.download_attempts} "
+            f"(ok={self.download_successes} failed={self.download_failures}) "
+            f"reads={self.reads} queries=[{queries}]"
+        )
+
+
+def summarize_tool_usage(messages: Sequence[BaseMessage | dict]) -> ToolUsageSummary:
+    summary = ToolUsageSummary()
+    for message in messages:
+        if isinstance(message, AIMessage):
+            _count_ai_message(message, summary)
+        elif isinstance(message, ToolMessage):
+            _count_tool_message(message, summary)
+    return summary
+
+
+def _count_ai_message(message: AIMessage, summary: ToolUsageSummary) -> None:
+    summary.llm_calls += 1
+    model_name = message.response_metadata.get(
+        "model_name"
+    ) or message.response_metadata.get("model")
+    if model_name and model_name not in summary.model_names:
+        summary.model_names.append(str(model_name))
+    if not isinstance(message.content, list):
+        return
+    for block in message.content:
+        if isinstance(block, dict) and block.get("type") == "web_search_call":
+            _count_web_search_call(block, summary)
+
+
+def _count_web_search_call(block: dict[str, Any], summary: ToolUsageSummary) -> None:
+    action = block.get("action") or {}
+    action_type = action.get("type") if isinstance(action, dict) else None
+    if action_type == "open_page":
+        summary.pages_opened += 1
+        return
+    summary.web_searches += 1
+    query = action.get("query") if isinstance(action, dict) else None
+    if query:
+        summary.search_queries.append(str(query))
+
+
+def _count_tool_message(message: ToolMessage, summary: ToolUsageSummary) -> None:
+    if message.name == READ_TOOL_NAME:
+        summary.reads += 1
+        return
+    if message.name != DOWNLOAD_TOOL_NAME:
+        return
+    summary.download_attempts += 1
+    if _download_succeeded(message.content):
+        summary.download_successes += 1
+    else:
+        summary.download_failures += 1
+
+
+def _download_succeeded(content: Any) -> bool:
+    """The download tool returns `DownloadFileFromUrlResponse` as JSON."""
+    if not isinstance(content, str):
+        return False
+    try:
+        payload = json.loads(content)
+    except ValueError:
+        return "Successfully downloaded" in content
+    return isinstance(payload, dict) and bool(payload.get("success"))

--- a/lib/workflows/reference_downloader/tools/download_file_from_url.py
+++ b/lib/workflows/reference_downloader/tools/download_file_from_url.py
@@ -33,13 +33,29 @@ headers = {
     "Referer": "https://www.google.com/",
 }
 
-# 20 requests per 60 seconds (1 minute) is the free Jina API rate limit for requests without API key.
+# Jina Reader rate limits (requests per minute): 20 anonymously, per source IP;
+# 500 with an API key, per key. https://jina.ai/api-dashboard/rate-limit
+JINA_ANONYMOUS_RPM = 20
+JINA_AUTHENTICATED_RPM = 500
+
+
+def _jina_headers() -> dict[str, str]:
+    """Bearer auth when a key is configured; anonymous otherwise."""
+    if config.JINA_API_KEY:
+        return {"Authorization": f"Bearer {config.JINA_API_KEY}"}
+    return {}
+
+
+def _jina_rpm() -> int:
+    return JINA_AUTHENTICATED_RPM if config.JINA_API_KEY else JINA_ANONYMOUS_RPM
+
+
 # Backed by Postgres so the cap is enforced across all workers/pods, not per-worker.
 jina_rate_limiter = PostgresRateLimiter(
     bucket_key="jina-api",
-    requests_per_second=20 / 60,
+    requests_per_second=_jina_rpm() / 60,
     check_every_n_seconds=1.0,
-    max_bucket_size=20,
+    max_bucket_size=_jina_rpm(),
 )
 
 
@@ -79,17 +95,25 @@ async def _download_file_from_url_async(
     try:
         saved_file = await _download_direct_url(url)
     except httpx.HTTPError as exc:
-        logger.debug(f"Failed to download content from {url} (HTTP Error: {exc})")
+        # Includes connect errors and timeouts, so a blocked egress path shows up here.
+        logger.warning("Download failed for %s: %s: %s", url, type(exc).__name__, exc)
         return DownloadFileFromUrlResponse(
             file_id=None,
             message=f"Failed to download content from {url}. Error: {exc}",
             success=False,
         )
     except Exception as exc:
-        logger.error(f"Error downloading content from {url} (error: {exc})")
+        logger.error(
+            "Unexpected error downloading %s: %s: %s",
+            url,
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
         raise
 
     if saved_file is None:
+        logger.warning("Download of %s produced no file", url)
         return DownloadFileFromUrlResponse(
             file_id=None,
             message=f"Failed to download content from {url}: no file produced",
@@ -121,7 +145,7 @@ async def _download_direct_url(url: str) -> SavedFile | None:
 
         # Download the file and check content type
         async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
-            logger.debug(f"Downloading file from direct URL: {url}")
+            logger.info("Downloading %s", url)
             response = await client.get(url, follow_redirects=True)
             response.raise_for_status()
 
@@ -133,24 +157,52 @@ async def _download_direct_url(url: str) -> SavedFile | None:
                 content = response.content
 
                 if len(content) == 0:
-                    logger.warning(f"Downloaded file from url is empty: {url}")
+                    logger.warning("Downloaded PDF from %s is empty", url)
                     return None
 
                 filename = await _save_content(content, "pdf")
-                logger.debug(f"Successfully downloaded and saved PDF to: {filename}")
+                logger.info(
+                    "Saved PDF from %s (%d bytes, final URL %s) as %s",
+                    url,
+                    len(content),
+                    response.url,
+                    filename,
+                )
                 return SavedFile(filename=filename, content_type="application/pdf")
             else:
                 # Not a PDF, use Jina to convert to markdown
-                logger.debug(
-                    f"Content is not PDF (Content-Type: {content_type}), using Jina to convert to markdown"
+                logger.info(
+                    "Non-PDF content from %s (Content-Type %r, HTTP %d); converting via Jina",
+                    url,
+                    content_type or "missing",
+                    response.status_code,
                 )
                 return await _download_with_jina_api(url)
 
     except httpx.HTTPStatusError as exc:
-        logger.debug(
-            f"Error downloading content from {url}, falling back to Jina (HTTP status error: {exc})"
+        logger.warning(
+            "Direct fetch of %s failed (%s); falling back to Jina",
+            url,
+            _describe_http_error(exc),
         )
         return await _download_with_jina_api(url)
+
+
+def _describe_http_error(exc: httpx.HTTPStatusError) -> str:
+    """Status plus who answered and what they said.
+
+    A 403 from a corporate egress proxy, from a publisher's bot protection and from
+    r.jina.ai itself all reach the tool as the same exception; the `server` header
+    and the first line of the body are what tell them apart in the log.
+    """
+    response = exc.response
+    server = response.headers.get("server", "-")
+    via = response.headers.get("via", "-")
+    body = response.text[:200].replace("\n", " ") if response.text else ""
+    return (
+        f"HTTP {response.status_code} final_url={response.url} server={server!r} "
+        f"via={via!r} body={body!r}"
+    )
 
 
 def is_rate_limited(exc: BaseException) -> bool:
@@ -167,20 +219,41 @@ async def _download_with_jina_api(url: str) -> SavedFile | None:
     """Download content using Jina API and save as markdown. Returns SavedFile if successful, None otherwise."""
 
     await jina_rate_limiter.aacquire()
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        logger.debug(f"Downloading content with Jina API from URL: {url}")
-        response = await client.get(
-            f"https://r.jina.ai/{url}", follow_redirects=True
+    jina_url = f"https://r.jina.ai/{url}"
+    headers = _jina_headers()
+    logger.info(
+        "Fetching %s via Jina reader (%s)",
+        url,
+        "authenticated" if headers else "anonymous",
+    )
+    try:
+        async with httpx.AsyncClient(timeout=120.0, headers=headers) as client:
+            response = await client.get(jina_url, follow_redirects=True)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        # Logged here, before the caller collapses it into a generic failure, so the
+        # log says which hop failed: the publisher or r.jina.ai itself.
+        logger.warning("Jina reader failed for %s (%s)", url, _describe_http_error(exc))
+        raise
+    except httpx.HTTPError as exc:
+        # Timeouts often stringify to '', so name the exception class explicitly.
+        logger.warning(
+            "Jina reader failed for %s: %s: %s", url, type(exc).__name__, exc
         )
-        response.raise_for_status()
+        raise
 
-        markdown_content = response.text
-        if not markdown_content:
-            raise ValueError(f"Jina API returned empty content for {url}")
+    markdown_content = response.text
+    if not markdown_content:
+        raise ValueError(f"Jina API returned empty content for {url}")
 
-        filename = await _save_content(markdown_content, "md")
-        logger.debug(f"Successfully downloaded and saved markdown to {filename}")
-        return SavedFile(filename=filename, content_type="text/markdown")
+    filename = await _save_content(markdown_content, "md")
+    logger.info(
+        "Saved markdown from %s via Jina (%d chars) as %s",
+        url,
+        len(markdown_content),
+        filename,
+    )
+    return SavedFile(filename=filename, content_type="text/markdown")
 
 
 async def _persist_file_record(
@@ -266,8 +339,8 @@ async def _save_content(content: bytes | str, extension: str) -> str:
 
     # Skip if file already exists
     if os.path.exists(file_path):
-        logger.debug(
-            f"File with hash {xxhash} already exists at {file_path}, skipping download"
+        logger.info(
+            "Content with hash %s already exists at %s; reusing it", xxhash, file_path
         )
         return f"{xxhash}.{extension}"
 

--- a/lib/workflows/reference_downloader/tools/read_file_content.py
+++ b/lib/workflows/reference_downloader/tools/read_file_content.py
@@ -1,9 +1,15 @@
+import logging
+
 import aiofiles
 from langchain.tools import ToolRuntime, tool
 
 from lib.services.converters.markitdown import markitdown_converter
 from lib.services.files import get_file_by_id
 from lib.workflows.context import ContextSchema
+
+logger = logging.getLogger(__name__)
+
+MAX_CONTENT_CHARS = 4000
 
 
 @tool()
@@ -24,16 +30,34 @@ async def read_file_content(file_id: str, runtime: ToolRuntime[ContextSchema]):
 async def _read_file_content_async(file_id: str) -> str | None:
     file = await get_file_by_id(file_id)
     if file is None:
+        logger.warning("read_file_content: no file record for id %s", file_id)
         return None
 
     if file.file_type == "text/markdown":
         # If file is already markdown, read directly from disk, no need to convert
         content = await _read_file_directly(file.file_path)
-        return content[:4000] if content else None
+    else:
+        # Use markitdown for conversion of non-markdown files
+        content = await markitdown_converter.convert_to_markdown(file.file_path)
 
-    # Use markitdown for conversion of non-markdown files
-    markdown = await markitdown_converter.convert_to_markdown(file.file_path)
-    return markdown[:4000]
+    total_chars = len(content) if content else 0
+    if total_chars == 0:
+        logger.warning(
+            "read_file_content: file %s (%s, %s) produced no text",
+            file_id,
+            file.file_type,
+            file.file_path,
+        )
+        return None
+
+    logger.info(
+        "read_file_content: file %s (%s) has %d chars, returning first %d",
+        file_id,
+        file.file_type,
+        total_chars,
+        min(total_chars, MAX_CONTENT_CHARS),
+    )
+    return content[:MAX_CONTENT_CHARS]
 
 
 async def _read_file_directly(file_path: str) -> str:

--- a/tests/unit/workflows/reference_downloader/test_jina_auth.py
+++ b/tests/unit/workflows/reference_downloader/test_jina_auth.py
@@ -1,0 +1,23 @@
+"""JINA_API_KEY is optional: absent means anonymous, present means bearer auth."""
+
+from unittest.mock import patch
+
+from lib.workflows.reference_downloader.tools import download_file_from_url as dl
+
+
+def test_no_key_means_anonymous_and_low_rate_limit():
+    with patch.object(dl.config, "JINA_API_KEY", None):
+        assert dl._jina_headers() == {}
+        assert dl._jina_rpm() == dl.JINA_ANONYMOUS_RPM
+
+
+def test_empty_key_is_treated_as_absent():
+    with patch.object(dl.config, "JINA_API_KEY", ""):
+        assert dl._jina_headers() == {}
+        assert dl._jina_rpm() == dl.JINA_ANONYMOUS_RPM
+
+
+def test_key_becomes_bearer_header_and_raises_rate_limit():
+    with patch.object(dl.config, "JINA_API_KEY", "jina_secret"):
+        assert dl._jina_headers() == {"Authorization": "Bearer jina_secret"}
+        assert dl._jina_rpm() == dl.JINA_AUTHENTICATED_RPM

--- a/tests/unit/workflows/reference_downloader/test_tool_usage.py
+++ b/tests/unit/workflows/reference_downloader/test_tool_usage.py
@@ -1,0 +1,76 @@
+"""The per-reference log line is built from the agent transcript; pin what it counts."""
+
+import json
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from lib.workflows.reference_downloader.tool_usage import summarize_tool_usage
+
+
+def _download_result(success: bool) -> ToolMessage:
+    payload = {
+        "file_id": "f1" if success else None,
+        "message": "Successfully downloaded" if success else "Failed to download",
+        "success": success,
+    }
+    return ToolMessage(
+        content=json.dumps(payload),
+        name="download_file_from_url",
+        tool_call_id="c1",
+    )
+
+
+def test_summary_counts_searches_downloads_and_reads():
+    messages = [
+        HumanMessage(content="ref"),
+        AIMessage(
+            content=[
+                {
+                    "type": "web_search_call",
+                    "action": {"type": "search", "query": "q1"},
+                },
+                {
+                    "type": "web_search_call",
+                    "action": {"type": "open_page", "url": "u"},
+                },
+                {"type": "text", "text": "..."},
+            ],
+            response_metadata={"model_name": "gpt-5.6-terra-2026-07-09-global-aaif"},
+        ),
+        _download_result(success=False),
+        _download_result(success=True),
+        ToolMessage(content="text", name="read_file_content", tool_call_id="c2"),
+        AIMessage(
+            content="done",
+            response_metadata={"model_name": "gpt-5.6-terra-2026-07-09-global-aaif"},
+        ),
+    ]
+
+    summary = summarize_tool_usage(messages)
+
+    assert summary.llm_calls == 2
+    assert summary.model_names == ["gpt-5.6-terra-2026-07-09-global-aaif"]
+    assert summary.web_searches == 1
+    assert summary.pages_opened == 1
+    assert summary.search_queries == ["q1"]
+    assert summary.download_attempts == 2
+    assert summary.download_successes == 1
+    assert summary.download_failures == 1
+    assert summary.reads == 1
+    assert "web_searches=1" in summary.describe()
+    assert "downloads=2 (ok=1 failed=1)" in summary.describe()
+
+
+def test_summary_of_empty_transcript_is_all_zero():
+    summary = summarize_tool_usage([])
+    assert summary.llm_calls == 0
+    assert "model=unknown" in summary.describe()
+
+
+def test_non_json_download_result_falls_back_to_text_match():
+    message = ToolMessage(
+        content="Successfully downloaded content",
+        name="download_file_from_url",
+        tool_call_id="c",
+    )
+    assert summarize_tool_usage([message]).download_successes == 1


### PR DESCRIPTION
## Summary

Makes the reference downloader diagnosable from its logs and adds optional `JINA_API_KEY` support for the Jina Reader hop. No change to workflow behavior beyond logging and the outbound auth header.

## Motivation

On RAND's internal deploy the reference downloader found 6 of 31 references on a document where the public deploy finds about 27. The app log for that run showed 31 fetches completing with almost no detail: download failures were logged at DEBUG, so nothing explained why the agent gave up. An eval run against the RAND deploy showed 91 of 108 download attempts ending in HTTP 403 from `r.jina.ai` and the rest timing out, with the agent's web search working fine. Two things were needed: logs that name the failing hop and who answered, and a way to authenticate to Jina so requests are tracked per key rather than per egress IP.

## What's Changed

### Backend

- `lib/workflows/reference_downloader/tool_usage.py` (new): reads the agent transcript back and counts LLM calls, model name returned by the API, web searches and page opens with their queries, download attempts split into ok/failed, and reads. Produces one grep-friendly line.
- `lib/workflows/reference_downloader/fetch_logging.py` (new): per-reference outcome line (INFO when found, WARNING otherwise, with conclusion, source URL, file id, inaccessibility reason and the tool-usage digest) and a per-run tally by conclusion.
- `lib/workflows/reference_downloader/nodes/fetch_references.py`: logs how many references were queued and from where, calls the outcome and summary helpers, warns when a file id is dropped from a non-found conclusion, logs exception class names on errors, and lists deleted candidate file ids in cleanup.
- `lib/workflows/reference_downloader/tools/download_file_from_url.py`: INFO lines for each direct fetch, PDF save (size, final URL), Jina fallback (content type, status) and Jina save; WARNING on failures naming the hop (direct vs Jina), exception class, status, `server`/`via` headers and first 200 chars of the body. Adds `_jina_headers()` sending `Authorization: Bearer` when `JINA_API_KEY` is set, and sizes the shared Postgres rate limiter to 20/min anonymous or 500/min authenticated.
- `lib/workflows/reference_downloader/tools/read_file_content.py`: WARNING when the file record is missing or yields no text, INFO with file type and character counts otherwise.
- `lib/config/env.py`: optional `JINA_API_KEY` setting, empty treated as unset.
- `.env.template`: documents the new variable.
- Tests: `tests/unit/workflows/reference_downloader/test_tool_usage.py` and `test_jina_auth.py`.

### Frontend

No changes.

## Risks and Mitigations

- **Log volume.** Each reference now emits a handful of INFO lines and each failed download a WARNING. The reference downloader runs at most a few dozen references per run, so this is bounded; the per-run summary keeps the headline readable.
- **Body snippets in logs.** HTTP error bodies are truncated to 200 characters and only logged for failures; they are what distinguishes a Cloudflare challenge from a proxy block page from a publisher bot wall.
- **Rate limit sizing.** The Jina limiter is configured at import time from the key's presence, so a key added without restarting the pods keeps the anonymous limit until restart. Both limits match Jina's published tiers.
- **Key handling.** The key is only sent to `r.jina.ai` and never logged; the INFO line records only `authenticated` or `anonymous`. Verified locally against a real key: Jina returned 200 and `x-ratelimit-limit: 500`.
- **No behavior change without the key.** With `JINA_API_KEY` unset the request path is identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
