### PR TITLE
refactor(frontend): draw the v2 app bar on every route and retire the old nav

### DIFF
--- a/frontend/components/chat/chat-assistant.tsx
+++ b/frontend/components/chat/chat-assistant.tsx
@@ -201,8 +201,8 @@ export function ChatAssistant() {
   });
 
   return (
-    // Full-bleed: fills the width and the viewport height below the nav (h-15 = 3.75rem).
-    <div className="flex h-[calc(100dvh-3.75rem)] w-full overflow-hidden bg-background">
+    // Full-bleed: fills the width and whatever height the shell leaves below the app bar.
+    <div className="flex min-h-0 w-full flex-1 overflow-hidden bg-background">
       <AssistantRuntimeProvider runtime={runtime}>
         {/* Dev-only inspector launcher (stripped from production builds). */}
         <DevToolsModal />

--- a/frontend/components/layout/application-shell.tsx
+++ b/frontend/components/layout/application-shell.tsx
@@ -1,22 +1,7 @@
 'use client';
 
-import { HelpCenter } from '@/components/help/help-center';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
-import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
-import { CircleHelp, LogInIcon, MenuIcon, XIcon } from 'lucide-react';
-import { useSession } from 'next-auth/react';
-import Link from 'next/link';
+import { AppBar } from '@/components/results/app-bar';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
-import { Button } from '../ui/button';
-import { MobileProfileMenu, ProfileDropdown } from './profile-dropdown';
-
-const navigation = [
-  { name: 'Projects', href: '/projects' },
-  // Chat is intentionally hidden from the nav but the /chat route stays available.
-  { name: 'About', href: '/about' },
-];
 
 /** Routes whose pages render the AppBar (or, for the add-in, no chrome at all) themselves. */
 const OWN_CHROME_ROUTES = ['/projects', '/share', '/addin'];
@@ -29,20 +14,14 @@ export interface ApplicationShellProps {
   children: React.ReactNode;
 }
 
+/**
+ * The application row over whichever page you are on. The home page, the
+ * project views and the add-in draw their own chrome edge to edge; every other
+ * page gets the same row here, so the furniture never changes between them.
+ */
 export function ApplicationShell({ children }: ApplicationShellProps) {
-  const session = useSession();
-  const isLoadingUser = session.status === 'loading';
-  const user = session.data?.user;
   const pathname = usePathname();
-  const [helpOpen, setHelpOpen] = useState(false);
 
-  const navigationWithCurrent = navigation.map((item) => ({
-    ...item,
-    current: pathname.startsWith(item.href),
-  }));
-
-  // The home page, the project views and the add-in draw their own chrome edge
-  // to edge, navigation included.
   if (rendersOwnChrome(pathname)) {
     return <>{children}</>;
   }
@@ -51,137 +30,15 @@ export function ApplicationShell({ children }: ApplicationShellProps) {
   const isFullBleed = pathname.startsWith('/chat');
 
   return (
-    <div className="min-h-full">
-      <Disclosure as="nav" className="border-b border-border bg-background">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="flex h-15 justify-between">
-            <div className="flex">
-              <div className="flex shrink-0 items-center">
-                <Link href="/" className="text-xl font-bold text-primary">
-                  Draft Detective
-                </Link>
-              </div>
-              <div className="hidden sm:-my-px sm:ml-6 sm:flex sm:space-x-8">
-                {navigationWithCurrent.map((item) => (
-                  <a
-                    key={item.name}
-                    href={item.href}
-                    aria-current={item.current ? 'page' : undefined}
-                    className={cn(
-                      item.current
-                        ? 'border-primary text-foreground'
-                        : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground',
-                      'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium text',
-                    )}
-                  >
-                    {item.name}
-                  </a>
-                ))}
-              </div>
-              <div className="hidden sm:ml-8 sm:flex sm:items-center">
-                <Button asChild size="sm" variant="outline">
-                  <Link href="/new">Start new project</Link>
-                </Button>
-              </div>
-            </div>
-            <div className="hidden sm:ml-6 sm:flex sm:items-center sm:gap-3">
-              {/* Beside the account menu, where the application's own controls
-                  live rather than the current page's. */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button variant="ghost" size="icon" onClick={() => setHelpOpen(true)} aria-label="Help">
-                    <CircleHelp />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Help</TooltipContent>
-              </Tooltip>
-
-              {user ? (
-                <ProfileDropdown user={user} />
-              ) : !isLoadingUser ? (
-                <Button asChild variant="outline">
-                  <Link href="/api/auth/signin">
-                    <LogInIcon className="w-4 h-4" />
-                    Sign in
-                  </Link>
-                </Button>
-              ) : null}
-            </div>
-            <div className="-mr-2 flex items-center sm:hidden">
-              {/* Mobile menu button */}
-              <DisclosureButton className="group relative inline-flex items-center justify-center rounded-md bg-background p-2 text-muted-foreground hover:bg-accent hover:text-foreground focus:outline-2 focus:outline-offset-2 focus:outline-primary">
-                <span className="absolute -inset-0.5" />
-                <span className="sr-only">Open main menu</span>
-                <MenuIcon aria-hidden="true" className="block size-6 group-data-open:hidden" />
-                <XIcon aria-hidden="true" className="hidden size-6 group-data-open:block" />
-              </DisclosureButton>
-            </div>
-          </div>
-        </div>
-
-        <DisclosurePanel className="sm:hidden">
-          <div className="space-y-1 pt-2 pb-3">
-            {navigationWithCurrent.map((item) => (
-              <DisclosureButton
-                key={item.name}
-                as="a"
-                href={item.href}
-                aria-current={item.current ? 'page' : undefined}
-                className={cn(
-                  item.current
-                    ? 'border-primary bg-primary/10 text-primary'
-                    : 'border-transparent text-muted-foreground hover:border-border hover:bg-accent hover:text-foreground',
-                  'block border-l-4 py-2 pr-4 pl-3 text-base font-medium',
-                )}
-              >
-                {item.name}
-              </DisclosureButton>
-            ))}
-          </div>
-          <div className="border-t border-border pt-4 pb-3">
-            <div className="px-4 pb-3">
-              <DisclosureButton
-                as="a"
-                href="/new"
-                className="block w-full rounded-md bg-primary px-3 py-2 text-center text-base font-medium text-primary-foreground hover:bg-primary/90"
-              >
-                Start new project
-              </DisclosureButton>
-            </div>
-            <div className="px-4 pb-3">
-              {/* The desktop cluster is hidden at this width, so the panel
-                  carries the same door. */}
-              <DisclosureButton
-                as="button"
-                onClick={() => setHelpOpen(true)}
-                className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-base font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
-              >
-                <CircleHelp className="size-5" />
-                Help
-              </DisclosureButton>
-            </div>
-            {user ? (
-              <MobileProfileMenu user={user} />
-            ) : !isLoadingUser ? (
-              <div className="px-4">
-                <DisclosureButton
-                  as="a"
-                  href="/api/auth/signin"
-                  className="block w-full rounded-md bg-primary px-3 py-2 text-center text-base font-medium text-primary-foreground hover:bg-primary/90"
-                >
-                  Sign in
-                </DisclosureButton>
-              </div>
-            ) : null}
-          </div>
-        </DisclosurePanel>
-      </Disclosure>
-
-      <main>{isFullBleed ? children : <div className="mx-auto max-w-7xl p-4 sm:px-6 lg:px-8">{children}</div>}</main>
-
-      {/* Outside the Disclosure: its panel unmounts when the menu closes, which
-          on mobile is the same click that asks for this dialog. */}
-      <HelpCenter open={helpOpen} onOpenChange={setHelpOpen} topic="assessments" />
+    <div className="bg-background text-foreground flex h-dvh flex-col">
+      <AppBar />
+      {isFullBleed ? (
+        <main className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</main>
+      ) : (
+        <main className="min-h-0 flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-7xl p-4 sm:px-6 lg:px-8">{children}</div>
+        </main>
+      )}
     </div>
   );
 }

--- a/frontend/components/layout/profile-dropdown.tsx
+++ b/frontend/components/layout/profile-dropdown.tsx
@@ -3,7 +3,7 @@
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
 import { UserRole } from '@/lib/generated-api';
 import { useUserMe } from '@/lib/hooks/use-user-me';
-import { DisclosureButton, Menu, MenuButton, MenuItem, MenuItems, MenuSection, MenuSeparator } from '@headlessui/react';
+import { Menu, MenuButton, MenuItem, MenuItems, MenuSection, MenuSeparator } from '@headlessui/react';
 import { ChevronDown } from 'lucide-react';
 import Image from 'next/image';
 import { ThemeToggle } from '../theme-toggle';
@@ -150,88 +150,5 @@ export function ProfileDropdown({
         )}
       </MenuItems>
     </Menu>
-  );
-}
-
-interface MobileProfileMenuProps {
-  user: User;
-}
-
-export function MobileProfileMenu({ user }: MobileProfileMenuProps) {
-  const { showExperimentalFeatures, setShowExperimentalFeatures, isUpdating } = useExperimentalFeatures();
-  const { data: userMe } = useUserMe();
-
-  return (
-    <>
-      <div className="flex items-center px-4">
-        <div className="shrink-0">
-          <Image
-            alt={user.name ?? 'User'}
-            src={user.image ?? 'https://ui-avatars.com/api/?name=' + user.name}
-            className="size-10 rounded-full outline -outline-offset-1 outline-black/5"
-            width={40}
-            height={40}
-          />
-        </div>
-        <div className="ml-3">
-          <div className="text-base font-medium text-foreground">{user.name}</div>
-          <div className="text-sm font-medium text-muted-foreground">{user.email}</div>
-        </div>
-      </div>
-      <div className="mt-3 space-y-1">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <label className="flex items-center justify-between px-4 py-2 text-base font-medium text-muted-foreground cursor-pointer">
-                <span>Alpha features</span>
-                <Switch
-                  checked={showExperimentalFeatures}
-                  onCheckedChange={setShowExperimentalFeatures}
-                  disabled={isUpdating}
-                />
-              </label>
-            </TooltipTrigger>
-            <TooltipContent side="left" className="max-w-xs">
-              Enable early access to new features that are still in development. These may be unstable or change without
-              notice.
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        <label className="flex items-center justify-between px-4 py-2 text-base font-medium text-muted-foreground cursor-pointer">
-          <span>Dark mode</span>
-          <ThemeToggle />
-        </label>
-        <div className="my-2 h-px bg-border mx-4" />
-        {userNavigation.map((item) => (
-          <DisclosureButton
-            key={item.name}
-            as="a"
-            href={item.href}
-            className="block px-4 py-2 text-base font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            {item.name}
-          </DisclosureButton>
-        ))}
-
-        {userMe?.role === UserRole.Admin && (
-          <>
-            <div className="px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-              Admin only
-            </div>
-            {adminNavigation.map((item) => (
-              <DisclosureButton
-                key={item.name}
-                as="a"
-                href={item.href}
-                className="block px-4 py-2 text-base font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
-              >
-                {item.name}
-              </DisclosureButton>
-            ))}
-            <div className="my-2 h-px bg-border mx-4" />
-          </>
-        )}
-      </div>
-    </>
   );
 }


### PR DESCRIPTION
## Summary

Every page now sits under the v2 `AppBar`. The start-project wizard, About, Settings, MCP, Chat and the admin pages were still framed by the v1 Disclosure nav inside `ApplicationShell`; that nav is deleted and the shell renders the `AppBar` for them instead.

## Motivation

The v1 to v2 layout migration moved home, the projects list and the project views onto the `AppBar`, but left the shell's old nav in place for the secondary routes. Going from the projects list into the start-project wizard swapped the whole header, which read as two different apps. Now the furniture is identical across routes.

## What's Changed

### Frontend

- `frontend/components/layout/application-shell.tsx`: removed the Disclosure nav, its mobile hamburger panel and the help-centre wiring (the `AppBar` carries its own). For every route that does not draw its own chrome, the shell renders the `AppBar` over a full-height flex column with the existing centred content container. Chat keeps its full-bleed layout inside that column.
- `frontend/components/chat/chat-assistant.tsx`: the chat root fills the space the shell leaves (`flex-1 min-h-0`) instead of subtracting the old nav's fixed height with `calc(100dvh - 3.75rem)`, which no longer matched anything.
- `frontend/components/layout/profile-dropdown.tsx`: removed `MobileProfileMenu` and the `DisclosureButton` import. It only rendered inside the old nav's mobile panel and had no other callers.

### Backend

No changes.

## Risks and Mitigations

- **Mobile affordance on secondary pages.** The old nav had a hamburger menu with links, help and the account menu. The `AppBar` has no mobile variant, so on narrow screens About, Settings, MCP, Chat and the admin pages now show the same compact bar the projects list already shows. This is consistent with the rest of the app, but it is a small change in mobile behaviour worth a glance.
- **Chat height.** Chat's height is now derived from the flex column rather than a viewport calculation. This was not checked visually; please open `/chat` and confirm the thread list and composer fill the viewport below the bar without a page scrollbar.
- **Verification.** `tsc --noEmit`, eslint and prettier pass. Checked `/about` and `/new` locally against a dev server: the v2 bar markup renders and none of the old nav markup remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
