### PR TITLE
fix(workflow-cost): price OpenAI snapshot names by their alias

### DIFF
--- a/lib/services/workflow_cost/pricing.py
+++ b/lib/services/workflow_cost/pricing.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from decimal import Decimal
 from typing import Iterable, Optional
 
@@ -12,11 +13,35 @@ from lib.services.workflow_cost.catalog import CatalogEntry, ModelPricing, get_c
 logger = logging.getLogger(__name__)
 
 
-def _match_model(name: str, models: list[CatalogEntry]) -> Optional[ModelPricing]:
+# OpenAI reports the deployed snapshot in response metadata, not the alias that
+# was requested: asking for `gpt-5.6-terra` comes back as
+# `gpt-5.6-terra-2026-07-09-global-aaif`. Langfuse's managed price entries match
+# the bare alias only, so the snapshot name prices nothing. Anchoring on the date
+# keeps a genuinely different variant (`gpt-5.6-terra-mini`) from being priced
+# as the base model.
+_SNAPSHOT_SUFFIX = re.compile(r"-\d{4}-\d{2}-\d{2}(-.*)?$")
+
+
+def _first_match(name: str, models: list[CatalogEntry]) -> Optional[ModelPricing]:
     for pattern, model in models:
         if pattern.fullmatch(name):
             return model
     return None
+
+
+def _match_model(name: str, models: list[CatalogEntry]) -> Optional[ModelPricing]:
+    """Price `name` directly, or by its alias once a dated snapshot suffix is removed."""
+    model = _first_match(name, models)
+    if model is not None:
+        return model
+
+    alias = _SNAPSHOT_SUFFIX.sub("", name, count=1)
+    if alias == name:
+        return None
+    model = _first_match(alias, models)
+    if model is not None:
+        logger.debug("priced snapshot %r as its alias %r", name, alias)
+    return model
 
 
 def _rate(prices: dict[str, Decimal], *keys: str) -> Decimal:

--- a/tests/unit/services/test_workflow_cost.py
+++ b/tests/unit/services/test_workflow_cost.py
@@ -43,6 +43,12 @@ def _stub_models_cache(monkeypatch):
             output_price=1e-5,
             cache_read_price=1.25e-6,
         ),
+        _fake_entry(
+            "gpt-5.6-terra",
+            input_price=2e-6,
+            output_price=1.2e-5,
+            cache_read_price=2e-7,
+        ),
     ]
     monkeypatch.setattr(
         catalog,
@@ -204,6 +210,37 @@ async def test_compute_cost_unknown_model_skipped():
     records = walk_state_for_usage({"messages": [msg]})
     assert len(records) == 1
     assert await compute_cost(records) is None
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_prices_dated_snapshot_as_its_alias():
+    """OpenAI reports `gpt-5.6-terra-2026-07-09-global-aaif` for `gpt-5.6-terra`."""
+    msg = _ai_message(
+        input_tokens=100, output_tokens=50, model="gpt-5.6-terra-2026-07-09-global-aaif"
+    )
+    result = await compute_cost(walk_state_for_usage({"messages": [msg]}))
+    assert result is not None
+    assert result.input_cost_usd == Decimal("100") * Decimal("2e-6")
+    assert result.output_cost_usd == Decimal("50") * Decimal("1.2e-5")
+    # The breakdown keeps the name the provider actually reported.
+    assert list(result.by_model) == ["gpt-5.6-terra-2026-07-09-global-aaif"]
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_prices_bare_dated_snapshot():
+    msg = _ai_message(
+        input_tokens=10, output_tokens=0, model="gpt-5.6-terra-2026-07-09"
+    )
+    result = await compute_cost(walk_state_for_usage({"messages": [msg]}))
+    assert result is not None
+    assert result.input_cost_usd == Decimal("10") * Decimal("2e-6")
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_does_not_price_undated_variant_as_base_model():
+    """A `-mini` is a different model, not a snapshot; it must stay unpriced."""
+    msg = _ai_message(input_tokens=10, output_tokens=0, model="gpt-5.6-terra-mini")
+    assert await compute_cost(walk_state_for_usage({"messages": [msg]})) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The cost calculator now prices a dated OpenAI snapshot name by its alias when Langfuse has no entry for the snapshot itself. `gpt-5.6-terra-2026-07-09-global-aaif` resolves to the managed `gpt-5.6-terra` prices.

## Motivation

The RAND internal deployment logs this on essentially every LLM message:

```
lib.services.workflow_cost.pricing - WARNING - Langfuse has no pricing for model 'gpt-5.6-terra-2026-07-09-global-aaif'; skipping cost calc
```

OpenAI reports the deployed snapshot in response metadata rather than the alias we requested, and Langfuse's managed price entry for this model is an exact match on the bare alias (`(?i)^(openai/)?(gpt-5.6-terra)$`). Every agent runs on this model, so every usage record missed the catalog. The visible effect is worse than log noise: the cost breakdown came back empty and no assessment in that deployment showed a cost.

Verified against the live Langfuse catalog: 181 records, and none matched the production name before this change.

## What's Changed

### Backend

- `lib/services/workflow_cost/pricing.py`: `_match_model` tries the reported name first, then retries with a trailing `-YYYY-MM-DD...` suffix removed. The strip is anchored on the date so an undated variant such as `gpt-5.6-terra-mini` is not mispriced as the base model and still logs the warning. A successful fallback logs at debug level.
- `tests/unit/services/test_workflow_cost.py`: adds a `gpt-5.6-terra` fixture entry and three tests covering the exact production name, a bare dated snapshot, and an undated variant that must stay unpriced. The breakdown keeps the provider-reported name as its key.

### Frontend

No changes.

## Risks and Mitigations

- **Mispricing a different model as its base.** Only a dated suffix triggers the fallback, and the live catalog check confirms `gpt-5.6-terra-mini` still misses. A test locks this in.
- **Langfuse's own trace cost is unaffected.** Langfuse computes trace-level cost with the same exact-match pattern, so the Langfuse dashboard for the RAND project will keep showing no cost until a custom model definition with a suffix-tolerant pattern is added there. That is a Langfuse UI change, not a repo change.

Tests: both workflow-cost test files pass (32 tests). `uv run mypy .` is clean. Black applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)