### PR TITLE
refactor(workflows): read file ids from the file table, fix MCP role serialization

### DIFF
--- a/lib/api/mcp/tools/files.py
+++ b/lib/api/mcp/tools/files.py
@@ -8,6 +8,7 @@ from mcp.types import ToolAnnotations
 
 from lib.api.mcp import helpers
 from lib.api.mcp.instance import mcp
+from lib.models.file import FileRole
 from lib.models.project import AccessLevel
 from lib.services.docx_workflow_service import DocxManipulatorType, generate_docx
 from lib.services.files import (
@@ -113,7 +114,7 @@ async def list_project_files(
                 "file_name": f.file_name,
                 "file_size": f.file_size,
                 "file_type": f.file_type,
-                "role": str(f.role) if f.role else None,
+                "role": FileRole(f.role).value if f.role else None,
                 "revision": f.revision,
                 "reference_id": file_to_reference.get(str(f.id)),
             }

--- a/lib/services/files.py
+++ b/lib/services/files.py
@@ -198,15 +198,20 @@ async def get_files_by_project_id(
 
 
 async def get_main_file_id(project_id: uuid.UUID | str, revision: int) -> str:
-    """Id of the revision's MAIN file, read from the file table."""
+    """Id of the revision's MAIN file, read from the file table.
+
+    MAIN rows always carry a revision; the query also returns shared rows
+    (revision IS NULL), so filter explicitly rather than trust the first hit.
+    """
     files = await get_files_by_project_id(
         project_id, roles=[FileRole.MAIN], revision=revision
     )
-    if not files:
+    main_files = [f for f in files if f.revision == revision]
+    if not main_files:
         raise ValueError(
             f"No main file found for project {project_id} revision {revision}"
         )
-    return str(files[0].id)
+    return str(main_files[0].id)
 
 
 async def get_processed_supporting_file_ids(

--- a/lib/services/files.py
+++ b/lib/services/files.py
@@ -209,15 +209,21 @@ async def get_main_file_id(project_id: uuid.UUID | str, revision: int) -> str:
     return str(files[0].id)
 
 
-async def get_supporting_file_ids(
+async def get_processed_supporting_file_ids(
     project_id: uuid.UUID | str, revision: int
 ) -> List[str]:
-    """Ids of the supporting files visible to a revision, read from the file
-    table. Supporting files are shared across revisions (revision IS NULL)."""
+    """Ids of the revision's supporting files that have cached markdown.
+
+    Supporting files are shared across revisions (revision IS NULL). A file
+    whose conversion failed has no cached markdown and is left out, matching
+    what document_processing reports as successfully processed: consumers
+    (summarization, reference file matching) read markdown and summaries and
+    would otherwise abort on the unusable file.
+    """
     files = await get_files_by_project_id(
         project_id, roles=[FileRole.SUPPORT], revision=revision
     )
-    return [str(f.id) for f in files]
+    return [str(f.id) for f in files if f.has_cached_markdown]
 
 
 async def get_project_files_list_items(

--- a/lib/services/files.py
+++ b/lib/services/files.py
@@ -197,6 +197,29 @@ async def get_files_by_project_id(
         return list(files)
 
 
+async def get_main_file_id(project_id: uuid.UUID | str, revision: int) -> str:
+    """Id of the revision's MAIN file, read from the file table."""
+    files = await get_files_by_project_id(
+        project_id, roles=[FileRole.MAIN], revision=revision
+    )
+    if not files:
+        raise ValueError(
+            f"No main file found for project {project_id} revision {revision}"
+        )
+    return str(files[0].id)
+
+
+async def get_supporting_file_ids(
+    project_id: uuid.UUID | str, revision: int
+) -> List[str]:
+    """Ids of the supporting files visible to a revision, read from the file
+    table. Supporting files are shared across revisions (revision IS NULL)."""
+    files = await get_files_by_project_id(
+        project_id, roles=[FileRole.SUPPORT], revision=revision
+    )
+    return [str(f.id) for f in files]
+
+
 async def get_project_files_list_items(
     project_id: uuid.UUID | str,
 ) -> List[FileListItem]:

--- a/lib/services/references.py
+++ b/lib/services/references.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 from typing import List, Optional, Tuple, cast
 
 from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus
+from lib.services.files import get_main_file_id, get_supporting_file_ids
 from lib.services.workflow_runs import (
     create_workflow_run,
     get_project_workflow_run_by_type,
@@ -47,20 +48,6 @@ async def _project_lock(project_id: str):
         yield
 
 
-async def _get_document_processing_workflow_state(project_id: str, revision: int):
-    """Get the DocumentProcessing workflow state for a project."""
-    run = await get_project_workflow_run_by_type(
-        project_id,
-        WorkflowRunType.DOCUMENT_PROCESSING,
-        revision=revision,
-        include_state=True,
-    )
-    if run is None:
-        return None
-
-    return await read_workflow_run_state(run)
-
-
 async def _get_file_matching_workflow_state(
     project_id: str,
     revision: int,
@@ -95,25 +82,20 @@ async def _get_file_matching_workflow_state(
     if state is not None:
         return run, cast(ReferenceFileMatchingState, state)
 
-    # State doesn't exist - construct a default one from document processing state
+    # State doesn't exist - construct a default one from the file table
     logger.info(
         f"No file matching state found for project {project_id}, constructing default"
     )
 
-    doc_processing_state = await _get_document_processing_workflow_state(
-        project_id, revision
-    )
-    if doc_processing_state is None:
+    try:
+        file_id = await get_main_file_id(project_id, revision)
+    except ValueError:
         logger.info(
-            f"No document processing state found for project {project_id}, "
+            f"No main file found for project {project_id} revision {revision}, "
             "cannot construct file matching state"
         )
         return run, None
-
-    file_id = doc_processing_state.file.file_id
-    supporting_file_ids = [
-        f.file_id for f in (doc_processing_state.supporting_files or [])
-    ]
+    supporting_file_ids = await get_supporting_file_ids(project_id, revision)
 
     default_state = ReferenceFileMatchingState(
         type=WorkflowRunType.REFERENCE_FILE_MATCHING,

--- a/lib/services/references.py
+++ b/lib/services/references.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from typing import List, Optional, Tuple, cast
 
 from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus
-from lib.services.files import get_main_file_id, get_supporting_file_ids
+from lib.services.files import get_main_file_id, get_processed_supporting_file_ids
 from lib.services.workflow_runs import (
     create_workflow_run,
     get_project_workflow_run_by_type,
@@ -57,14 +57,14 @@ async def _get_file_matching_workflow_state(
 
     If the workflow run exists but has no state, or if there's no workflow run,
     creates a new workflow run and constructs a default ReferenceFileMatchingState
-    with empty matches using file information from the DocumentProcessing workflow.
+    with empty matches from the project's file table.
 
     Args:
         project_id: The project ID
 
     Returns:
-        Tuple of (workflow_run, state) or (None, None) if document processing
-        state is not available to construct a default state
+        Tuple of (workflow_run, state) or (run, None) if the revision has no
+        main file to construct a default state from
     """
     from lib.workflows.reference_file_matching.state import ReferenceFileMatchingConfig
 
@@ -95,7 +95,7 @@ async def _get_file_matching_workflow_state(
             "cannot construct file matching state"
         )
         return run, None
-    supporting_file_ids = await get_supporting_file_ids(project_id, revision)
+    supporting_file_ids = await get_processed_supporting_file_ids(project_id, revision)
 
     default_state = ReferenceFileMatchingState(
         type=WorkflowRunType.REFERENCE_FILE_MATCHING,

--- a/lib/workflows/document_summarization/manifest.py
+++ b/lib/workflows/document_summarization/manifest.py
@@ -14,7 +14,7 @@ from lib.workflows.document_summarization.state import (
 from lib.workflows.manifest import WorkflowManifest
 from lib.workflows.models import DocumentIssue, WorkflowRunType
 from lib.workflows.workflow_types import WorkflowState
-from lib.services.files import get_main_file_id, get_supporting_file_ids
+from lib.services.files import get_main_file_id, get_processed_supporting_file_ids
 
 
 class DocumentSummarizationManifest(
@@ -58,7 +58,7 @@ class DocumentSummarizationManifest(
         return DocumentSummarizationState(
             type=WorkflowRunType.DOCUMENT_SUMMARIZATION,
             main_file_id=await get_main_file_id(config.project_id, revision),
-            supporting_file_ids=await get_supporting_file_ids(
+            supporting_file_ids=await get_processed_supporting_file_ids(
                 config.project_id, revision
             ),
             config=config,

--- a/lib/workflows/document_summarization/manifest.py
+++ b/lib/workflows/document_summarization/manifest.py
@@ -14,7 +14,7 @@ from lib.workflows.document_summarization.state import (
 from lib.workflows.manifest import WorkflowManifest
 from lib.workflows.models import DocumentIssue, WorkflowRunType
 from lib.workflows.workflow_types import WorkflowState
-from lib.workflows.util import get_main_file_id, get_supporting_file_ids
+from lib.services.files import get_main_file_id, get_supporting_file_ids
 
 
 class DocumentSummarizationManifest(
@@ -54,13 +54,13 @@ class DocumentSummarizationManifest(
         only summarizes new files). Threads are no longer reused across runs,
         so this state is no longer inherited via the checkpointer.
         """
-        summaries = (
-            prior_self_state.summaries if prior_self_state is not None else []
-        )
+        summaries = prior_self_state.summaries if prior_self_state is not None else []
         return DocumentSummarizationState(
             type=WorkflowRunType.DOCUMENT_SUMMARIZATION,
-            main_file_id=get_main_file_id(existing_states),
-            supporting_file_ids=get_supporting_file_ids(existing_states),
+            main_file_id=await get_main_file_id(config.project_id, revision),
+            supporting_file_ids=await get_supporting_file_ids(
+                config.project_id, revision
+            ),
             config=config,
             summaries=summaries,
         )

--- a/lib/workflows/reference_extraction/manifest.py
+++ b/lib/workflows/reference_extraction/manifest.py
@@ -12,7 +12,7 @@ from lib.workflows.reference_extraction.state import (
     ReferenceExtractionState,
 )
 from lib.workflows.workflow_types import WorkflowState
-from lib.workflows.util import get_main_file_id
+from lib.services.files import get_main_file_id
 
 
 class ReferenceExtractionManifest(
@@ -54,7 +54,7 @@ class ReferenceExtractionManifest(
         return ReferenceExtractionState(
             type=WorkflowRunType.REFERENCE_EXTRACTION,
             config=config,
-            file_id=get_main_file_id(existing_states),
+            file_id=await get_main_file_id(config.project_id, revision),
         )
 
     def convert_state_to_issues(

--- a/lib/workflows/reference_extraction/manifest.py
+++ b/lib/workflows/reference_extraction/manifest.py
@@ -47,9 +47,11 @@ class ReferenceExtractionManifest(
         prior_self_state: ReferenceExtractionState | None = None,
     ) -> ReferenceExtractionState:
         """
-        Create initial state from DOCUMENT_PROCESSING dependency.
+        Create the initial state with the revision's main file id.
 
-        Gets file with markdown from DOCUMENT_PROCESSING workflow.
+        The id is read from the file table; the markdown itself is loaded at
+        run time through the file artifacts service, which serves the cache
+        written by DOCUMENT_PROCESSING (a required dependency).
         """
         return ReferenceExtractionState(
             type=WorkflowRunType.REFERENCE_EXTRACTION,

--- a/lib/workflows/reference_file_matching/manifest.py
+++ b/lib/workflows/reference_file_matching/manifest.py
@@ -56,10 +56,11 @@ class ReferenceFileMatchingManifest(
         prior_self_state: ReferenceFileMatchingState | None = None,
     ) -> ReferenceFileMatchingState:
         """
-        Create initial state from REFERENCE_EXTRACTION dependency.
+        Create the initial state for a matching run.
 
-        Gets file IDs from existing workflow states and preserves any existing
-        matches so that already-matched references are not re-processed.
+        The main file id and the processed supporting file ids are read from
+        the file table. Existing matches are carried over from the prior
+        matching state so already-matched references are not re-processed.
         """
         existing_matching_state = get_state_by_type(
             WorkflowRunType.REFERENCE_FILE_MATCHING, existing_states

--- a/lib/workflows/reference_file_matching/manifest.py
+++ b/lib/workflows/reference_file_matching/manifest.py
@@ -14,11 +14,8 @@ from lib.workflows.reference_file_matching.state import (
     ReferenceFileMatchingState,
 )
 from lib.workflows.workflow_types import WorkflowState
-from lib.workflows.util import (
-    get_main_file_id,
-    get_state_by_type,
-    get_supporting_file_ids,
-)
+from lib.services.files import get_main_file_id, get_supporting_file_ids
+from lib.workflows.util import get_state_by_type
 
 
 class ReferenceFileMatchingManifest(
@@ -76,8 +73,10 @@ class ReferenceFileMatchingManifest(
         return ReferenceFileMatchingState(
             type=WorkflowRunType.REFERENCE_FILE_MATCHING,
             config=config,
-            file_id=get_main_file_id(existing_states),
-            supporting_file_ids=get_supporting_file_ids(existing_states),
+            file_id=await get_main_file_id(config.project_id, revision),
+            supporting_file_ids=await get_supporting_file_ids(
+                config.project_id, revision
+            ),
             matches=existing_matches,
         )
 

--- a/lib/workflows/reference_file_matching/manifest.py
+++ b/lib/workflows/reference_file_matching/manifest.py
@@ -14,7 +14,7 @@ from lib.workflows.reference_file_matching.state import (
     ReferenceFileMatchingState,
 )
 from lib.workflows.workflow_types import WorkflowState
-from lib.services.files import get_main_file_id, get_supporting_file_ids
+from lib.services.files import get_main_file_id, get_processed_supporting_file_ids
 from lib.workflows.util import get_state_by_type
 
 
@@ -74,7 +74,7 @@ class ReferenceFileMatchingManifest(
             type=WorkflowRunType.REFERENCE_FILE_MATCHING,
             config=config,
             file_id=await get_main_file_id(config.project_id, revision),
-            supporting_file_ids=await get_supporting_file_ids(
+            supporting_file_ids=await get_processed_supporting_file_ids(
                 config.project_id, revision
             ),
             matches=existing_matches,

--- a/lib/workflows/reviewer_2/manifest.py
+++ b/lib/workflows/reviewer_2/manifest.py
@@ -6,7 +6,7 @@ from lib.workflows.manifest import WorkflowManifest
 from lib.workflows.models import DocumentIssue, WorkflowRunType
 from lib.workflows.reviewer_2.graph import build_reviewer_2_graph
 from lib.workflows.reviewer_2.state import Reviewer2Config, Reviewer2State
-from lib.workflows.util import get_main_file_id
+from lib.services.files import get_main_file_id
 from lib.workflows.workflow_types import WorkflowState
 
 
@@ -38,7 +38,7 @@ class Reviewer2Manifest(WorkflowManifest[Reviewer2State, Reviewer2Config]):
         return Reviewer2State(
             type=WorkflowRunType.REVIEWER_2,
             config=config,
-            file_id=get_main_file_id(existing_states),
+            file_id=await get_main_file_id(config.project_id, revision),
         )
 
     def convert_state_to_issues(

--- a/lib/workflows/util.py
+++ b/lib/workflows/util.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, List, Optional
 
-from lib.workflows.document_processing.state import DocumentProcessingState
 from lib.workflows.models import WorkflowRunType
 
 if TYPE_CHECKING:
@@ -18,25 +17,3 @@ def get_state_by_type(
         if state.type == type:
             return state
     return None
-
-
-def get_main_file_id(all_states: List["WorkflowState"]) -> str:
-    """
-    Get the ID of the main file from a list of states.
-    """
-
-    for state in all_states:
-        if isinstance(state, DocumentProcessingState):
-            return state.file.file_id
-    raise ValueError("No main file found in states")
-
-
-def get_supporting_file_ids(all_states: List["WorkflowState"]) -> List[str]:
-    """
-    Get the IDs of the supporting files from a list of states.
-    """
-
-    for state in all_states:
-        if isinstance(state, DocumentProcessingState):
-            return [file.file_id for file in state.supporting_files or []]
-    raise ValueError("No supporting files found in states")

--- a/tests/unit/services/test_file_ids.py
+++ b/tests/unit/services/test_file_ids.py
@@ -1,6 +1,9 @@
-"""get_main_file_id / get_supporting_file_ids read the file table, so workflow
-initial states no longer depend on the last document_processing run having
-seen every file (a file saved by reference_downloader after that run, say)."""
+"""get_main_file_id / get_processed_supporting_file_ids read the file table, so
+workflow initial states no longer depend on the last document_processing run
+having seen every file (a file saved by reference_downloader after that run,
+say). Only supporting files with cached markdown count as processed: a file
+whose conversion failed has none, and summarization / reference matching
+would abort trying to read it."""
 
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -8,10 +11,10 @@ from uuid import uuid4
 import pytest
 
 from lib.models.file import File, FileRole
-from lib.services.files import get_main_file_id, get_supporting_file_ids
+from lib.services.files import get_main_file_id, get_processed_supporting_file_ids
 
 
-def _file(role: FileRole, revision: int | None) -> File:
+def _file(role: FileRole, revision: int | None, markdown: str | None = "# md") -> File:
     return File(
         id=uuid4(),
         project_id=uuid4(),
@@ -23,6 +26,7 @@ def _file(role: FileRole, revision: int | None) -> File:
         role=role,
         uploaded_by=uuid4(),
         revision=revision,
+        markdown=markdown,
     )
 
 
@@ -48,20 +52,36 @@ async def test_get_main_file_id_raises_when_the_revision_has_no_main_file():
 
 
 @pytest.mark.asyncio
-async def test_get_supporting_file_ids_lists_support_files_only():
+async def test_processed_supporting_file_ids_lists_files_with_cached_markdown():
     a, b = _file(FileRole.SUPPORT, None), _file(FileRole.SUPPORT, None)
     with patch(
         "lib.services.files.get_files_by_project_id",
         new=AsyncMock(return_value=[a, b]),
     ) as lookup:
-        assert await get_supporting_file_ids(a.project_id, 1) == [str(a.id), str(b.id)]
+        assert await get_processed_supporting_file_ids(a.project_id, 1) == [
+            str(a.id),
+            str(b.id),
+        ]
 
     lookup.assert_awaited_once_with(a.project_id, roles=[FileRole.SUPPORT], revision=1)
 
 
 @pytest.mark.asyncio
-async def test_get_supporting_file_ids_is_empty_without_support_files():
+async def test_processed_supporting_file_ids_skips_files_without_cached_markdown():
+    """A supporting file whose conversion failed keeps its row but has no
+    markdown. It must be left out so consumers do not abort on it."""
+    ok = _file(FileRole.SUPPORT, None)
+    failed = _file(FileRole.SUPPORT, None, markdown=None)
+    with patch(
+        "lib.services.files.get_files_by_project_id",
+        new=AsyncMock(return_value=[failed, ok]),
+    ):
+        assert await get_processed_supporting_file_ids(ok.project_id, 1) == [str(ok.id)]
+
+
+@pytest.mark.asyncio
+async def test_processed_supporting_file_ids_is_empty_without_support_files():
     with patch(
         "lib.services.files.get_files_by_project_id", new=AsyncMock(return_value=[])
     ):
-        assert await get_supporting_file_ids(uuid4(), 1) == []
+        assert await get_processed_supporting_file_ids(uuid4(), 1) == []

--- a/tests/unit/services/test_file_ids.py
+++ b/tests/unit/services/test_file_ids.py
@@ -1,0 +1,67 @@
+"""get_main_file_id / get_supporting_file_ids read the file table, so workflow
+initial states no longer depend on the last document_processing run having
+seen every file (a file saved by reference_downloader after that run, say)."""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from lib.models.file import File, FileRole
+from lib.services.files import get_main_file_id, get_supporting_file_ids
+
+
+def _file(role: FileRole, revision: int | None) -> File:
+    return File(
+        id=uuid4(),
+        project_id=uuid4(),
+        file_name=f"{role.value}.pdf",
+        file_path="/tmp/x",
+        file_type="application/pdf",
+        file_size=1,
+        content_hash="h",
+        role=role,
+        uploaded_by=uuid4(),
+        revision=revision,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_main_file_id_returns_the_revision_main_file():
+    main = _file(FileRole.MAIN, revision=2)
+    with patch(
+        "lib.services.files.get_files_by_project_id",
+        new=AsyncMock(return_value=[main]),
+    ) as lookup:
+        assert await get_main_file_id(main.project_id, 2) == str(main.id)
+
+    lookup.assert_awaited_once_with(main.project_id, roles=[FileRole.MAIN], revision=2)
+
+
+@pytest.mark.asyncio
+async def test_get_main_file_id_raises_when_the_revision_has_no_main_file():
+    with patch(
+        "lib.services.files.get_files_by_project_id", new=AsyncMock(return_value=[])
+    ):
+        with pytest.raises(ValueError, match="No main file found"):
+            await get_main_file_id(uuid4(), 1)
+
+
+@pytest.mark.asyncio
+async def test_get_supporting_file_ids_lists_support_files_only():
+    a, b = _file(FileRole.SUPPORT, None), _file(FileRole.SUPPORT, None)
+    with patch(
+        "lib.services.files.get_files_by_project_id",
+        new=AsyncMock(return_value=[a, b]),
+    ) as lookup:
+        assert await get_supporting_file_ids(a.project_id, 1) == [str(a.id), str(b.id)]
+
+    lookup.assert_awaited_once_with(a.project_id, roles=[FileRole.SUPPORT], revision=1)
+
+
+@pytest.mark.asyncio
+async def test_get_supporting_file_ids_is_empty_without_support_files():
+    with patch(
+        "lib.services.files.get_files_by_project_id", new=AsyncMock(return_value=[])
+    ):
+        assert await get_supporting_file_ids(uuid4(), 1) == []

--- a/tests/unit/services/test_file_ids.py
+++ b/tests/unit/services/test_file_ids.py
@@ -6,18 +6,25 @@ whose conversion failed has none, and summarization / reference matching
 would abort trying to read it."""
 
 from unittest.mock import AsyncMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
 from lib.models.file import File, FileRole
 from lib.services.files import get_main_file_id, get_processed_supporting_file_ids
 
+PROJECT_ID = uuid4()
 
-def _file(role: FileRole, revision: int | None, markdown: str | None = "# md") -> File:
+
+def _file(
+    role: FileRole,
+    revision: int | None,
+    markdown: str | None = "# md",
+    project_id: UUID = PROJECT_ID,
+) -> File:
     return File(
         id=uuid4(),
-        project_id=uuid4(),
+        project_id=project_id,
         file_name=f"{role.value}.pdf",
         file_path="/tmp/x",
         file_type="application/pdf",
@@ -30,40 +37,52 @@ def _file(role: FileRole, revision: int | None, markdown: str | None = "# md") -
     )
 
 
+def _lookup(files: list[File]) -> AsyncMock:
+    return AsyncMock(return_value=files)
+
+
 @pytest.mark.asyncio
 async def test_get_main_file_id_returns_the_revision_main_file():
     main = _file(FileRole.MAIN, revision=2)
     with patch(
-        "lib.services.files.get_files_by_project_id",
-        new=AsyncMock(return_value=[main]),
+        "lib.services.files.get_files_by_project_id", new=_lookup([main])
     ) as lookup:
-        assert await get_main_file_id(main.project_id, 2) == str(main.id)
+        assert await get_main_file_id(PROJECT_ID, 2) == str(main.id)
 
-    lookup.assert_awaited_once_with(main.project_id, roles=[FileRole.MAIN], revision=2)
+    lookup.assert_awaited_once_with(PROJECT_ID, roles=[FileRole.MAIN], revision=2)
+
+
+@pytest.mark.asyncio
+async def test_get_main_file_id_ignores_a_main_row_without_a_revision():
+    """The query returns shared rows (revision IS NULL) alongside the
+    revision's own; a MAIN row stored that way must not be picked up."""
+    stray = _file(FileRole.MAIN, revision=None)
+    main = _file(FileRole.MAIN, revision=2)
+    with patch(
+        "lib.services.files.get_files_by_project_id", new=_lookup([stray, main])
+    ):
+        assert await get_main_file_id(PROJECT_ID, 2) == str(main.id)
 
 
 @pytest.mark.asyncio
 async def test_get_main_file_id_raises_when_the_revision_has_no_main_file():
-    with patch(
-        "lib.services.files.get_files_by_project_id", new=AsyncMock(return_value=[])
-    ):
+    with patch("lib.services.files.get_files_by_project_id", new=_lookup([])):
         with pytest.raises(ValueError, match="No main file found"):
-            await get_main_file_id(uuid4(), 1)
+            await get_main_file_id(PROJECT_ID, 1)
 
 
 @pytest.mark.asyncio
 async def test_processed_supporting_file_ids_lists_files_with_cached_markdown():
     a, b = _file(FileRole.SUPPORT, None), _file(FileRole.SUPPORT, None)
     with patch(
-        "lib.services.files.get_files_by_project_id",
-        new=AsyncMock(return_value=[a, b]),
+        "lib.services.files.get_files_by_project_id", new=_lookup([a, b])
     ) as lookup:
-        assert await get_processed_supporting_file_ids(a.project_id, 1) == [
+        assert await get_processed_supporting_file_ids(PROJECT_ID, 1) == [
             str(a.id),
             str(b.id),
         ]
 
-    lookup.assert_awaited_once_with(a.project_id, roles=[FileRole.SUPPORT], revision=1)
+    lookup.assert_awaited_once_with(PROJECT_ID, roles=[FileRole.SUPPORT], revision=1)
 
 
 @pytest.mark.asyncio
@@ -72,16 +91,11 @@ async def test_processed_supporting_file_ids_skips_files_without_cached_markdown
     markdown. It must be left out so consumers do not abort on it."""
     ok = _file(FileRole.SUPPORT, None)
     failed = _file(FileRole.SUPPORT, None, markdown=None)
-    with patch(
-        "lib.services.files.get_files_by_project_id",
-        new=AsyncMock(return_value=[failed, ok]),
-    ):
-        assert await get_processed_supporting_file_ids(ok.project_id, 1) == [str(ok.id)]
+    with patch("lib.services.files.get_files_by_project_id", new=_lookup([failed, ok])):
+        assert await get_processed_supporting_file_ids(PROJECT_ID, 1) == [str(ok.id)]
 
 
 @pytest.mark.asyncio
 async def test_processed_supporting_file_ids_is_empty_without_support_files():
-    with patch(
-        "lib.services.files.get_files_by_project_id", new=AsyncMock(return_value=[])
-    ):
-        assert await get_processed_supporting_file_ids(uuid4(), 1) == []
+    with patch("lib.services.files.get_files_by_project_id", new=_lookup([])):
+        assert await get_processed_supporting_file_ids(PROJECT_ID, 1) == []

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -38,6 +38,7 @@ from lib.api.mcp.tools.uploads import (  # noqa: E402
     get_tus_upload_credentials,
 )
 from lib.api.mcp.tools.workflows import run_workflow  # noqa: E402
+from lib.models.file import FileRole  # noqa: E402
 
 _mcp_auth_mod.create_mcp_auth = _orig
 
@@ -768,7 +769,7 @@ async def test_list_project_files_returns_files_with_reference():
     file1.file_name = "paper.pdf"
     file1.file_size = 12345
     file1.file_type = "application/pdf"
-    file1.role = "support"
+    file1.role = FileRole.SUPPORT
     file1.revision = None
 
     project.current_revision = 1

--- a/tests/unit/workflows/document_summarization/test_manifest.py
+++ b/tests/unit/workflows/document_summarization/test_manifest.py
@@ -7,7 +7,7 @@ via prior_self_state instead of the checkpointer — these tests pin that seedin
 """
 
 import uuid
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -56,11 +56,11 @@ async def test_create_initial_state_seeds_summaries_from_prior():
     with (
         patch(
             "lib.workflows.document_summarization.manifest.get_main_file_id",
-            return_value="main",
+            new=AsyncMock(return_value="main"),
         ),
         patch(
             "lib.workflows.document_summarization.manifest.get_supporting_file_ids",
-            return_value=[],
+            new=AsyncMock(return_value=[]),
         ),
     ):
         state = await DocumentSummarizationManifest().create_initial_state(
@@ -76,11 +76,11 @@ async def test_create_initial_state_empty_without_prior():
     with (
         patch(
             "lib.workflows.document_summarization.manifest.get_main_file_id",
-            return_value="main",
+            new=AsyncMock(return_value="main"),
         ),
         patch(
             "lib.workflows.document_summarization.manifest.get_supporting_file_ids",
-            return_value=[],
+            new=AsyncMock(return_value=[]),
         ),
     ):
         state = await DocumentSummarizationManifest().create_initial_state(

--- a/tests/unit/workflows/document_summarization/test_manifest.py
+++ b/tests/unit/workflows/document_summarization/test_manifest.py
@@ -59,7 +59,7 @@ async def test_create_initial_state_seeds_summaries_from_prior():
             new=AsyncMock(return_value="main"),
         ),
         patch(
-            "lib.workflows.document_summarization.manifest.get_supporting_file_ids",
+            "lib.workflows.document_summarization.manifest.get_processed_supporting_file_ids",
             new=AsyncMock(return_value=[]),
         ),
     ):
@@ -79,7 +79,7 @@ async def test_create_initial_state_empty_without_prior():
             new=AsyncMock(return_value="main"),
         ),
         patch(
-            "lib.workflows.document_summarization.manifest.get_supporting_file_ids",
+            "lib.workflows.document_summarization.manifest.get_processed_supporting_file_ids",
             new=AsyncMock(return_value=[]),
         ),
     ):


### PR DESCRIPTION
## Summary

Two follow-ups from the MCP consent-gate work in #747:

1. Workflows that need the project's file IDs now read them from the file table instead of the last `document_processing` run's state.
2. The MCP `list_project_files` tool serializes a file's role as its value (`main`, `support`) instead of `FileRole.MAIN`.

## Motivation

While removing the optional edge from document processing to the reference downloader (#747), an audit showed that markdown content is already read database-first everywhere, but the *list* of files was not. Reference file matching, document summarization, reference extraction and reviewer 2 all pulled the main and supporting file IDs out of `DocumentProcessingState`, and `lib/services/references.py` did the same when constructing a default matching state. That works today only because document processing always runs first in every batch. It was the last reason for those workflows to depend on another workflow's state snapshot, and it would silently miss any file saved after that snapshot. Reading the file table removes the coupling.

The role serialization bug was spotted in a live MCP run: `str(FileRole.MAIN)` is `FileRole.MAIN`, and the unit test masked it by putting a plain string on a mock.

## What's Changed

### Backend

- `lib/services/files.py`: new async helpers `get_main_file_id(project_id, revision)` and `get_processed_supporting_file_ids(project_id, revision)`, thin wrappers over the existing `get_files_by_project_id` with its revision filter. The supporting-file helper returns only files with cached markdown, the same set document processing reports as successfully converted, so a file whose conversion failed is left out exactly as before. The main lookup raises `ValueError` when the revision has no main file.
- `lib/workflows/reference_file_matching/manifest.py`, `lib/workflows/document_summarization/manifest.py`, `lib/workflows/reference_extraction/manifest.py`, `lib/workflows/reviewer_2/manifest.py`: `create_initial_state` awaits the new helpers with `config.project_id` and `revision` instead of scanning `existing_states`.
- `lib/services/references.py`: the default `ReferenceFileMatchingState` is built from the helpers; the private document-processing-state loader is removed.
- `lib/workflows/util.py`: the state-based `get_main_file_id` and `get_supporting_file_ids` are removed along with the `DocumentProcessingState` import. `get_state_by_type` stays.
- `lib/api/mcp/tools/files.py`: `role` is emitted as `FileRole(f.role).value`.
- `tests/unit/services/test_file_ids.py`: new, covers both helpers including the missing-main-file error and the exclusion of a supporting file without cached markdown.
- `tests/unit/workflows/document_summarization/test_manifest.py`: patches the helpers as async.
- `tests/unit/test_mcp_tools.py`: the list-files test uses the real `FileRole` enum so the serialization path is exercised.

### Frontend

No changes.

## Risks and Mitigations

- **Behaviour on a project with no main file for the revision.** Previously `get_main_file_id` raised `ValueError("No main file found in states")`; the new helper raises `ValueError` too, and `references.py` catches it the same way it handled a missing state. Covered by a unit test.
- **Supporting files that failed to convert.** Document processing keeps the row but drops the file from its results. A first cut of this PR returned every supporting file and made summarization abort on the unusable one (caught in review). The helper now filters on cached markdown, and a unit test pins the exclusion.
- **Supporting files across revisions.** The helpers rely on `get_files_by_project_id`'s existing semantics: files of the given revision plus shared files with a null revision, which is how supporting files are stored. Document processing already used the same query to pick its files, so the set is identical.
- **Extra database reads per workflow start.** Two small indexed queries per `create_initial_state`, replacing an in-memory scan. Negligible next to the LLM work that follows.

Verified with 1241 passing unit tests plus the integration workflow suite, `uv run mypy .` clean, and black on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

