### PR TITLE
feat(explorer): link issues to their assessment via a routable assessments tab

### DIFF
--- a/frontend/app/(authenticated)/projects/[projectId]/analyses/[workflowType]/page.tsx
+++ b/frontend/app/(authenticated)/projects/[projectId]/analyses/[workflowType]/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { AssessmentsPanel } from '@/components/results/assessments-panel';
+
+/** One assessment, named by the route; the panel reads it from the URL. */
+export default function Page() {
+  return <AssessmentsPanel />;
+}

--- a/frontend/app/(authenticated)/projects/[projectId]/layout.tsx
+++ b/frontend/app/(authenticated)/projects/[projectId]/layout.tsx
@@ -16,7 +16,8 @@ export default function ProjectLayout({ children }: { children: ReactNode }) {
   const params = useParams();
   const projectId = params.projectId as string;
 
-  const { activeTab, onTabChange } = useTabRouting(`/projects/${projectId}`);
+  const basePath = `/projects/${projectId}`;
+  const { activeTab, onTabChange } = useTabRouting(basePath);
 
   const {
     project,
@@ -84,6 +85,7 @@ export default function ProjectLayout({ children }: { children: ReactNode }) {
   return (
     <ProjectShell
       projectDetail={project}
+      basePath={basePath}
       activeTab={activeTab}
       onTabChange={onTabChange}
       readOnly={readOnly}

--- a/frontend/app/share/[token]/analyses/[workflowType]/page.tsx
+++ b/frontend/app/share/[token]/analyses/[workflowType]/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { AssessmentsPanel } from '@/components/results/assessments-panel';
+
+/** One assessment, named by the route; the panel reads it from the URL. */
+export default function Page() {
+  return <AssessmentsPanel />;
+}

--- a/frontend/app/share/[token]/layout.tsx
+++ b/frontend/app/share/[token]/layout.tsx
@@ -16,7 +16,8 @@ export default function SharedProjectLayout({ children }: { children: ReactNode 
   const params = useParams();
   const token = params.token as string;
 
-  const { activeTab, onTabChange } = useTabRouting(`/share/${token}`);
+  const basePath = `/share/${token}`;
+  const { activeTab, onTabChange } = useTabRouting(basePath);
   const { data: currentUser } = useUserMe();
 
   const { data, isLoading, error } = useQuery({
@@ -51,6 +52,7 @@ export default function SharedProjectLayout({ children }: { children: ReactNode 
     <ShareProvider token={token}>
       <ProjectShell
         projectDetail={data}
+        basePath={basePath}
         readOnly
         activeTab={activeTab}
         onTabChange={onTabChange}

--- a/frontend/components/results/assessments/use-workflow-selection.ts
+++ b/frontend/components/results/assessments/use-workflow-selection.ts
@@ -1,7 +1,10 @@
+import { parseWorkflowRunType } from '@/components/results/constants';
+import { useProjectView } from '@/components/results/project-view-context';
 import { getProjectWorkflowRunsByTypeEndpointApiProjectProjectIdWorkflowRunsGet } from '@/lib/generated-api';
 import type { WorkflowRunDetail, WorkflowRunType } from '@/lib/generated-api';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useMemo } from 'react';
 
 interface UseWorkflowSelectionParams {
   projectId: string;
@@ -15,16 +18,27 @@ interface UseWorkflowSelectionParams {
   defaultWorkflowType?: WorkflowRunType | null;
 }
 
+/**
+ * Which assessment the tab shows, read from the URL: `/analyses/<type>` names
+ * the assessment and `?run=<id>` one run of it. Being in the URL is what lets
+ * an issue in the document explorer link to the report it came from, and what
+ * makes a selection survive a reload or a shared link.
+ */
 export function useWorkflowSelection({
   projectId,
   workflowDetails,
   shareToken,
   defaultWorkflowType = null,
 }: UseWorkflowSelectionParams) {
-  const [pickedWorkflowType, setPickedWorkflowType] = useState<WorkflowRunType | null>(null);
-  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const params = useParams<{ workflowType?: string }>();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { assessmentHref } = useProjectView();
 
-  const selectedWorkflowType = pickedWorkflowType ?? defaultWorkflowType;
+  const routedWorkflowType = parseWorkflowRunType(params.workflowType);
+  const selectedWorkflowType = routedWorkflowType ?? defaultWorkflowType;
+  // The run only means something for the assessment it belongs to.
+  const selectedRunId = routedWorkflowType ? searchParams.get('run') : null;
 
   const mainRequestWorkflow = selectedWorkflowType
     ? workflowDetails.find((w) => w.run.type === selectedWorkflowType)
@@ -63,12 +77,11 @@ export function useWorkflowSelection({
   }, [selectedWorkflowType, selectedRunId, historyData, mainRequestWorkflow]);
 
   const handleSelectWorkflowType = (workflowType: WorkflowRunType) => {
-    setPickedWorkflowType(workflowType);
-    setSelectedRunId(null);
+    router.push(assessmentHref(workflowType));
   };
 
   const handleSelectRun = (run: WorkflowRunDetail) => {
-    setSelectedRunId(run.run.id);
+    router.push(assessmentHref(run.run.type, run.run.id));
   };
 
   return {

--- a/frontend/components/results/constants.ts
+++ b/frontend/components/results/constants.ts
@@ -1,3 +1,5 @@
+import { WorkflowRunType } from '@/lib/generated-api';
+
 export const TABS = ['document-explorer', 'references', 'files', 'analyses', 'peer-review'] as const;
 
 export type TabType = (typeof TABS)[number];
@@ -13,8 +15,28 @@ export function tabHref(basePath: string, tab: TabType): string {
   return tab === ROOT_TAB ? basePath : `${basePath}/${tab}`;
 }
 
-/** Resolve the active tab from a pathname under `basePath`. */
+/**
+ * Resolve the active tab from a pathname under `basePath`. Only the first
+ * segment names the tab; anything after it belongs to the tab, like the
+ * assessment at `/analyses/results_extraction`.
+ */
 export function tabFromPathname(pathname: string, basePath: string): TabType {
-  const suffix = pathname.slice(basePath.length).replace(/^\//, '').replace(/\/$/, '');
-  return TABS.find((tab) => tab === suffix) ?? ROOT_TAB;
+  const [first = ''] = pathname.slice(basePath.length).replace(/^\//, '').split('/');
+  return TABS.find((tab) => tab === first) ?? ROOT_TAB;
+}
+
+/**
+ * Route for one assessment on the assessments tab, optionally a particular run
+ * of it (`?run=`), so an issue elsewhere can point at the report it came from.
+ */
+export function assessmentHref(basePath: string, workflowType: WorkflowRunType, runId?: string | null): string {
+  const base = `${tabHref(basePath, 'analyses')}/${workflowType}`;
+  return runId ? `${base}?run=${encodeURIComponent(runId)}` : base;
+}
+
+const WORKFLOW_RUN_TYPES: ReadonlySet<string> = new Set(Object.values(WorkflowRunType));
+
+/** The route segment as a workflow type, or null for anything else (an old or mistyped URL). */
+export function parseWorkflowRunType(segment: string | string[] | undefined): WorkflowRunType | null {
+  return typeof segment === 'string' && WORKFLOW_RUN_TYPES.has(segment) ? (segment as WorkflowRunType) : null;
 }

--- a/frontend/components/results/document-explorer/issue-note.tsx
+++ b/frontend/components/results/document-explorer/issue-note.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Markdown } from '@/components/markdown';
+import { useProjectView } from '@/components/results/project-view-context';
 import { feedbackLabel, IssueFeedbackButtons } from '@/components/results/components/document-issue-card';
 import {
   useCanSubmitIssueFeedback,
@@ -16,6 +17,7 @@ import { SEVERITY } from '@/lib/severity-style';
 import { isIssueResolved } from '@/lib/stores/document-explorer-store';
 import { cn } from '@/lib/utils';
 import {
+  ArrowUpRightIcon,
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
@@ -24,6 +26,7 @@ import {
   ThumbsUpIcon,
   UndoIcon,
 } from 'lucide-react';
+import Link from 'next/link';
 import { useState } from 'react';
 
 export function lineLabel(issue: Issue): string | null {
@@ -123,6 +126,25 @@ export function IssueMeta({ issue }: { issue: Issue }) {
 }
 
 /**
+ * A way from an issue to the assessment run that raised it: the run's report
+ * (the reproducibility check, say, writes one the issues only itemise), its
+ * history, and every other issue it found.
+ */
+function AssessmentReportLink({ issue }: { issue: Issue }) {
+  const { assessmentHref } = useProjectView();
+
+  return (
+    <Link
+      href={assessmentHref(issue.workflow_type, issue.workflow_run_id)}
+      className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+    >
+      View full assessment report
+      <ArrowUpRightIcon className="size-3" />
+    </Link>
+  );
+}
+
+/**
  * Everything an open issue shows below its title — description, suggested
  * action, details, and the actions that change it. Shared so the margin note and
  * the list row cannot drift apart.
@@ -170,6 +192,8 @@ export function IssueBody({ issue, readOnly }: { issue: Issue; readOnly: boolean
           )}
         </>
       )}
+
+      <AssessmentReportLink issue={issue} />
 
       {issue.id && (!readOnly || canRate) && (
         <div className="flex items-center gap-1.5 pt-0.5">

--- a/frontend/components/results/project-shell.tsx
+++ b/frontend/components/results/project-shell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AnalysisOptionsMenu } from '@/components/results/components/analysis-options-menu';
-import { TabType } from '@/components/results/constants';
+import { assessmentHref as assessmentHrefUnder, TabType } from '@/components/results/constants';
 import { derivePeerReviewFacts, peerReviewNeedsAttention } from '@/components/results/peer-review/peer-review-derive';
 import { ProjectViewProvider } from '@/components/results/project-view-context';
 import { PageTitle } from '@/components/shared/page-title';
@@ -25,6 +25,8 @@ import { RunActivityLine } from './run-activity/run-activity-line';
 
 interface ProjectShellProps {
   projectDetail: ProjectDetailed;
+  /** The route holding the shell, e.g. `/projects/abc` or `/share/xyz`; tabs live under it. */
+  basePath: string;
   activeTab: TabType;
   onTabChange: (tab: TabType, hash?: string) => void;
   readOnly?: boolean;
@@ -51,6 +53,7 @@ interface ProjectShellProps {
  */
 export function ProjectShell({
   projectDetail,
+  basePath,
   activeTab,
   onTabChange,
   readOnly = false,
@@ -125,6 +128,8 @@ export function ProjectShell({
   const canAccessFeedback = shareToken === null && (isOwner || userMe?.role === UserRole.Admin);
 
   const navigateToTab = (tab: TabType, hash?: string) => onTabChange(tab, hash);
+  const assessmentHref = (workflowType: WorkflowRunType, runId?: string | null) =>
+    assessmentHrefUnder(basePath, workflowType, runId);
 
   return (
     <ProjectFeedbackProvider
@@ -142,6 +147,7 @@ export function ProjectShell({
           onRevisionChange,
           onRevisionCreated,
           navigateToTab,
+          assessmentHref,
         }}
       >
         <div className="bg-background text-foreground flex h-dvh flex-col">

--- a/frontend/components/results/project-view-context.tsx
+++ b/frontend/components/results/project-view-context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ProjectDetailed } from '@/lib/generated-api';
+import { ProjectDetailed, WorkflowRunType } from '@/lib/generated-api';
 import { createContext, useContext } from 'react';
 import { TabType } from './constants';
 
@@ -16,6 +16,8 @@ export interface ProjectViewContextValue {
   onRevisionCreated?: () => void;
   /** Switch to another tab, optionally landing on a URL hash (e.g. `#L5-12`) */
   navigateToTab: (tab: TabType, hash?: string) => void;
+  /** Route for an assessment on the assessments tab, or one run of it. */
+  assessmentHref: (workflowType: WorkflowRunType, runId?: string | null) => string;
 }
 
 const ProjectViewContext = createContext<ProjectViewContextValue | undefined>(undefined);


### PR DESCRIPTION
## Summary

Every issue in the document explorer now carries a "View full assessment report" link that opens the assessment run which raised it. To give that link somewhere to land, the assessments tab is routable: `/projects/<id>/analyses/<workflow_type>` selects an assessment and `?run=<id>` a particular run of it, in both the project and share views.

## Motivation

Some assessments say more than their issues do. The Reproducibility Check, for example, writes a report the issues only itemise, and every assessment has a run history and a full issue list. From an issue in the explorer there was no way to get there short of switching tabs and finding the assessment by hand. The assessments tab also kept its selection in component state, so a selection did not survive a reload and could not be linked to.

## What's Changed

### Frontend

- `frontend/app/(authenticated)/projects/[projectId]/analyses/[workflowType]/page.tsx`, `frontend/app/share/[token]/analyses/[workflowType]/page.tsx`: new routes rendering the assessments panel for one assessment.
- `frontend/components/results/constants.ts`: `tabFromPathname` reads only the first segment so the nested route still highlights the Assessments tab; new `assessmentHref` and `parseWorkflowRunType` helpers.
- `frontend/components/results/assessments/use-workflow-selection.ts`: selection comes from the route param and `?run=` query instead of local state; rail and history clicks push the URL.
- `frontend/components/results/project-shell.tsx`, `frontend/components/results/project-view-context.tsx`: the shell takes a `basePath` and exposes `assessmentHref` through the project view context.
- `frontend/app/(authenticated)/projects/[projectId]/layout.tsx`, `frontend/app/share/[token]/layout.tsx`: pass `basePath` to the shell.
- `frontend/components/results/document-explorer/issue-note.tsx`: `AssessmentReportLink` rendered in `IssueBody`, so it appears in both the margin and list views.

### Backend

No changes.

## Risks and Mitigations

- **Old or mistyped assessment URLs.** An unknown `[workflowType]` segment parses to null and the tab falls back to its default selection rather than erroring.
- **Tab highlighting under nested routes.** `tabFromPathname` previously required an exact match; it now matches the first segment. Existing tab routes have a single segment, so their behaviour is unchanged.
- **Link target for an older run.** The link carries the issue's `workflow_run_id`, so it opens the exact run even after a re-run; if the run is missing from history the tab shows the newest run of that type.
- Verified in the browser on a local instance: link renders on issues, navigation lands on the right assessment and run, rail clicks update the URL. `tsc`, `eslint`, and `prettier` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)