### PR TITLE
feat(chat): offer only the gpt-5.6 terra, luna and sol models

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -74,11 +74,6 @@ export async function POST(req: Request): Promise<Response> {
     return Response.json({ error: 'OPENAI_API_KEY is not configured on the server.' }, { status: 500 });
   }
 
-  // Ask reasoning-capable models (gpt-5.x) for summarized reasoning so the
-  // chain-of-thought UI can display it. gpt-4.1 is not a reasoning model, so
-  // the Responses API would reject the option — only send it when supported.
-  const isReasoningModel = chatModel.id.startsWith('gpt-5');
-
   const result = streamText({
     model: openai(chatModel.id),
     // Fixed Draft Detective persona + skill catalog; not overridable by the client.
@@ -92,7 +87,9 @@ export async function POST(req: Request): Promise<Response> {
     },
     // Let the model call tools and then continue with its answer in the same request.
     stopWhen: stepCountIs(10),
-    ...(isReasoningModel ? { providerOptions: { openai: { reasoningSummary: 'auto' } } } : {}),
+    // Every offered model is reasoning-capable; ask for summarized reasoning so
+    // the chain-of-thought UI can display it.
+    providerOptions: { openai: { reasoningSummary: 'auto' } },
   });
 
   // Stream the full event stream (reasoning, tool calls, tool results, text) as

--- a/frontend/lib/chat-models.ts
+++ b/frontend/lib/chat-models.ts
@@ -3,8 +3,8 @@
  *
  * This module is intentionally free of any AI SDK / component imports so it can
  * be shared between the client (model selector) and the server (`/api/chat`
- * route). The list mirrors the OpenAI models the backend exposes in
- * `lib/config/llm_models.py`.
+ * route). Only the gpt-5.6 tier is offered; terra is the default because it is
+ * the model every backend agent runs on (see `lib/config/llm_models.py`).
  */
 
 export interface ChatModel {
@@ -13,13 +13,12 @@ export interface ChatModel {
 }
 
 export const CHAT_MODELS: ChatModel[] = [
-  { id: 'gpt-5.5', name: 'GPT-5.5' },
-  { id: 'gpt-5.4', name: 'GPT-5.4' },
-  { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini' },
-  { id: 'gpt-4.1', name: 'GPT-4.1' },
+  { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra' },
+  { id: 'gpt-5.6-luna', name: 'GPT-5.6 Luna' },
+  { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol' },
 ];
 
-export const DEFAULT_MODEL_ID = 'gpt-5.5';
+export const DEFAULT_MODEL_ID = 'gpt-5.6-terra';
 
 export function getChatModel(id: string): ChatModel | undefined {
   return CHAT_MODELS.find((model) => model.id === id);


### PR DESCRIPTION
## Summary

Trims the `/chat` model picker to the GPT-5.6 tier (Terra, Luna, Sol) and removes GPT-5.5, GPT-5.4, GPT-5.4 Mini and GPT-4.1. Terra becomes the default.

## Motivation

Every backend agent moved to `gpt-5.6-terra` on 28 Aug 2026, but the chat page still offered the superseded gpt-5.4/5.5 tiers plus gpt-4.1. Aligning the picker with the 5.6 tier keeps the chat experience consistent with the rest of the product and stops users from picking models we no longer evaluate against.

## What's Changed

### Frontend

- `frontend/lib/chat-models.ts`: replaced the registry with `gpt-5.6-terra`, `gpt-5.6-luna` and `gpt-5.6-sol`; default is now terra. The server-side allowlist reads from this list, so stale model ids from old clients fall back to terra.
- `frontend/app/api/chat/route.ts`: removed the per-model reasoning guard. It only existed to skip the `reasoningSummary` option for gpt-4.1, which is no longer selectable, so the option is now always sent.

### Backend

No changes.

## Risks and Mitigations

- **Luna and Sol ids are inferred.** Only terra appears in the repo, so `gpt-5.6-luna` and `gpt-5.6-sol` follow its naming pattern. If the provider uses different identifiers, the fix is a one-line edit in the registry.
- **Reasoning option is now unconditional.** All three offered models are reasoning models, and the route's allowlist prevents any other model from reaching the call.
- The chat title generator still uses gpt-4.1 as an internal, non-selectable call and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)