### PR TITLE
docs(help): add sharing topic to the help center

### DIFF
--- a/frontend/components/help/topics.ts
+++ b/frontend/components/help/topics.ts
@@ -3,6 +3,7 @@ import {
   CircleAlert,
   FileText,
   History,
+  Link2,
   ListChecks,
   LucideIcon,
   MessagesSquare,
@@ -15,6 +16,7 @@ import { IssuesTopic } from './topics/issues';
 import { PeerReviewTopic } from './topics/peer-review';
 import { ReferencesTopic } from './topics/references';
 import { RevisionsTopic } from './topics/revisions';
+import { SharingTopic } from './topics/sharing';
 import { SourceFilesTopic } from './topics/source-files';
 
 export type HelpTopicId =
@@ -23,6 +25,7 @@ export type HelpTopicId =
   | 'references'
   | 'source-files'
   | 'revisions'
+  | 'sharing'
   | 'peer-review'
   | 'feedback';
 
@@ -59,9 +62,9 @@ export interface HelpTopic {
 /**
  * The concepts the app explains in one place, ordered as the work runs:
  * assessments produce issues, references name sources, one assessment needs
- * those sources, revisions are what all of it hangs from, peer review is what
- * happens once someone else has read the draft, and feedback is how any of it
- * gets better. Every "what is this" link
+ * those sources, revisions are what all of it hangs from, sharing is how the
+ * draft reaches someone else, peer review is what happens once they have read
+ * it, and feedback is how any of it gets better. Every "what is this" link
  * in the product opens this list at one of them, so a question asked in one
  * corner is answered next to all the others.
  */
@@ -106,6 +109,14 @@ export const HELP_TOPICS: HelpTopic[] = [
     description: 'Each draft you upload becomes a revision. The ones before it stay, with everything they found.',
     icon: History,
     Body: RevisionsTopic,
+  },
+  {
+    id: 'sharing',
+    label: 'Sharing',
+    title: 'Sharing a project by link',
+    description: 'A public, read-only link to your project. Anyone holding it can look; only you can change anything.',
+    icon: Link2,
+    Body: SharingTopic,
   },
   {
     id: 'peer-review',

--- a/frontend/components/help/topics/sharing.tsx
+++ b/frontend/components/help/topics/sharing.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { Check, EllipsisVertical, Eye, Link2, Link2Off, LucideIcon, X } from 'lucide-react';
+import { ReactNode } from 'react';
+import { SectionTitle, TopicLink } from '../help-primitives';
+import { HelpTopicBodyProps } from '../topics';
+
+interface Ability {
+  can: boolean;
+  text: string;
+}
+
+/** What creating a link sets in motion, in the order it happens. */
+const STEPS: { icon: LucideIcon; title: string; body: string }[] = [
+  {
+    icon: EllipsisVertical,
+    title: 'Open the project menu and choose “Share this project”',
+    body: 'The three-dot button at the right of the project header. Nothing is shared yet; the dialog only asks whether you want a link.',
+  },
+  {
+    icon: Link2,
+    title: '“Enable Sharing” creates the link',
+    body: 'A unique address for this project, ready to copy. From then on the header shows a green “Sharing enabled” badge, and clicking it brings the dialog back.',
+  },
+  {
+    icon: Eye,
+    title: '“Preview” opens what readers get',
+    body: 'The same page they will see, with a banner along the top reminding you that this is the shared version and a button back to the editable one.',
+  },
+];
+
+/**
+ * The link says who a reader is, so this is the one place where being logged in
+ * grants nothing: the list is written from the reader's side, and it is the same
+ * whoever holds the link.
+ */
+const READER_ABILITIES: Ability[] = [
+  { can: true, text: 'Read the document, with every issue anchored where it was found' },
+  { can: true, text: 'Browse the assessments, their results, and the references' },
+  { can: true, text: 'Download the uploaded files, and the Export with the issues as Word comments' },
+  { can: false, text: 'Run an assessment, upload a revision, or edit the project details' },
+  { can: false, text: 'Resolve or rate an issue, or see any rating you have given' },
+  { can: false, text: 'Reach an earlier revision: the link always shows the current one' },
+];
+
+/**
+ * What a share link is, what it gives away, and how to take it back. The
+ * worry underneath is always the same: who can see my draft now? So the answer
+ * leads. Anyone holding the link, nobody else, and only for as long as you leave
+ * it on.
+ */
+export function SharingTopic({ onOpenTopic }: HelpTopicBodyProps) {
+  return (
+    <div className="space-y-5">
+      <section>
+        <SectionTitle>One link, read-only</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          A project is private until you share it. Sharing creates a{' '}
+          <strong className="text-foreground font-medium">public link that anyone can open</strong>, with or without a
+          Draft Detective account. It shows the project as you see it, minus everything that would change it: a reader
+          can look at the draft and every finding, and can touch none of it.
+        </p>
+
+        <div className="mt-2 overflow-hidden rounded-md border">
+          <div className="flex items-center gap-2 border-b px-3 py-2">
+            <span className="min-w-0 flex-1 truncate rounded border bg-background/60 px-2 py-1 font-mono text-[11px] text-muted-foreground">
+              https://…/share/kQ3vX9mB2pLw7RtYcN4eZg
+            </span>
+            <span className="bg-primary text-primary-foreground shrink-0 rounded p-1" aria-hidden>
+              <Check className="size-3" />
+            </span>
+            <span className="text-xs text-green-600 dark:text-green-400">Copied</span>
+          </div>
+          <div className="flex items-center gap-2 px-3 py-2">
+            <span className="rounded border border-green-200 bg-green-50 px-1.5 py-0.5 text-[10px] font-medium text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-300">
+              <Link2 className="mr-1 inline size-3 align-[-0.15em]" aria-hidden />
+              Sharing enabled
+            </span>
+            <span className="text-xs text-muted-foreground">What the header shows while a link exists.</span>
+          </div>
+        </div>
+
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          The address ends in a long random code that cannot be guessed, so the link itself is the key. Whoever you send
+          it to can send it on, and nobody is told when it is opened.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Creating one</SectionTitle>
+        <div className="space-y-2">
+          {STEPS.map((step) => (
+            <Step key={step.title} icon={step.icon} title={step.title}>
+              {step.body}
+            </Step>
+          ))}
+        </div>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          Only the person whose project it is can share it. Each project has its own link, and sharing one says nothing
+          about the others.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>What a reader can and can&apos;t do</SectionTitle>
+        <ul className="space-y-1.5">
+          {READER_ABILITIES.map((ability) => (
+            <li key={ability.text} className="flex gap-1.5 text-xs leading-relaxed">
+              {ability.can ? (
+                <Check className="mt-0.5 size-3 shrink-0 text-green-600 dark:text-green-400" aria-hidden />
+              ) : (
+                <X className="mt-0.5 size-3 shrink-0 text-muted-foreground" aria-hidden />
+              )}
+              <span className={ability.can ? 'text-foreground/80' : 'text-muted-foreground'}>{ability.text}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          The page is live, not a snapshot. Resolve an{' '}
+          <TopicLink to="issues" onOpenTopic={onOpenTopic}>
+            issue
+          </TopicLink>
+          , run another assessment, or upload a{' '}
+          <TopicLink to="revisions" onOpenTopic={onOpenTopic}>
+            revision
+          </TopicLink>
+          , and the link shows the new state the next time it is opened. Your own ratings are the exception: the thumbs
+          never appear on a shared page, whoever is looking, so previewing your link shows you exactly what a reader
+          gets.
+        </p>
+      </section>
+
+      <section>
+        <SectionTitle>Turning it off</SectionTitle>
+        <p className="text-foreground/80 leading-relaxed">
+          Open the share dialog again, from the badge or the menu, and choose{' '}
+          <strong className="text-foreground font-medium">Disable</strong>.{' '}
+          <strong className="text-foreground font-medium">Every copy of the link stops working at once</strong>; anyone
+          opening it sees only that the link was not found. Your project is untouched.
+        </p>
+        <div className="mt-2 flex items-start gap-2 rounded-md border p-2.5">
+          <Link2Off className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <div className="min-w-0">
+            <p className="text-xs font-medium">Re-enabling creates a new address</p>
+            <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+              The old one stays dead. Turning sharing off and on again is how you cut off everyone who had the link
+              while keeping the project shareable.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <SectionTitle>Where else sharing comes up</SectionTitle>
+        <ul className="space-y-1.5">
+          <Fact term="Export to Word">
+            The download offers to add a link to each comment, pointing at that issue on the shared page. Ticking it
+            turns sharing on, exactly as the dialog would, because the links are useless otherwise.
+          </Fact>
+          <Fact
+            term={
+              <TopicLink to="feedback" onOpenTopic={onOpenTopic}>
+                Feedback visibility
+              </TopicLink>
+            }
+          >
+            A different setting. It decides what Draft Detective&apos;s administrators may see of your project when you
+            rate a finding, and has nothing to do with the link. Sharing a project does not share your feedback, and
+            sharing your feedback creates no link.
+          </Fact>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function Step({ icon: Icon, title, children }: { icon: LucideIcon; title: string; children: ReactNode }) {
+  return (
+    <div className="flex gap-2.5 rounded-md border p-2.5">
+      <Icon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <div className="min-w-0">
+        <p className="text-xs font-medium">{title}</p>
+        <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function Fact({ term, children }: { term: ReactNode; children: ReactNode }) {
+  return (
+    <li className="text-xs leading-relaxed">
+      <strong className="font-medium">{term}.</strong> <span className="text-muted-foreground">{children}</span>
+    </li>
+  );
+}

--- a/frontend/components/share/share-dialog.tsx
+++ b/frontend/components/share/share-dialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { HelpLink } from '@/components/help/help-link';
 import { Input } from '@/components/ui/input';
 import { ShareStatusResponse } from '@/lib/generated-api';
 import { Check, Copy, ExternalLink, Loader2 } from 'lucide-react';
@@ -113,7 +114,8 @@ export function ShareDialog({
           <DialogDescription>
             {isEnabled
               ? 'Anyone with this link can view a read-only version of your project.'
-              : 'Create a public link that anyone can use to view this project.'}
+              : 'Create a public link that anyone can use to view this project.'}{' '}
+            <HelpLink topic="sharing">What can they see?</HelpLink>
           </DialogDescription>
         </DialogHeader>
 


### PR DESCRIPTION
## Summary

Adds a "Sharing" topic to the in-app help center that explains the public share link, and links to it from the share dialog.

## Motivation

The share dialog says a link is "read-only" and "public" but never spells out what that means: who can open it, what they see, whether it goes stale, and how to revoke it. Those are the questions people hesitate on before enabling sharing. Every other core concept already has a help center topic; sharing did not.

## What's Changed

### Frontend

- `frontend/components/help/topics/sharing.tsx` (new): the topic body. Covers what a share link is, the steps to create one, a can/can't list for readers, how disabling works (every copy dies at once, re-enabling mints a new address), and how sharing relates to the Word export's "add links to comments" option and to Feedback Visibility. Cross-links to the Issues, Revisions, and Feedback topics.
- `frontend/components/help/topics.ts`: registers the topic between Revisions and Peer Review with a `Link2` icon, adds `'sharing'` to `HelpTopicId`, and updates the ordering comment.
- `frontend/components/share/share-dialog.tsx`: appends a "What can they see?" help link to the dialog description, so the explanation is one click from where the decision is made.

### Backend

No changes.

## Risks and Mitigations

- **Copy drifting from behaviour.** Every claim was checked against the code: owner-only enable (write access required), unauthenticated public endpoint, no middleware redirect on `/share`, feedback never loaded on the share route, `disable_sharing` deactivating all active links, `enable_sharing` creating a fresh token, and the DOCX export enabling sharing for `comments-with-links`.
- **Nested dialog.** `HelpLink` opens the help center dialog from inside the share dialog. It already does this from other dialogs and rows, and it stops click propagation, so the share dialog is unaffected.
- **Verification.** `tsc --noEmit` and `eslint` pass. Checked visually on a local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)